### PR TITLE
[P1][bugfix] 단방향 @OneToMany FK/JoinTable 분기 정합성, to-one 네이밍 & nullable 규칙 보강, 조인테이블 역측 PK 버그 수정

### DIFF
--- a/jinx-processor/src/main/java/org/jinx/handler/EntityHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/EntityHandler.java
@@ -62,6 +62,16 @@ public class EntityHandler {
 
         // 8. 보조 테이블 처리 및 상속 관계 처리 -> PK가 확정된 뒤에 FK 생성
         processJoinedTables(typeElement, entity);
+
+        // 9. 최종 PK 검증: JOINED/SecondaryTable 처리까지 끝난 후에도 PK가 없다면 invalid
+        if (context.findAllPrimaryKeyColumns(entity).isEmpty()) {
+            context.getMessager().printMessage(
+                    Diagnostic.Kind.ERROR,
+                    "Entity '" + entity.getEntityName() + "' must have a primary key.",
+                    typeElement
+            );
+            entity.setValid(false);
+        }
     }
 
     public void runDeferredJoinedFks() {

--- a/jinx-processor/src/main/java/org/jinx/handler/RelationshipHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/RelationshipHandler.java
@@ -36,30 +36,61 @@ public class RelationshipHandler {
         ManyToMany manyToMany = field.getAnnotation(ManyToMany.class);
         OneToMany oneToMany = field.getAnnotation(OneToMany.class);
 
+        // @ManyToOne 또는 @OneToOne (to-one 관계)
         if (manyToOne != null || oneToOne != null) {
             processToOneRelationship(field, ownerEntity, manyToOne, oneToOne);
-        } else if (oneToMany != null) {
-            if (oneToMany.mappedBy().isEmpty()) {
-                processUnidirectionalOneToMany(field, ownerEntity, oneToMany);
+            return;
+        }
+
+        // @OneToMany (단방향만, mappedBy 없음)
+        if (oneToMany != null && oneToMany.mappedBy().isEmpty()) {
+            JoinTable jt = field.getAnnotation(JoinTable.class);
+            JoinColumns jcs = field.getAnnotation(JoinColumns.class);
+            JoinColumn jc = field.getAnnotation(JoinColumn.class);
+            boolean hasJoinColumn = (jcs != null && jcs.value().length > 0) || (jc != null);
+
+            // @JoinTable과 @JoinColumn(s) 동시 사용 검증
+            if (jt != null && hasJoinColumn) {
+                context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                        "@OneToMany에 @JoinTable과 @JoinColumn(s)를 함께 사용할 수 없습니다.", field);
+                return;
             }
-        } else if (manyToMany != null) {
-            if (manyToMany.mappedBy().isEmpty()) {
-                processOwningManyToMany(field, ownerEntity, manyToMany);
+
+            // 분기: @JoinColumn(s) 있으면 FK 방식, 없으면 JoinTable 방식
+            if (hasJoinColumn) {
+                processUnidirectionalOneToMany_FK(field, ownerEntity, oneToMany);
+            } else {
+                processUnidirectionalOneToMany_JoinTable(field, ownerEntity, oneToMany);
             }
+            return;
+        }
+
+        // @ManyToMany (소유측만, mappedBy 없음)
+        if (manyToMany != null && manyToMany.mappedBy().isEmpty()) {
+            processOwningManyToMany(field, ownerEntity, manyToMany);
         }
     }
 
-    private void processToOneRelationship(VariableElement field, EntityModel ownerEntity, ManyToOne manyToOne, OneToOne oneToOne) {
+    /**
+     * @ManyToOne 또는 @OneToOne 관계 처리
+     * 소유측 엔티티에 FK 컬럼을 추가
+     */
+    private void processToOneRelationship(VariableElement field, EntityModel ownerEntity,
+                                          ManyToOne manyToOne, OneToOne oneToOne) {
         TypeElement referencedTypeElement = getReferencedTypeElement(field.asType());
         if (referencedTypeElement == null) return;
-        EntityModel referencedEntity = context.getSchemaModel().getEntities().get(referencedTypeElement.getQualifiedName().toString());
+
+        EntityModel referencedEntity = context.getSchemaModel().getEntities()
+                .get(referencedTypeElement.getQualifiedName().toString());
         if (referencedEntity == null) return;
 
         List<ColumnModel> refPkList = context.findAllPrimaryKeyColumns(referencedEntity);
         if (refPkList.isEmpty()) {
-            context.getMessager().printMessage(Diagnostic.Kind.ERROR, "Entity " + referencedEntity.getEntityName() + " must have a primary key to be referenced.", field);
+            context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    "Entity " + referencedEntity.getEntityName() + " must have a primary key to be referenced.", field);
             return;
         }
+
         Map<String, ColumnModel> refPkMap = refPkList.stream()
                 .collect(Collectors.toMap(ColumnModel::getColumnName, c -> c));
 
@@ -69,13 +100,18 @@ public class RelationshipHandler {
         List<JoinColumn> joinColumns = joinColumnsAnno != null ? Arrays.asList(joinColumnsAnno.value()) :
                 (joinColumnAnno != null ? List.of(joinColumnAnno) : Collections.emptyList());
 
+        // 복합 키 검증
         if (joinColumns.isEmpty() && refPkList.size() > 1) {
-            context.getMessager().printMessage(Diagnostic.Kind.ERROR, "Composite primary key on " + referencedEntity.getEntityName() + " requires explicit @JoinColumns on " + ownerEntity.getEntityName() + "." + field.getSimpleName(), field);
+            context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    "Composite primary key on " + referencedEntity.getEntityName() +
+                            " requires explicit @JoinColumns on " + ownerEntity.getEntityName() + "." + field.getSimpleName(), field);
             return;
         }
 
         if (!joinColumns.isEmpty() && joinColumns.size() != refPkList.size()) {
-            context.getMessager().printMessage(Diagnostic.Kind.ERROR, "@JoinColumns size mismatch on " + ownerEntity.getEntityName() + "." + field.getSimpleName() + ". Expected " + refPkList.size() + " (from referenced PK), but got " + joinColumns.size() + ".", field);
+            context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    "@JoinColumns size mismatch on " + ownerEntity.getEntityName() + "." + field.getSimpleName() +
+                            ". Expected " + refPkList.size() + " (from referenced PK), but got " + joinColumns.size() + ".", field);
             return;
         }
 
@@ -84,11 +120,13 @@ public class RelationshipHandler {
         MapsId mapsId = field.getAnnotation(MapsId.class);
         String mapsIdAttr = (mapsId != null && !mapsId.value().isEmpty()) ? mapsId.value() : null;
 
+        // FK 컬럼 생성
         for (int i = 0; i < refPkList.size(); i++) {
             JoinColumn jc = joinColumns.isEmpty() ? null : joinColumns.get(i);
 
             String referencedPkName = (jc != null && !jc.referencedColumnName().isEmpty())
                     ? jc.referencedColumnName() : refPkList.get(i).getColumnName();
+
             ColumnModel referencedPkColumn = refPkMap.get(referencedPkName);
             if (referencedPkColumn == null) {
                 context.getMessager().printMessage(Diagnostic.Kind.ERROR,
@@ -97,21 +135,34 @@ public class RelationshipHandler {
                 return;
             }
 
-            // Naming 규칙을 사용하여 FK 컬럼명 생성
-            String fkColumnName = (jc != null && !jc.name().isEmpty()) ? jc.name() : context.getNaming().foreignKeyColumnName(field.getSimpleName().toString(), referencedPkName);
+            // FK 컬럼명 결정 (필드명 기반)
+            String fieldName = field.getSimpleName().toString();
+            String fkColumnName = (jc != null && !jc.name().isEmpty())
+                    ? jc.name()
+                    : context.getNaming().foreignKeyColumnName(
+                    fieldName, referencedPkName);
 
+            // @MapsId 처리
             boolean makePk;
             if (mapsId == null) {
                 makePk = false;
             } else if (mapsIdAttr == null) {
                 makePk = true; // 전체 ID 공유
             } else {
-                // heuristics: FK가 가리키는 참조 PK명이 attr과 일치/접미 일치하면 PK 승격
+                // 휴리스틱: FK가 가리키는 참조 PK명이 attr과 일치하면 PK 승격
                 makePk = referencedPkName.equalsIgnoreCase(mapsIdAttr)
                         || referencedPkName.endsWith("_" + mapsIdAttr);
             }
 
-            boolean isNullable = (jc != null) ? jc.nullable() : (manyToOne != null ? manyToOne.optional() : oneToOne.optional());
+            // JPA 의도상 optional=false면 연관관계가 반드시 존재해야 하므로, DDL에서도 NOT NULL을 보장..
+            boolean associationOptional =
+                    (manyToOne != null) ? manyToOne.optional() : oneToOne.optional();
+
+            boolean columnNullableFromAnno =
+                    (jc != null) ? jc.nullable() : associationOptional;
+
+            // PK는 무조건 NOT NULL, 그리고 optional=false면 NOT NULL 강제
+            boolean isNullable = !makePk && (associationOptional && columnNullableFromAnno);
 
             ColumnModel fkColumn = ColumnModel.builder()
                     .columnName(fkColumnName)
@@ -120,18 +171,24 @@ public class RelationshipHandler {
                     .isNullable(!makePk && isNullable) // PK 컬럼은 non-null
                     .build();
 
+            // 기존 컬럼과 타입 충돌 검증
             if (ownerEntity.getColumns().containsKey(fkColumnName)) {
                 ColumnModel existing = ownerEntity.getColumns().get(fkColumnName);
                 if (!existing.getJavaType().equals(fkColumn.getJavaType())) {
-                    context.getMessager().printMessage(Diagnostic.Kind.ERROR, "Type mismatch for column '" + fkColumnName + "' on " + ownerEntity.getEntityName() + ". FK requires type " + fkColumn.getJavaType() + " but existing column has type " + existing.getJavaType(), field);
+                    context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                            "Type mismatch for column '" + fkColumnName + "' on " + ownerEntity.getEntityName() +
+                                    ". FK requires type " + fkColumn.getJavaType() +
+                                    " but existing column has type " + existing.getJavaType(), field);
                 }
             } else {
                 ownerEntity.getColumns().put(fkColumnName, fkColumn);
             }
+
             fkColumnNames.add(fkColumnName);
             referencedPkNames.add(referencedPkName);
         }
 
+        // FK 제약 조건명 결정
         String explicitFkName = joinColumns.stream()
                 .map(JoinColumn::foreignKey)
                 .map(ForeignKey::name)
@@ -139,9 +196,11 @@ public class RelationshipHandler {
                 .findFirst()
                 .orElse(null);
 
-        String relationConstraintName = (explicitFkName != null) ? explicitFkName : context.getNaming().fkName(
-                ownerEntity.getTableName(), fkColumnNames, referencedEntity.getTableName(), referencedPkNames);
+        String relationConstraintName = (explicitFkName != null) ? explicitFkName :
+                context.getNaming().fkName(ownerEntity.getTableName(), fkColumnNames,
+                        referencedEntity.getTableName(), referencedPkNames);
 
+        // 관계 모델 생성
         RelationshipModel relationship = RelationshipModel.builder()
                 .type(manyToOne != null ? RelationshipType.MANY_TO_ONE : RelationshipType.ONE_TO_ONE)
                 .columns(fkColumnNames)
@@ -153,29 +212,32 @@ public class RelationshipHandler {
                 .orphanRemoval(oneToOne != null && oneToOne.orphanRemoval())
                 .fetchType(manyToOne != null ? manyToOne.fetch() : oneToOne.fetch())
                 .build();
+
         ownerEntity.getRelationships().put(relationship.getConstraintName(), relationship);
     }
 
-    private void processUnidirectionalOneToMany(VariableElement field, EntityModel ownerEntity, OneToMany oneToMany) {
+    /**
+     * 단방향 @OneToMany FK 방식 처리
+     * 타겟 엔티티에 FK 컬럼을 추가
+     */
+    private void processUnidirectionalOneToMany_FK(VariableElement field, EntityModel ownerEntity, OneToMany oneToMany) {
         TypeMirror targetType = ((DeclaredType) field.asType()).getTypeArguments().get(0);
         TypeElement targetEntityElement = (TypeElement) ((DeclaredType) targetType).asElement();
-        EntityModel targetEntityModel = context.getSchemaModel().getEntities().get(targetEntityElement.getQualifiedName().toString());
+        EntityModel targetEntityModel = context.getSchemaModel().getEntities()
+                .get(targetEntityElement.getQualifiedName().toString());
         if (targetEntityModel == null) return;
 
         List<ColumnModel> ownerPks = context.findAllPrimaryKeyColumns(ownerEntity);
         if (ownerPks.isEmpty()) {
-            context.getMessager().printMessage(Diagnostic.Kind.ERROR, "Entity " + ownerEntity.getEntityName() + " must have a primary key for @OneToMany relationship.", field);
+            context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    "Entity " + ownerEntity.getEntityName() + " must have a primary key for @OneToMany relationship.", field);
             return;
         }
 
         JoinColumns jcs = field.getAnnotation(JoinColumns.class);
         JoinColumn jc = field.getAnnotation(JoinColumn.class);
-        List<JoinColumn> jlist = jcs != null ? Arrays.asList(jcs.value()) : (jc != null ? List.of(jc) : Collections.emptyList());
-
-        if (jlist.isEmpty() && ownerPks.size() > 1) {
-            context.getMessager().printMessage(Diagnostic.Kind.ERROR, "Unidirectional @OneToMany with a composite key on " + ownerEntity.getEntityName() + " requires explicit @JoinColumns.", field);
-            return;
-        }
+        List<JoinColumn> jlist = jcs != null ? Arrays.asList(jcs.value()) :
+                (jc != null ? List.of(jc) : Collections.emptyList());
 
         if (!jlist.isEmpty() && jlist.size() != ownerPks.size()) {
             context.getMessager().printMessage(Diagnostic.Kind.ERROR,
@@ -186,14 +248,20 @@ public class RelationshipHandler {
 
         List<String> fkNames = new ArrayList<>();
         List<String> refNames = new ArrayList<>();
+
+        // FK 컬럼 생성 (타겟 엔티티에 추가)
         for (int i = 0; i < ownerPks.size(); i++) {
             ColumnModel ownerPk = ownerPks.get(i);
-            JoinColumn j = jlist.isEmpty() ? null : jlist.get(i);
+            // j != null이 항상 성립 하므로 분기 제거
+            JoinColumn j = jlist.get(i);
 
-            String refName = (j != null && !j.referencedColumnName().isEmpty()) ? j.referencedColumnName() : ownerPk.getColumnName();
+            String refName = (j != null && !j.referencedColumnName().isEmpty())
+                    ? j.referencedColumnName() : ownerPk.getColumnName();
 
-            // Naming 규칙을 사용하여 FK 컬럼명 생성
-            String fkName = (j != null && !j.name().isEmpty()) ? j.name() : context.getNaming().foreignKeyColumnName(ownerEntity.getTableName(), refName);
+            // FK 컬럼명 결정 (네이밍 통일: 테이블_컬럼 형식)
+            String fkName = (j != null && !j.name().isEmpty())
+                    ? j.name()
+                    : context.getNaming().foreignKeyColumnName(ownerEntity.getTableName(), refName);
 
             ColumnModel fkColumn = ColumnModel.builder()
                     .columnName(fkName)
@@ -201,21 +269,33 @@ public class RelationshipHandler {
                     .isNullable(j == null || j.nullable())
                     .build();
 
+            // 타입 충돌 검증
             if (targetEntityModel.getColumns().containsKey(fkName)) {
                 ColumnModel existing = targetEntityModel.getColumns().get(fkName);
                 if (!existing.getJavaType().equals(fkColumn.getJavaType())) {
-                    context.getMessager().printMessage(Diagnostic.Kind.ERROR, "Type mismatch for implicit foreign key column '" + fkName + "' in " + targetEntityModel.getEntityName() + ". Expected type " + fkColumn.getJavaType() + " but found existing column with type " + existing.getJavaType(), field);
+                    context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                            "Type mismatch for implicit foreign key column '" + fkName + "' in " +
+                                    targetEntityModel.getEntityName() + ". Expected type " + fkColumn.getJavaType() +
+                                    " but found existing column with type " + existing.getJavaType(), field);
                 }
             } else {
                 targetEntityModel.getColumns().put(fkName, fkColumn);
             }
+
             fkNames.add(fkName);
             refNames.add(refName);
         }
 
-        String constraintName = jlist.stream().findFirst().map(JoinColumn::foreignKey).filter(fk -> !fk.name().isEmpty()).map(ForeignKey::name)
-                .orElseGet(() -> context.getNaming().fkName(targetEntityModel.getTableName(), fkNames, ownerEntity.getTableName(), refNames));
+        // FK 제약 조건명 결정
+        String constraintName = jlist.stream()
+                .findFirst()
+                .map(JoinColumn::foreignKey)
+                .filter(fk -> !fk.name().isEmpty())
+                .map(ForeignKey::name)
+                .orElseGet(() -> context.getNaming().fkName(targetEntityModel.getTableName(), fkNames,
+                        ownerEntity.getTableName(), refNames));
 
+        // 관계 모델 생성 (타겟 엔티티에 추가)
         RelationshipModel rel = RelationshipModel.builder()
                 .type(RelationshipType.ONE_TO_MANY)
                 .columns(fkNames)
@@ -230,24 +310,146 @@ public class RelationshipHandler {
         targetEntityModel.getRelationships().put(rel.getConstraintName(), rel);
     }
 
+    /**
+     * 단방향 @OneToMany JoinTable 방식 처리
+     * 별도의 조인 테이블 생성
+     */
+    private void processUnidirectionalOneToMany_JoinTable(VariableElement field, EntityModel ownerEntity, OneToMany oneToMany) {
+        // 타겟(자식) 엔티티
+        TypeMirror targetType = ((DeclaredType) field.asType()).getTypeArguments().get(0);
+        TypeElement targetEntityElement = (TypeElement) ((DeclaredType) targetType).asElement();
+        EntityModel targetEntity = context.getSchemaModel().getEntities()
+                .get(targetEntityElement.getQualifiedName().toString());
+        if (targetEntity == null) return;
+
+        List<ColumnModel> ownerPks = context.findAllPrimaryKeyColumns(ownerEntity);
+        List<ColumnModel> targetPks = context.findAllPrimaryKeyColumns(targetEntity);
+
+        if (ownerPks.isEmpty()) {
+            context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    "Owner 엔티티에 PK가 필요합니다(@OneToMany JoinTable).", field);
+            return;
+        }
+        if (targetPks.isEmpty()) {
+            context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    "Target 엔티티에 PK가 필요합니다(@OneToMany JoinTable).", field);
+            return;
+        }
+
+        JoinTable jt = field.getAnnotation(JoinTable.class);
+        String joinTableName = (jt != null && !jt.name().isEmpty())
+                ? jt.name()
+                : context.getNaming().joinTableName(ownerEntity.getTableName(), targetEntity.getTableName());
+
+        // 중복 생성 방지
+        if (context.getSchemaModel().getEntities().containsKey(joinTableName)) {
+            return;
+        }
+
+        JoinColumn[] joinColumns = (jt != null) ? jt.joinColumns() : new JoinColumn[0]; // owner측
+        JoinColumn[] inverseJoinColumns = (jt != null) ? jt.inverseJoinColumns() : new JoinColumn[0]; // target측
+
+        // 개수 일치 검증
+        if (joinColumns.length > 0 && joinColumns.length != ownerPks.size()) {
+            context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    "JoinTable.joinColumns 개수가 Owner PK 개수와 일치해야 합니다: expected " + ownerPks.size()
+                            + ", found " + joinColumns.length + ".", field);
+            return;
+        }
+        if (inverseJoinColumns.length > 0 && inverseJoinColumns.length != targetPks.size()) {
+            context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    "JoinTable.inverseJoinColumns 개수가 Target PK 개수와 일치해야 합니다: expected " + targetPks.size()
+                            + ", found " + inverseJoinColumns.length + ".", field);
+            return;
+        }
+
+        // FK 제약 조건명 추출
+        String ownerFkConstraint = Arrays.stream(joinColumns)
+                .map(JoinColumn::foreignKey).map(ForeignKey::name)
+                .filter(n -> n != null && !n.isEmpty()).findFirst().orElse(null);
+        String targetFkConstraint = Arrays.stream(inverseJoinColumns)
+                .map(JoinColumn::foreignKey).map(ForeignKey::name)
+                .filter(n -> n != null && !n.isEmpty()).findFirst().orElse(null);
+
+        // 조인 컬럼 매핑 해결
+        Map<String,String> ownerFkToPkMap = resolveJoinColumnMapping(joinColumns, ownerPks, ownerEntity.getTableName());
+        Map<String,String> targetFkToPkMap = resolveJoinColumnMapping(inverseJoinColumns, targetPks, targetEntity.getTableName());
+
+        JoinTableDetails details = new JoinTableDetails(
+                joinTableName, ownerFkToPkMap, targetFkToPkMap, ownerEntity, targetEntity,
+                ownerFkConstraint, targetFkConstraint
+        );
+
+        // 조인 테이블 생성 및 관계 추가
+        EntityModel joinTableEntity = createJoinTableEntity_ForOneToMany(details, ownerPks, targetPks);
+        addRelationshipsToJoinTable(joinTableEntity, details);
+
+        context.getSchemaModel().getEntities().putIfAbsent(joinTableEntity.getEntityName(), joinTableEntity);
+    }
+
+    /**
+     * OneToMany용 조인 테이블 엔티티 생성
+     */
+    private EntityModel createJoinTableEntity_ForOneToMany(JoinTableDetails details,
+                                                           List<ColumnModel> ownerPks,
+                                                           List<ColumnModel> targetPks) {
+        EntityModel joinTableEntity = EntityModel.builder()
+                .entityName(details.joinTableName()) // record accessor 사용
+                .tableName(details.joinTableName())
+                .tableType(EntityModel.TableType.JOIN_TABLE)
+                .build();
+
+        // owner 측 FK들 → PK로 승격
+        details.ownerFkToPkMap().forEach((fkName, pkName) -> {
+            ColumnModel pk = ownerPks.stream()
+                    .filter(p -> p.getColumnName().equals(pkName))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Owner PK '" + pkName + "' not found while creating join table '" + details.joinTableName() +"'"));
+            joinTableEntity.getColumns().put(fkName, ColumnModel.builder()
+                    .columnName(fkName).javaType(pk.getJavaType()).isPrimaryKey(true).isNullable(false).build());
+        });
+
+        // target 측 FK들 → PK로 승격 (버그 수정: targetPks 사용)
+        details.inverseFkToPkMap().forEach((fkName, pkName) -> {
+            ColumnModel pk = targetPks.stream() // ← 수정됨: targetPks 사용
+                    .filter(p -> p.getColumnName().equals(pkName))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Target PK '" + pkName + "' not found while creating join table '" + details.joinTableName() +"'"));
+            joinTableEntity.getColumns().put(fkName, ColumnModel.builder()
+                    .columnName(fkName).javaType(pk.getJavaType()).isPrimaryKey(true).isNullable(false).build());
+        });
+
+        return joinTableEntity;
+    }
+
+    /**
+     * 소유측 @ManyToMany 관계 처리
+     */
     private void processOwningManyToMany(VariableElement field, EntityModel ownerEntity, ManyToMany manyToMany) {
         JoinTable joinTable = field.getAnnotation(JoinTable.class);
         TypeElement referencedTypeElement = getReferencedTypeElement(((DeclaredType) field.asType()).getTypeArguments().get(0));
         if (referencedTypeElement == null) return;
-        EntityModel referencedEntity = context.getSchemaModel().getEntities().get(referencedTypeElement.getQualifiedName().toString());
+
+        EntityModel referencedEntity = context.getSchemaModel().getEntities()
+                .get(referencedTypeElement.getQualifiedName().toString());
         if (referencedEntity == null) return;
 
         List<ColumnModel> ownerPks = context.findAllPrimaryKeyColumns(ownerEntity);
         List<ColumnModel> referencedPks = context.findAllPrimaryKeyColumns(referencedEntity);
 
         if (ownerPks.isEmpty() || referencedPks.isEmpty()) {
-            context.getMessager().printMessage(Diagnostic.Kind.ERROR, "Entities in a @ManyToMany relationship must have a primary key.", field);
+            context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    "Entities in a @ManyToMany relationship must have a primary key.", field);
             return;
         }
 
         String joinTableName = (joinTable != null && !joinTable.name().isEmpty())
-                ? joinTable.name() : context.getNaming().joinTableName(ownerEntity.getTableName(), referencedEntity.getTableName());
+                ? joinTable.name()
+                : context.getNaming().joinTableName(ownerEntity.getTableName(), referencedEntity.getTableName());
 
+        // 중복 생성 방지
         if (context.getSchemaModel().getEntities().containsKey(joinTableName)) {
             return;
         }
@@ -255,14 +457,23 @@ public class RelationshipHandler {
         JoinColumn[] joinColumns = (joinTable != null) ? joinTable.joinColumns() : new JoinColumn[0];
         JoinColumn[] inverseJoinColumns = (joinTable != null) ? joinTable.inverseJoinColumns() : new JoinColumn[0];
 
+        // 개수 일치 검증
         if (joinColumns.length > 0 && joinColumns.length != ownerPks.size()) {
-            context.getMessager().printMessage(Diagnostic.Kind.ERROR, "The number of @JoinColumn annotations for " + ownerEntity.getTableName() + " must match its primary key columns: expected " + ownerPks.size() + ", found " + joinColumns.length + ".", field);
+            context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    "The number of @JoinColumn annotations for " + ownerEntity.getTableName() +
+                            " must match its primary key columns: expected " + ownerPks.size() +
+                            ", found " + joinColumns.length + ".", field);
             return;
         }
         if (inverseJoinColumns.length > 0 && inverseJoinColumns.length != referencedPks.size()) {
-            context.getMessager().printMessage(Diagnostic.Kind.ERROR, "The number of @InverseJoinColumn annotations for " + referencedEntity.getTableName() + " must match its primary key columns: expected " + referencedPks.size() + ", found " + inverseJoinColumns.length + ".", field);
+            context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    "The number of @InverseJoinColumn annotations for " + referencedEntity.getTableName() +
+                            " must match its primary key columns: expected " + referencedPks.size() +
+                            ", found " + inverseJoinColumns.length + ".", field);
             return;
         }
+
+        // FK 제약 조건명 추출
         String ownerFkConstraint = Arrays.stream(joinColumns)
                 .map(JoinColumn::foreignKey).map(ForeignKey::name)
                 .filter(n -> n != null && !n.isEmpty()).findFirst().orElse(null);
@@ -271,29 +482,44 @@ public class RelationshipHandler {
                 .map(JoinColumn::foreignKey).map(ForeignKey::name)
                 .filter(n -> n != null && !n.isEmpty()).findFirst().orElse(null);
 
+        // 조인 컬럼 매핑 해결
         Map<String, String> ownerFkToPkMap = resolveJoinColumnMapping(joinColumns, ownerPks, ownerEntity.getTableName());
         Map<String, String> inverseFkToPkMap = resolveJoinColumnMapping(inverseJoinColumns, referencedPks, referencedEntity.getTableName());
 
-        JoinTableDetails details = new JoinTableDetails(joinTableName, ownerFkToPkMap, inverseFkToPkMap, ownerEntity, referencedEntity, ownerFkConstraint, inverseFkConstraint);
+        JoinTableDetails details = new JoinTableDetails(joinTableName, ownerFkToPkMap, inverseFkToPkMap,
+                ownerEntity, referencedEntity, ownerFkConstraint, inverseFkConstraint);
+
+        // 조인 테이블 생성 및 관계 추가
         EntityModel joinTableEntity = createJoinTableEntity(details, ownerPks, referencedPks);
         addRelationshipsToJoinTable(joinTableEntity, details);
 
         context.getSchemaModel().getEntities().putIfAbsent(joinTableEntity.getEntityName(), joinTableEntity);
     }
 
+    /**
+     * 조인 컬럼 매핑 해결
+     */
     private Map<String, String> resolveJoinColumnMapping(JoinColumn[] joinColumns, List<ColumnModel> referencedPks, String entityTableName) {
         Map<String, String> mapping = new LinkedHashMap<>();
+
         if (joinColumns == null || joinColumns.length == 0) {
+            // 기본 매핑: 테이블명_컬럼명 형식
             referencedPks.forEach(pk -> mapping.put(
                     context.getNaming().foreignKeyColumnName(entityTableName, pk.getColumnName()),
                     pk.getColumnName()
             ));
         } else {
+            // 명시적 매핑
             for (int i = 0; i < joinColumns.length; i++) {
                 JoinColumn jc = joinColumns[i];
-                String pkName = jc.referencedColumnName().isEmpty() ? referencedPks.get(i).getColumnName() : jc.referencedColumnName();
+                String pkName = jc.referencedColumnName().isEmpty()
+                        ? referencedPks.get(i).getColumnName()
+                        : jc.referencedColumnName();
 
-                String fkName = jc.name().isEmpty() ? context.getNaming().foreignKeyColumnName(entityTableName, pkName) : jc.name();
+                String fkName = jc.name().isEmpty()
+                        ? context.getNaming().foreignKeyColumnName(entityTableName, pkName)
+                        : jc.name();
+
                 if (mapping.containsKey(fkName)) {
                     context.getMessager().printMessage(Diagnostic.Kind.ERROR,
                             "Duplicate FK column '"+ fkName +"' in join table mapping for " + entityTableName);
@@ -305,65 +531,81 @@ public class RelationshipHandler {
         return mapping;
     }
 
+    /**
+     * ManyToMany용 조인 테이블 엔티티 생성
+     */
     private EntityModel createJoinTableEntity(JoinTableDetails details, List<ColumnModel> ownerPks, List<ColumnModel> referencedPks) {
         EntityModel joinTableEntity = EntityModel.builder()
-                .entityName(details.joinTableName)
-                .tableName(details.joinTableName)
+                .entityName(details.joinTableName()) // record accessor 사용
+                .tableName(details.joinTableName())
                 .tableType(EntityModel.TableType.JOIN_TABLE)
                 .build();
 
-        details.ownerFkToPkMap.forEach((fkName, pkName) -> {
+        // owner 측 FK들 → PK로 승격
+        details.ownerFkToPkMap().forEach((fkName, pkName) -> {
             ColumnModel pk = ownerPks.stream()
                     .filter(p -> p.getColumnName().equals(pkName))
                     .findFirst()
                     .orElseThrow(() -> new IllegalStateException(
-                            "Owner PK '" + pkName + "' not found while creating join table '" + details.joinTableName +"'"));
-            joinTableEntity.getColumns().put(fkName, ColumnModel.builder().columnName(fkName).javaType(pk.getJavaType()).isPrimaryKey(true).build());
+                            "Owner PK '" + pkName + "' not found while creating join table '" + details.joinTableName() +"'"));
+            joinTableEntity.getColumns().put(fkName, ColumnModel.builder()
+                    .columnName(fkName).javaType(pk.getJavaType()).isPrimaryKey(true).isNullable(false).build());
         });
-        details.inverseFkToPkMap.forEach((fkName, pkName) -> {
-            ColumnModel pk = ownerPks.stream()
+
+        // referenced 측 FK들 → PK로 승격 (버그 수정: referencedPks 사용)
+        details.inverseFkToPkMap().forEach((fkName, pkName) -> {
+            ColumnModel pk = referencedPks.stream() // ← 수정됨: referencedPks 사용
                     .filter(p -> p.getColumnName().equals(pkName))
                     .findFirst()
                     .orElseThrow(() -> new IllegalStateException(
-                            "Owner PK '" + pkName + "' not found while creating join table '" + details.joinTableName +"'"));
-            joinTableEntity.getColumns().put(fkName, ColumnModel.builder().columnName(fkName).javaType(pk.getJavaType()).isPrimaryKey(true).build());
+                            "Referenced PK '" + pkName + "' not found while creating join table '" + details.joinTableName() +"'"));
+            joinTableEntity.getColumns().put(fkName, ColumnModel.builder()
+                    .columnName(fkName).javaType(pk.getJavaType()).isPrimaryKey(true).isNullable(false).build());
         });
 
         return joinTableEntity;
     }
 
+    /**
+     * 조인 테이블에 FK 관계 추가
+     */
     private void addRelationshipsToJoinTable(EntityModel joinTableEntity, JoinTableDetails details) {
-        List<String> ownerFkColumns = new ArrayList<>(details.ownerFkToPkMap.keySet());
-        List<String> ownerPkColumns = new ArrayList<>(details.ownerFkToPkMap.values());
+        // owner 측 관계
+        List<String> ownerFkColumns = new ArrayList<>(details.ownerFkToPkMap().keySet());
+        List<String> ownerPkColumns = new ArrayList<>(details.ownerFkToPkMap().values());
 
         RelationshipModel ownerRel = RelationshipModel.builder()
                 .type(RelationshipType.MANY_TO_ONE)
                 .columns(ownerFkColumns)
-                .referencedTable(details.ownerEntity.getTableName())
+                .referencedTable(details.ownerEntity().getTableName())
                 .referencedColumns(ownerPkColumns)
                 .constraintName(details.ownerFkConstraintName() != null
                         ? details.ownerFkConstraintName()
-                        : context.getNaming().fkName(details.joinTableName, ownerFkColumns,
-                        details.ownerEntity.getTableName(), ownerPkColumns))
+                        : context.getNaming().fkName(details.joinTableName(), ownerFkColumns,
+                        details.ownerEntity().getTableName(), ownerPkColumns))
                 .build();
         joinTableEntity.getRelationships().put(ownerRel.getConstraintName(), ownerRel);
 
-        List<String> inverseFkColumns = new ArrayList<>(details.inverseFkToPkMap.keySet());
-        List<String> inversePkColumns = new ArrayList<>(details.inverseFkToPkMap.values());
+        // referenced/target 측 관계
+        List<String> targetFkColumns = new ArrayList<>(details.inverseFkToPkMap().keySet());
+        List<String> targetPkColumns = new ArrayList<>(details.inverseFkToPkMap().values());
 
-        RelationshipModel inverseRel = RelationshipModel.builder()
+        RelationshipModel targetRel = RelationshipModel.builder()
                 .type(RelationshipType.MANY_TO_ONE)
-                .columns(inverseFkColumns)
-                .referencedTable(details.referencedEntity.getTableName())
-                .referencedColumns(inversePkColumns)
+                .columns(targetFkColumns)
+                .referencedTable(details.referencedEntity().getTableName())
+                .referencedColumns(targetPkColumns)
                 .constraintName(details.inverseFkConstraintName() != null
                         ? details.inverseFkConstraintName()
-                        : context.getNaming().fkName(details.joinTableName(), inverseFkColumns,
-                        details.referencedEntity.getTableName(), inversePkColumns))
+                        : context.getNaming().fkName(details.joinTableName(), targetFkColumns,
+                        details.referencedEntity().getTableName(), targetPkColumns))
                 .build();
-        joinTableEntity.getRelationships().put(inverseRel.getConstraintName(), inverseRel);
+        joinTableEntity.getRelationships().put(targetRel.getConstraintName(), targetRel);
     }
 
+    /**
+     * 타입에서 참조되는 TypeElement 추출
+     */
     private TypeElement getReferencedTypeElement(TypeMirror typeMirror) {
         if (typeMirror instanceof DeclaredType declaredType && declaredType.asElement() instanceof TypeElement) {
             return (TypeElement) declaredType.asElement();
@@ -371,10 +613,16 @@ public class RelationshipHandler {
         return null;
     }
 
+    /**
+     * JPA CascadeType 배열을 내부 CascadeType 리스트로 변환
+     */
     private List<CascadeType> toCascadeList(jakarta.persistence.CascadeType[] arr) {
         return arr == null ? Collections.emptyList() : Arrays.stream(arr).toList();
     }
 
+    /**
+     * 조인 테이블 상세 정보를 담는 record
+     */
     private record JoinTableDetails(
             String joinTableName,
             Map<String, String> ownerFkToPkMap,

--- a/jinx-processor/src/test/java/org/jinx/handler/RelationshipHandlerTest.java
+++ b/jinx-processor/src/test/java/org/jinx/handler/RelationshipHandlerTest.java
@@ -1,305 +1,1035 @@
-//package org.jinx.handler;
-//
-//import jakarta.persistence.*;
-//import org.jinx.context.ProcessingContext;
-//import org.jinx.model.*;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.*;
-//import org.mockito.exceptions.base.MockitoException;
-//
-//import javax.annotation.processing.Messager;
-//import javax.lang.model.element.*;
-//import javax.lang.model.type.DeclaredType;
-//import javax.lang.model.type.TypeMirror;
-//import javax.lang.model.element.Name;
-//import javax.tools.Diagnostic;
-//import java.util.*;
-//
-//import static com.google.common.truth.Truth.assertThat;
-//import static org.mockito.Mockito.*;
-//
-//class RelationshipHandlerTest {
-//
-//    @Mock
-//    private ProcessingContext context;
-//    @Mock
-//    private SchemaModel schemaModel;
-//    @Mock
-//    private Messager messager;
-//    @Mock
-//    private TypeElement ownerTypeElement;
-//    @Mock
-//    private VariableElement fieldElement;
-//    @Mock
-//    private DeclaredType fieldType;
-//    @Mock
-//    private TypeElement referencedTypeElement;
-//    @Mock
-//    private Name referencedElementName;
-//    @Mock
-//    private Name fieldElementName;
-//
-//    @Captor
-//    private ArgumentCaptor<EntityModel> entityModelCaptor;
-//    @Captor
-//    private ArgumentCaptor<String> stringCaptor;
-//    @Captor
-//    private ArgumentCaptor<RelationshipModel> relationshipCaptor;
-//
-//    private RelationshipHandler relationshipHandler;
-//    private EntityModel ownerEntityModel;
-//    private EntityModel referencedEntityModel;
-//
-//    @BeforeEach
-//    void setUp() {
-//        MockitoAnnotations.openMocks(this);
-//
-//        relationshipHandler = new RelationshipHandler(context);
-//
-//        when(context.getSchemaModel()).thenReturn(schemaModel);
-//        lenient().when(context.getMessager()).thenReturn(messager);
-//
-//        ownerEntityModel = EntityModel.builder()
-//                .entityName("Owner")
-//                .tableName("owner_table")
-//                .columns(new java.util.HashMap<>())
-//                .relationships(new java.util.ArrayList<>())
-//                .build();
-//        doReturn(List.of(fieldElement)).when(ownerTypeElement).getEnclosedElements();
-//        when(fieldElement.getKind()).thenReturn(ElementKind.FIELD);
-//
-//        referencedEntityModel = EntityModel.builder()
-//                .entityName("Referenced")
-//                .tableName("referenced_table")
-//                .columns(new java.util.HashMap<>())
-//                .build();
-//        ColumnModel referencedPkColumn = ColumnModel.builder().columnName("id").javaType("java.lang.Long").isPrimaryKey(true).build();
-//        referencedEntityModel.getColumns().put("id", referencedPkColumn);
-//
-//        lenient().when(referencedElementName.toString()).thenReturn("com.example.Referenced");
-//        lenient().when(fieldElementName.toString()).thenReturn("referenced");
-//        lenient().when(referencedTypeElement.getQualifiedName()).thenReturn(referencedElementName);
-//        lenient().when(fieldElement.getSimpleName()).thenReturn(fieldElementName);
-//        lenient().when(schemaModel.getEntities()).thenReturn(Map.of("com.example.Referenced", referencedEntityModel));
-//        lenient().when(context.findPrimaryKeyColumnName(referencedEntityModel)).thenReturn(Optional.of("id"));
-//    }
-//
-//    private void setupFieldType() {
-//        when(fieldElement.asType()).thenReturn(fieldType);
-//        when(fieldType.asElement()).thenReturn(referencedTypeElement);
-//    }
-//
-//    @Test
-//    @DisplayName("@ManyToOne 관계를 올바르게 처리해야 한다")
-//    void resolveRelationships_WithManyToOne_ShouldCreateForeignKeyAndRelationship() {
-//        // Given
-//        setupFieldType();
-//        ManyToOne manyToOne = mock(ManyToOne.class);
-//        JoinColumn joinColumn = mock(JoinColumn.class);
-//        when(fieldElement.getAnnotation(ManyToOne.class)).thenReturn(manyToOne);
-//        when(fieldElement.getAnnotation(JoinColumn.class)).thenReturn(joinColumn);
-//        when(joinColumn.name()).thenReturn(""); // 기본 이름 생성 규칙 테스트
-//        when(manyToOne.optional()).thenReturn(true);
-//        when(manyToOne.fetch()).thenReturn(FetchType.EAGER);
-//        when(manyToOne.cascade()).thenReturn(new CascadeType[]{});
-//
-//        // When
-//        relationshipHandler.resolveRelationships(ownerTypeElement, ownerEntityModel);
-//
-//        // Then
-//        assertThat(ownerEntityModel.getColumns()).hasSize(1);
-//        ColumnModel fkColumn = ownerEntityModel.getColumns().get("referenced_id");
-//        assertThat(fkColumn).isNotNull();
-//        assertThat(fkColumn.getColumnName()).isEqualTo("referenced_id");
-//        assertThat(fkColumn.getJavaType()).isEqualTo("java.lang.Long");
-//        assertThat(fkColumn.isPrimaryKey()).isFalse();
-//        assertThat(fkColumn.isNullable()).isTrue();
-//
-//        assertThat(ownerEntityModel.getRelationships()).hasSize(1);
-//        RelationshipModel relationship = ownerEntityModel.getRelationships().get(0);
-//        assertThat(relationship.getType()).isEqualTo(RelationshipType.MANY_TO_ONE);
-//        assertThat(relationship.getColumn()).isEqualTo("referenced_id");
-//        assertThat(relationship.getReferencedTable()).isEqualTo("referenced_table");
-//        assertThat(relationship.getReferencedColumn()).isEqualTo("id");
-//        assertThat(relationship.getFetchType()).isEqualTo(FetchType.EAGER);
-//    }
-//
-//    @Test
-//    @DisplayName("@OneToOne(unique=true) 관계를 올바르게 처리해야 한다")
-//    void resolveRelationships_WithOneToOne_ShouldCreateUniqueForeignKey() {
-//        // Given
-//        setupFieldType();
-//        OneToOne oneToOne = mock(OneToOne.class);
-//        JoinColumn joinColumn = mock(JoinColumn.class);
-//        when(fieldElement.getAnnotation(OneToOne.class)).thenReturn(oneToOne);
-//        when(fieldElement.getAnnotation(JoinColumn.class)).thenReturn(joinColumn);
-//        when(joinColumn.name()).thenReturn("ref_custom_id"); // 커스텀 이름 테스트
-//        when(oneToOne.optional()).thenReturn(false);
-//        when(oneToOne.fetch()).thenReturn(FetchType.LAZY);
-//        when(oneToOne.cascade()).thenReturn(new CascadeType[]{});
-//
-//        // When
-//        relationshipHandler.resolveRelationships(ownerTypeElement, ownerEntityModel);
-//
-//        // Then
-//        assertThat(ownerEntityModel.getColumns()).hasSize(1);
-//        ColumnModel fkColumn = ownerEntityModel.getColumns().get("ref_custom_id");
-//        assertThat(fkColumn).isNotNull();
-//        assertThat(fkColumn.isUnique()).isTrue();
-//        assertThat(fkColumn.isNullable()).isFalse();
-//
-//        assertThat(ownerEntityModel.getRelationships()).hasSize(1);
-//        RelationshipModel relationship = ownerEntityModel.getRelationships().get(0);
-//        assertThat(relationship.getType()).isEqualTo(RelationshipType.ONE_TO_ONE);
-//        assertThat(relationship.getColumn()).isEqualTo("ref_custom_id");
-//    }
-//
-//    @Test
-//    @DisplayName("@OneToOne 과 @MapsId 를 사용한 주키-외래키 관계를 올바르게 처리해야 한다")
-//    void resolveRelationships_WithOneToOneAndMapsId_ShouldCreatePrimaryKeyForeignKey() {
-//        // Given
-//        setupFieldType();
-//        OneToOne oneToOne = mock(OneToOne.class);
-//        JoinColumn joinColumn = mock(JoinColumn.class);
-//        MapsId mapsId = mock(MapsId.class);
-//        when(fieldElement.getAnnotation(OneToOne.class)).thenReturn(oneToOne);
-//        when(fieldElement.getAnnotation(JoinColumn.class)).thenReturn(joinColumn);
-//        when(fieldElement.getAnnotation(MapsId.class)).thenReturn(mapsId);
-//        when(joinColumn.name()).thenReturn("");
-//        when(oneToOne.fetch()).thenReturn(FetchType.LAZY);
-//        when(oneToOne.cascade()).thenReturn(new CascadeType[]{});
-//
-//        // When
-//        relationshipHandler.resolveRelationships(ownerTypeElement, ownerEntityModel);
-//
-//        // Then
-//        assertThat(ownerEntityModel.getColumns()).hasSize(1);
-//        ColumnModel fkColumn = ownerEntityModel.getColumns().get("referenced_id");
-//        assertThat(fkColumn).isNotNull();
-//        assertThat(fkColumn.isPrimaryKey()).isTrue();
-//        assertThat(fkColumn.isNullable()).isFalse(); // @MapsId implies non-nullable
-//
-//        assertThat(ownerEntityModel.getRelationships()).hasSize(1);
-//        RelationshipModel relationship = ownerEntityModel.getRelationships().get(0);
-//        assertThat(relationship.isMapsId()).isTrue();
-//    }
-//
-//    @Test
-//    @DisplayName("@OneToMany(단방향) 관계를 올바르게 처리해야 한다")
-//    void resolveRelationships_WithUnidirectionalOneToMany_ShouldCreateRelationship() {
-//        // Given
-//        DeclaredType listType = mock(DeclaredType.class);
-//        DeclaredType genericType = mock(DeclaredType.class);
-//
-//        when(fieldElement.asType()).thenReturn(listType);              // field.asType()은 List<Referenced> 타입을 반환
-//        doReturn(List.of(genericType)).when(listType).getTypeArguments();
-//        when(genericType.asElement()).thenReturn(referencedTypeElement);    // Referenced 타입의 Element는 referencedTypeElement
-//
-//        OneToMany oneToMany = mock(OneToMany.class);
-//        JoinColumn joinColumn = mock(JoinColumn.class);
-//        when(fieldElement.getAnnotation(OneToMany.class)).thenReturn(oneToMany);
-//        when(fieldElement.getAnnotation(JoinColumn.class)).thenReturn(joinColumn);
-//
-//        when(oneToMany.mappedBy()).thenReturn("");
-//        when(joinColumn.name()).thenReturn("owner_id_in_referenced");
-//        when(oneToMany.fetch()).thenReturn(FetchType.LAZY);
-//        when(oneToMany.cascade()).thenReturn(new CascadeType[]{CascadeType.ALL});
-//        when(oneToMany.orphanRemoval()).thenReturn(true);
-//
-//        // When
-//        relationshipHandler.resolveRelationships(ownerTypeElement, ownerEntityModel);
-//
-//        // Then
-//        assertThat(ownerEntityModel.getColumns()).isEmpty();
-//
-//        assertThat(ownerEntityModel.getRelationships()).hasSize(1);
-//        RelationshipModel relationship = ownerEntityModel.getRelationships().get(0);
-//        assertThat(relationship.getType()).isEqualTo(RelationshipType.ONE_TO_MANY);
-//        assertThat(relationship.getColumn()).isEqualTo("owner_id_in_referenced");
-//        assertThat(relationship.getReferencedTable()).isEqualTo("referenced_table");
-//        assertThat(relationship.getCascadeTypes()).containsExactly(CascadeType.ALL);
-//        assertThat(relationship.isOrphanRemoval()).isTrue();
-//    }
-//
-//    @Test
-//    @DisplayName("@ManyToMany 관계는 조인 테이블 엔티티를 생성해야 한다")
-//    void resolveRelationships_WithManyToMany_ShouldCreateJoinTableEntity() {
-//        // Given
-//        // Mock a collection field: List<Referenced>
-//        DeclaredType listType = mock(DeclaredType.class);
-//        DeclaredType genericType = mock(DeclaredType.class);
-//
-//        when(fieldElement.asType()).thenReturn(listType);
-//        doReturn(List.of(genericType)).when(listType).getTypeArguments();
-//        when(genericType.asElement()).thenReturn(referencedTypeElement);
-//
-//        ManyToMany manyToMany = mock(ManyToMany.class);
-//        JoinTable joinTable = mock(JoinTable.class);
-//        when(manyToMany.mappedBy()).thenReturn("");
-//        when(manyToMany.cascade()).thenReturn(new CascadeType[]{});
-//        when(manyToMany.fetch()).thenReturn(FetchType.LAZY);
-//        when(fieldElement.getAnnotation(ManyToMany.class)).thenReturn(manyToMany);
-//        when(fieldElement.getAnnotation(JoinTable.class)).thenReturn(joinTable);
-//
-//        // Mock JoinTable annotation details
-//        when(joinTable.name()).thenReturn("owner_referenced_join_table");
-//        JoinColumn ownerJoinColumn = mock(JoinColumn.class);
-//        when(ownerJoinColumn.name()).thenReturn("owner_fk");
-//        when(joinTable.joinColumns()).thenReturn(new JoinColumn[]{ownerJoinColumn});
-//        JoinColumn inverseJoinColumn = mock(JoinColumn.class);
-//        when(inverseJoinColumn.name()).thenReturn("referenced_fk");
-//        when(joinTable.inverseJoinColumns()).thenReturn(new JoinColumn[]{inverseJoinColumn});
-//
-//        // Mock PK for owner entity
-//        ColumnModel ownerPkColumn = ColumnModel.builder().columnName("owner_pk").javaType("java.lang.Integer").isPrimaryKey(true).build();
-//        ownerEntityModel.getColumns().put("owner_pk", ownerPkColumn);
-//        when(context.findPrimaryKeyColumnName(ownerEntityModel)).thenReturn(Optional.of("owner_pk"));
-//
-//        // schemaModel.getEntities()가 호출될 때 putIfAbsent를 위해 수정 가능한 Map을 반환하도록 설정
-//        Map<String, EntityModel> entitiesMap = Mockito.spy(new HashMap<>());
-//        entitiesMap.put("com.example.Referenced", referencedEntityModel);
-//        when(schemaModel.getEntities()).thenReturn(entitiesMap);
-//
-//        // When
-//        relationshipHandler.resolveRelationships(ownerTypeElement, ownerEntityModel);
-//
-//        // Then
-//        // Verify a new entity for the join table was created and added to the schema
-//        verify(schemaModel.getEntities()).putIfAbsent(stringCaptor.capture(), entityModelCaptor.capture());
-//
-//        assertThat(stringCaptor.getValue()).isEqualTo("owner_referenced_join_table");
-//        EntityModel joinTableEntity = entityModelCaptor.getValue();
-//
-//        assertThat(joinTableEntity.getTableName()).isEqualTo("owner_referenced_join_table");
-//        assertThat(joinTableEntity.getTableType()).isEqualTo(EntityModel.TableType.JOIN_TABLE);
-//
-//        // 조인 테이블의 컬럼 검증
-//        assertThat(joinTableEntity.getColumns()).hasSize(2);
-//        ColumnModel ownerFk = joinTableEntity.getColumns().get("owner_fk");
-//        assertThat(ownerFk).isNotNull();
-//        assertThat(ownerFk.getJavaType()).isEqualTo("java.lang.Integer");
-//        assertThat(ownerFk.isPrimaryKey()).isTrue();
-//
-//        ColumnModel referencedFk = joinTableEntity.getColumns().get("referenced_fk");
-//        assertThat(referencedFk).isNotNull();
-//        assertThat(referencedFk.getJavaType()).isEqualTo("java.lang.Long");
-//        assertThat(referencedFk.isPrimaryKey()).isTrue();
-//
-//        // 조인 테이블의 관계 검증
-//        assertThat(joinTableEntity.getRelationships()).hasSize(2);
-//        RelationshipModel toOwner = joinTableEntity.getRelationships().stream()
-//                .filter(r -> r.getReferencedTable().equals("owner_table")).findFirst().orElse(null);
-//        assertThat(toOwner).isNotNull();
-//        assertThat(toOwner.getColumn()).isEqualTo("owner_fk");
-//        assertThat(toOwner.getReferencedColumn()).isEqualTo("owner_pk");
-//
-//        RelationshipModel toReferenced = joinTableEntity.getRelationships().stream()
-//                .filter(r -> r.getReferencedTable().equals("referenced_table")).findFirst().orElse(null);
-//        assertThat(toReferenced).isNotNull();
-//        assertThat(toReferenced.getColumn()).isEqualTo("referenced_fk");
-//        assertThat(toReferenced.getReferencedColumn()).isEqualTo("id");
-//    }
-//}
+package org.jinx.handler;
+
+import jakarta.persistence.*;
+import org.jinx.context.Naming;
+import org.jinx.context.ProcessingContext;
+import org.jinx.model.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.lang.model.element.*;
+import javax.lang.model.type.DeclaredType;
+import javax.tools.Diagnostic;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RelationshipHandlerTest {
+
+    @Mock private ProcessingContext context;
+    @Mock private SchemaModel schemaModel;
+    @Mock private Naming namingStrategy;
+    @Mock private javax.annotation.processing.Messager messager;
+
+    private RelationshipHandler handler;
+    private EntityModel ownerEntity;
+    private EntityModel targetEntity;
+    private Map<String, EntityModel> entities;
+
+    @BeforeEach
+    void setUp() {
+        handler = new RelationshipHandler(context);
+
+        // 기본 엔티티 모델 설정
+        ownerEntity = EntityModel.builder()
+                .entityName("Owner")
+                .tableName("owner_table")
+                .build();
+
+        targetEntity = EntityModel.builder()
+                .entityName("Target")
+                .tableName("target_table")
+                .build();
+
+        entities = new HashMap<>();
+        entities.put("com.example.Owner", ownerEntity);
+        entities.put("com.example.Target", targetEntity);
+
+        lenient().when(context.getSchemaModel()).thenReturn(schemaModel);
+        lenient().when(schemaModel.getEntities()).thenReturn(entities);
+        lenient().when(context.getNaming()).thenReturn(namingStrategy);
+        lenient().when(context.getMessager()).thenReturn(messager);
+
+        // 기본 네이밍 전략 설정
+        lenient().when(namingStrategy.foreignKeyColumnName(anyString(), anyString()))
+                .thenAnswer(inv -> inv.getArgument(0) + "_" + inv.getArgument(1));
+        lenient().when(namingStrategy.joinTableName(anyString(), anyString()))
+                .thenAnswer(inv -> inv.getArgument(0) + "_" + inv.getArgument(1));
+        lenient().when(namingStrategy.fkName(anyString(), any(List.class), anyString(), any(List.class)))
+                .thenAnswer(inv -> "fk_" + inv.getArgument(0) + "_" + inv.getArgument(2));
+    }
+
+    @Test
+    void testManyToOneRelationship_SimplePrimaryKey() {
+        // Given
+        // 1. Owner TypeElement 모킹
+        TypeElement ownerTypeElement = mockTypeElement("com.example.Owner");
+
+        // 2. Field(VariableElement) 및 그 이름 모킹
+        VariableElement field = mockField("targetField");
+        Name fieldName = mock(Name.class);
+        when(fieldName.toString()).thenReturn("targetField");
+        when(field.getSimpleName()).thenReturn(fieldName); // <<-- [FIX #2] getSimpleName() 모킹
+
+        // 3. Owner가 해당 필드를 포함하도록 설정
+        doReturn(List.of(field)).when(ownerTypeElement).getEnclosedElements();
+
+        mockManyToOneAnnotation(field, true); // optional = true
+
+        // 타겟 엔티티에 단일 PK 설정
+        ColumnModel targetPk = ColumnModel.builder()
+                .columnName("id")
+                .javaType("Long")
+                .isPrimaryKey(true)
+                .build();
+        targetEntity.getColumns().put("id", targetPk);
+
+        when(context.findAllPrimaryKeyColumns(targetEntity))
+                .thenReturn(List.of(targetPk));
+
+        TypeElement targetTypeElement = mockTypeElement("com.example.Target");
+        mockFieldType(field, targetTypeElement);
+
+        // When
+        handler.resolveRelationships(ownerTypeElement, ownerEntity); // 수정된 ownerTypeElement 사용
+
+        // Then
+        // FK 컬럼이 소유 엔티티에 추가되었는지 확인
+        String expectedFkName = "targetField_id";
+        assertTrue(ownerEntity.getColumns().containsKey(expectedFkName),
+                "FK column '" + expectedFkName + "' should exist in ownerEntity");
+        ColumnModel fkColumn = ownerEntity.getColumns().get(expectedFkName);
+        assertEquals("Long", fkColumn.getJavaType());
+        assertFalse(fkColumn.isPrimaryKey());
+        assertTrue(fkColumn.isNullable()); // optional = true
+
+        // 관계 모델이 추가되었는지 확인
+        assertEquals(1, ownerEntity.getRelationships().size());
+        RelationshipModel relationship = ownerEntity.getRelationships().values().iterator().next();
+        assertEquals(RelationshipType.MANY_TO_ONE, relationship.getType());
+        assertEquals(List.of(expectedFkName), relationship.getColumns());
+        assertEquals("target_table", relationship.getReferencedTable());
+        assertEquals(List.of("id"), relationship.getReferencedColumns());
+    }
+
+    @Test
+    void testManyToOneRelationship_CompositePrimaryKey_WithJoinColumns() {
+        // Given
+        VariableElement field = mockField("targetField");
+        TypeElement ownerTypeElement = mockOwnerTypeElement(field);
+        mockManyToOneAnnotation(field, false); // optional = false
+
+        // 타겟 엔티티에 복합 PK 설정
+        ColumnModel targetPk1 = ColumnModel.builder()
+                .columnName("id1")
+                .javaType("Long")
+                .isPrimaryKey(true)
+                .build();
+        ColumnModel targetPk2 = ColumnModel.builder()
+                .columnName("id2")
+                .javaType("String")
+                .isPrimaryKey(true)
+                .build();
+        targetEntity.getColumns().put("id1", targetPk1);
+        targetEntity.getColumns().put("id2", targetPk2);
+
+        when(context.findAllPrimaryKeyColumns(targetEntity))
+                .thenReturn(List.of(targetPk1, targetPk2));
+
+        // @JoinColumns 설정
+        JoinColumns joinColumnsAnno = mockJoinColumnsAnnotation(field,
+                new String[]{"fk_id1", "fk_id2"},
+                new String[]{"id1", "id2"});
+
+        TypeElement targetTypeElement = mockTypeElement("com.example.Target");
+        mockFieldType(field, targetTypeElement);
+
+        // When
+        handler.resolveRelationships(ownerTypeElement, ownerEntity);
+
+        // Then
+        // 두 개의 FK 컬럼이 추가되었는지 확인
+        assertTrue(ownerEntity.getColumns().containsKey("fk_id1"));
+        assertTrue(ownerEntity.getColumns().containsKey("fk_id2"));
+
+        ColumnModel fk1 = ownerEntity.getColumns().get("fk_id1");
+        ColumnModel fk2 = ownerEntity.getColumns().get("fk_id2");
+
+        assertEquals("Long", fk1.getJavaType());
+        assertEquals("String", fk2.getJavaType());
+        assertFalse(fk1.isNullable()); // optional = false
+        assertFalse(fk2.isNullable());
+
+        // 관계 모델 확인
+        assertEquals(1, ownerEntity.getRelationships().size());
+        RelationshipModel relationship = ownerEntity.getRelationships().values().iterator().next();
+        assertEquals(List.of("fk_id1", "fk_id2"), relationship.getColumns());
+        assertEquals(List.of("id1", "id2"), relationship.getReferencedColumns());
+    }
+
+    @Test
+    void testManyToOneRelationship_CompositePrimaryKey_NoJoinColumns_ShouldFail() {
+        // Given
+        VariableElement field = mockField("targetField");
+        TypeElement ownerTypeElement = mockOwnerTypeElement(field);
+        mockManyToOneAnnotation(field, true);
+
+        // 타겟 엔티티에 복합 PK 설정하지만 @JoinColumns 없음
+        ColumnModel targetPk1 = ColumnModel.builder()
+                .columnName("id1")
+                .javaType("Long")
+                .isPrimaryKey(true)
+                .build();
+        ColumnModel targetPk2 = ColumnModel.builder()
+                .columnName("id2")
+                .javaType("String")
+                .isPrimaryKey(true)
+                .build();
+        targetEntity.getColumns().put("id1", targetPk1);
+        targetEntity.getColumns().put("id2", targetPk2);
+
+        when(context.findAllPrimaryKeyColumns(targetEntity))
+                .thenReturn(List.of(targetPk1, targetPk2));
+
+        TypeElement targetTypeElement = mockTypeElement("com.example.Target");
+        mockFieldType(field, targetTypeElement);
+
+        // When
+        handler.resolveRelationships(ownerTypeElement, ownerEntity);
+
+        // Then
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("Composite primary key on Target requires explicit @JoinColumns"), eq(field));
+
+        // FK 컬럼이 추가되지 않았는지 확인
+        assertTrue(ownerEntity.getColumns().isEmpty());
+        assertTrue(ownerEntity.getRelationships().isEmpty());
+    }
+
+    @Test
+    void testManyToOneRelationship_WithMapsId() {
+        // Given
+        VariableElement field = mockField("targetField");
+        TypeElement ownerTypeElement = mockOwnerTypeElement(field);
+
+        // @MapsId 설정
+        MapsId mapsId = mock(MapsId.class);
+        when(mapsId.value()).thenReturn(""); // 전체 ID 공유
+        when(field.getAnnotation(MapsId.class)).thenReturn(mapsId);
+        when(field.getAnnotation(ManyToOne.class)).thenReturn(mock(ManyToOne.class));
+        when(field.getAnnotation(OneToOne.class)).thenReturn(null);
+        when(field.getAnnotation(OneToMany.class)).thenReturn(null);
+        when(field.getAnnotation(ManyToMany.class)).thenReturn(null);
+        when(field.getAnnotation(JoinColumns.class)).thenReturn(null);
+        when(field.getAnnotation(JoinColumn.class)).thenReturn(null);
+
+        // 타겟 엔티티 PK 설정
+        ColumnModel targetPk = ColumnModel.builder()
+                .columnName("id")
+                .javaType("Long")
+                .isPrimaryKey(true)
+                .build();
+        targetEntity.getColumns().put("id", targetPk);
+
+        when(context.findAllPrimaryKeyColumns(targetEntity))
+                .thenReturn(List.of(targetPk));
+
+        TypeElement targetTypeElement = mockTypeElement("com.example.Target");
+        mockFieldType(field, targetTypeElement);
+
+        // When
+        handler.resolveRelationships(ownerTypeElement, ownerEntity);
+
+        // Then
+        // FK 컬럼이 PK로 승격되었는지 확인
+        String expectedFkName = "targetField_id";
+        assertTrue(ownerEntity.getColumns().containsKey(expectedFkName));
+        ColumnModel fkColumn = ownerEntity.getColumns().get(expectedFkName);
+        assertTrue(fkColumn.isPrimaryKey());
+        assertFalse(fkColumn.isNullable());
+
+        // 관계에서 mapsId 플래그 확인
+        RelationshipModel relationship = ownerEntity.getRelationships().values().iterator().next();
+        assertTrue(relationship.isMapsId());
+    }
+
+    @Test
+    void testOneToManyRelationship_ForeignKey() {
+        // Given
+        VariableElement field = mockField("targetList");
+        TypeElement ownerTypeElement = mockOwnerTypeElement(field);
+        mockOneToManyAnnotation(field);
+        mockJoinColumnAnnotation(field, "owner_id", "id", true);
+        mockCollectionFieldType(field, "com.example.Target");
+
+        // 소유 엔티티 PK 설정
+        ColumnModel ownerPk = ColumnModel.builder()
+                .columnName("id")
+                .javaType("Long")
+                .isPrimaryKey(true)
+                .build();
+        ownerEntity.getColumns().put("id", ownerPk);
+
+        when(context.findAllPrimaryKeyColumns(ownerEntity))
+                .thenReturn(List.of(ownerPk));
+
+        // 타겟 엔티티 설정 (Collection<Target>의 Target)
+        mockCollectionFieldType(field, "com.example.Target");
+
+        // When
+        handler.resolveRelationships(ownerTypeElement, ownerEntity);
+
+        // Then
+        // 타겟 엔티티에 FK 컬럼이 추가되었는지 확인
+        assertTrue(targetEntity.getColumns().containsKey("owner_id"));
+        ColumnModel fkColumn = targetEntity.getColumns().get("owner_id");
+        assertEquals("Long", fkColumn.getJavaType());
+        assertFalse(fkColumn.isPrimaryKey());
+        assertTrue(fkColumn.isNullable());
+
+        // 타겟 엔티티에 관계가 추가되었는지 확인
+        assertEquals(1, targetEntity.getRelationships().size());
+        RelationshipModel relationship = targetEntity.getRelationships().values().iterator().next();
+        assertEquals(RelationshipType.ONE_TO_MANY, relationship.getType());
+        assertEquals(List.of("owner_id"), relationship.getColumns());
+        assertEquals("owner_table", relationship.getReferencedTable());
+        assertEquals(List.of("id"), relationship.getReferencedColumns());
+    }
+
+    @Test
+    void testOneToManyRelationship_JoinTable() {
+        // Given
+        VariableElement field = mockField("targetList");
+        TypeElement ownerTypeElement = mockOwnerTypeElement(field);
+        mockCollectionFieldType(field, "com.example.Target");
+        mockOneToManyAnnotation(field);
+        mockJoinTableAnnotation(field, "owner_target_join",
+                new String[]{"owner_id"}, new String[]{"target_id"});
+
+        // 소유 및 타겟 엔티티 PK 설정
+        setupSinglePrimaryKeys();
+
+        // When
+        handler.resolveRelationships(ownerTypeElement, ownerEntity);
+
+        // Then
+        // 조인 테이블이 생성되었는지 확인
+        assertTrue(entities.containsKey("owner_target_join"));
+        EntityModel joinTable = entities.get("owner_target_join");
+        assertEquals(EntityModel.TableType.JOIN_TABLE, joinTable.getTableType());
+
+        // 조인 테이블에 FK 컬럼들이 PK로 추가되었는지 확인
+        assertTrue(joinTable.getColumns().containsKey("owner_id"));
+        assertTrue(joinTable.getColumns().containsKey("target_id"));
+
+        ColumnModel ownerFk = joinTable.getColumns().get("owner_id");
+        ColumnModel targetFk = joinTable.getColumns().get("target_id");
+
+        assertTrue(ownerFk.isPrimaryKey());
+        assertTrue(targetFk.isPrimaryKey());
+        assertFalse(ownerFk.isNullable());
+        assertFalse(targetFk.isNullable());
+
+        // 조인 테이블에 두 개의 FK 관계가 있는지 확인
+        assertEquals(2, joinTable.getRelationships().size());
+    }
+
+    @Test
+    void testOneToManyRelationship_JoinTableAndJoinColumn_ShouldFail() {
+        // Given
+        VariableElement field = mockField("targetList");
+        TypeElement ownerTypeElement = mockOwnerTypeElement(field);
+        mockOneToManyAnnotation(field);
+        when(field.getAnnotation(JoinTable.class)).thenReturn(mock(JoinTable.class));
+        when(field.getAnnotation(JoinColumn.class)).thenReturn(mock(JoinColumn.class));
+        OneToMany oneToMany = mock(OneToMany.class);
+        when(field.getAnnotation(OneToMany.class)).thenReturn(oneToMany);
+        when(oneToMany.mappedBy()).thenReturn("");
+
+        ColumnModel ownerPk = ColumnModel.builder()
+                .columnName("owner_id")
+                .javaType("Long")
+                .isPrimaryKey(true)
+                .build();
+        ownerEntity.getColumns().put("owner_id", ownerPk);
+
+        assertNotNull(field.getAnnotation(jakarta.persistence.JoinTable.class));
+        assertNotNull(field.getAnnotation(jakarta.persistence.JoinColumn.class));
+        assertNotNull(field.getAnnotation(jakarta.persistence.OneToMany.class));
+
+        lenient().when(context.findAllPrimaryKeyColumns(ownerEntity))
+                .thenReturn(List.of(ownerPk));
+
+        mockCollectionFieldType(field, "com.example.Target");
+
+        // When
+        handler.resolveRelationships(ownerTypeElement, ownerEntity);
+
+        // Then
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("@OneToMany에 @JoinTable과 @JoinColumn(s)를 함께 사용할 수 없습니다"),
+                eq(field));
+    }
+
+    @Test
+    void testOneToMany_FK_NoOwnerPk_ShouldError() {
+        VariableElement field = mockField("targetList");
+        TypeElement ownerTypeElement = mockOwnerTypeElement(field);
+        mockOneToManyAnnotation(field);
+        mockJoinColumnAnnotation(field, "fk_col", "ref_col", true);
+        mockCollectionFieldType(field, "com.example.Target");
+
+        // owner PK 모킹 안 함 → empty
+        when(context.findAllPrimaryKeyColumns(ownerEntity)).thenReturn(List.of());
+
+        handler.resolveRelationships(ownerTypeElement, ownerEntity);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                eq("Entity " + ownerEntity.getEntityName() + " must have a primary key for @OneToMany relationship."),
+                eq(field));
+    }
+
+
+    @Test
+    void testManyToManyRelationship() {
+        // Given
+        VariableElement field = mockField("targetList");
+        TypeElement ownerTypeElement = mockOwnerTypeElement(field);
+        mockManyToManyAnnotation(field);
+        mockJoinTableAnnotation(field, "owner_target",
+                new String[]{"owner_id"}, new String[]{"target_id"});
+
+        setupSinglePrimaryKeys();
+        mockCollectionFieldType(field, "com.example.Target");
+
+        // When
+        handler.resolveRelationships(ownerTypeElement, ownerEntity);
+
+        // Then
+        // 조인 테이블 생성 확인
+        assertTrue(entities.containsKey("owner_target"));
+        EntityModel joinTable = entities.get("owner_target");
+
+        // PK 컬럼들 확인
+        assertTrue(joinTable.getColumns().containsKey("owner_id"));
+        assertTrue(joinTable.getColumns().containsKey("target_id"));
+
+        ColumnModel ownerFk = joinTable.getColumns().get("owner_id");
+        ColumnModel targetFk = joinTable.getColumns().get("target_id");
+
+        assertTrue(ownerFk.isPrimaryKey());
+        assertTrue(targetFk.isPrimaryKey());
+        assertEquals("Long", ownerFk.getJavaType());
+        assertEquals("Long", targetFk.getJavaType());
+
+        // FK 관계들 확인
+        assertEquals(2, joinTable.getRelationships().size());
+
+        List<RelationshipModel> relationships = new ArrayList<>(joinTable.getRelationships().values());
+        boolean hasOwnerRelation = relationships.stream()
+                .anyMatch(r -> r.getReferencedTable().equals("owner_table"));
+        boolean hasTargetRelation = relationships.stream()
+                .anyMatch(r -> r.getReferencedTable().equals("target_table"));
+
+        assertTrue(hasOwnerRelation);
+        assertTrue(hasTargetRelation);
+    }
+
+    @Test
+    void testManyToManyRelationship_DuplicateJoinTable_ShouldNotCreateTwice() {
+        // Given
+        VariableElement field1 = mockField("targets1");
+        VariableElement field2 = mockField("targets2");
+
+        mockManyToManyAnnotation(field1);
+        mockManyToManyAnnotation(field2);
+
+        // 같은 이름의 조인 테이블
+        mockJoinTableAnnotation(field1, "same_join_table", new String[]{"owner_id"}, new String[]{"target_id"});
+        mockJoinTableAnnotation(field2, "same_join_table", new String[]{"owner_id"}, new String[]{"target_id"});
+
+        setupSinglePrimaryKeys();
+        mockCollectionFieldType(field1, "com.example.Target");
+        mockCollectionFieldType(field2, "com.example.Target");
+
+        // 두 필드를 가진 TypeElement 모킹
+        TypeElement ownerTypeElement = mock(TypeElement.class);
+        doReturn(List.of(field1, field2)).when(ownerTypeElement).getEnclosedElements();
+
+        // When
+        handler.resolveRelationships(ownerTypeElement, ownerEntity);
+
+        // Then
+        // 조인 테이블이 한 번만 생성되었는지 확인
+        assertTrue(entities.containsKey("same_join_table"));
+
+        // putIfAbsent 호출 확인 (두 번째 호출에서는 추가되지 않음)
+        verify(schemaModel, atLeast(1)).getEntities();
+    }
+
+    @Test
+    void testTypeConflict_ShouldReportError() {
+        // Given
+        VariableElement field = mockField("targetField");
+        TypeElement ownerTypeElement = mockOwnerTypeElement(field);
+        mockManyToOneAnnotation(field, true);
+
+        String expectedFkName = "targetField_id";
+
+        // 기존에 다른 타입의 컬럼이 있는 상황
+        ColumnModel existingColumn = ColumnModel.builder()
+                .columnName(expectedFkName)
+                .javaType("String") // 충돌: Long이 와야 하는데 String
+                .build();
+        ownerEntity.getColumns().put(expectedFkName, existingColumn);
+
+        // 타겟 엔티티 PK는 Long 타입
+        ColumnModel targetPk = ColumnModel.builder()
+                .columnName("id")
+                .javaType("Long")
+                .isPrimaryKey(true)
+                .build();
+        targetEntity.getColumns().put("id", targetPk);
+
+        when(context.findAllPrimaryKeyColumns(targetEntity))
+                .thenReturn(List.of(targetPk));
+
+        TypeElement targetTypeElement = mockTypeElement("com.example.Target");
+        mockFieldType(field, targetTypeElement);
+
+        // When
+        handler.resolveRelationships(ownerTypeElement, ownerEntity);
+
+        // Then
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("Type mismatch for column '" + expectedFkName + "'"), eq(field));
+    }
+
+    @Test
+    void testMissingPrimaryKey_ShouldReportError() {
+        // Given
+        VariableElement field = mockField("targetField");
+        TypeElement ownerTypeElement = mockOwnerTypeElement(field);
+        mockManyToOneAnnotation(field, true);
+
+        // 타겟 엔티티에 PK가 없는 상황
+        when(context.findAllPrimaryKeyColumns(targetEntity))
+                .thenReturn(Collections.emptyList());
+
+        TypeElement targetTypeElement = mockTypeElement("com.example.Target");
+        mockFieldType(field, targetTypeElement);
+
+        // When
+        handler.resolveRelationships(ownerTypeElement, ownerEntity);
+
+        // Then
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("Entity Target must have a primary key to be referenced"), eq(field));
+    }
+
+    // Helper Methods
+    private void setupSinglePrimaryKeys() {
+        ColumnModel ownerPk = ColumnModel.builder()
+                .columnName("id")
+                .javaType("Long")
+                .isPrimaryKey(true)
+                .build();
+        ColumnModel targetPk = ColumnModel.builder()
+                .columnName("id")
+                .javaType("Long")
+                .isPrimaryKey(true)
+                .build();
+
+        ownerEntity.getColumns().put("id", ownerPk);
+        targetEntity.getColumns().put("id", targetPk);
+
+        lenient().when(context.findAllPrimaryKeyColumns(ownerEntity))
+                .thenReturn(List.of(ownerPk));
+        when(context.findAllPrimaryKeyColumns(targetEntity))
+                .thenReturn(List.of(targetPk));
+    }
+
+    @Test
+    void testFieldWithTransient_ShouldBeIgnored() {
+        // Given
+        // @Transient 애노테이션을 가진 필드 모킹
+        VariableElement transientField = mockField("transientField");
+        when(transientField.getAnnotation(Transient.class)).thenReturn(mock(Transient.class));
+
+        // 다른 정상적인 필드도
+        VariableElement normalField = mockField("targetField");
+        mockManyToOneAnnotation(normalField, true);
+        mockFieldType(normalField, mockTypeElement("com.example.Target"));
+        setupSinglePrimaryKeys(); // targetEntity에 PK 설정
+
+        TypeElement ownerTypeElement = mockOwnerTypeElement(transientField, normalField);
+
+        // When
+        handler.resolveRelationships(ownerTypeElement, ownerEntity);
+
+        // Then
+        assertTrue(ownerEntity.getColumns().containsKey("targetField_id"));
+        assertEquals(1, ownerEntity.getRelationships().size());
+
+        // transientField에 대해서는 아무 작업도 일어나지 않았음을 확인
+    }
+
+    @Test
+    void testBidirectionalOneToMany_ShouldBeIgnored() {
+        // Given
+        VariableElement mappedByField = mockField("ownerField");
+
+        // mappedBy 속성에 값이 있는 @OneToMany 애노테이션을 모킹
+        OneToMany oneToMany = mock(OneToMany.class);
+        when(oneToMany.mappedBy()).thenReturn("owner"); // 양방향 관계 설정
+        when(mappedByField.getAnnotation(OneToMany.class)).thenReturn(oneToMany);
+        when(mappedByField.getAnnotation(ManyToOne.class)).thenReturn(null);
+        when(mappedByField.getAnnotation(OneToOne.class)).thenReturn(null);
+        when(mappedByField.getAnnotation(ManyToMany.class)).thenReturn(null);
+
+        TypeElement ownerTypeElement = mockOwnerTypeElement(mappedByField);
+
+        // When
+        handler.resolveRelationships(ownerTypeElement, ownerEntity);
+
+        // Then
+        // mappedBy 필드는 무시되어야 하므로, 어떤 컬럼이나 관계도 추가되지 않아야 함
+        assertTrue(ownerEntity.getColumns().isEmpty());
+        assertTrue(ownerEntity.getRelationships().isEmpty());
+    }
+
+    @Test
+    void testManyToOne_WithMapsId_WithValue() {
+        // Given
+        VariableElement field = mockField("childPk");
+        TypeElement ownerTypeElement = mockOwnerTypeElement(field);
+        mockManyToOneAnnotation(field, false);
+
+        // @MapsId("id1") 설정. Child의 PK 일부가 Parent의 PK 일부와 매핑됨을 의미
+        MapsId mapsId = mock(MapsId.class);
+        when(mapsId.value()).thenReturn("id1");
+        when(field.getAnnotation(MapsId.class)).thenReturn(mapsId);
+
+        // 참조되는 엔티티는 복합 키를 가짐
+        ColumnModel targetPk1 = ColumnModel.builder().columnName("id1").javaType("Long").isPrimaryKey(true).build();
+        ColumnModel targetPk2 = ColumnModel.builder().columnName("id2").javaType("String").isPrimaryKey(true).build();
+        targetEntity.getColumns().put("id1", targetPk1);
+        targetEntity.getColumns().put("id2", targetPk2);
+        when(context.findAllPrimaryKeyColumns(targetEntity)).thenReturn(List.of(targetPk1, targetPk2));
+
+        // @JoinColumns로 명시적 매핑
+        mockJoinColumnsAnnotation(field, new String[]{"parent_id1", "parent_id2"}, new String[]{"id1", "id2"});
+        mockFieldType(field, mockTypeElement("com.example.Target"));
+
+        // When
+        handler.resolveRelationships(ownerTypeElement, ownerEntity);
+
+        // Then
+        // @MapsId("id1")에 의해 id1을 참조하는 FK(parent_id1)는 PK로 승격
+        ColumnModel fk1 = ownerEntity.getColumns().get("parent_id1");
+        assertTrue(fk1.isPrimaryKey());
+        assertFalse(fk1.isNullable());
+
+        // @MapsId와 관련 없는 다른 FK(parent_id2)는 일반 컬럼
+        ColumnModel fk2 = ownerEntity.getColumns().get("parent_id2");
+        assertFalse(fk2.isPrimaryKey());
+    }
+
+    @Test
+    void testManyToMany_WithDefaultJoinTableColumnNames() {
+        // Given
+        VariableElement field = mockField("targets");
+        TypeElement ownerTypeElement = mockOwnerTypeElement(field);
+        setupSinglePrimaryKeys(); // owner, target에 'id'라는 PK 설정
+
+        // joinColumns/inverseJoinColumns가 비어있는 @JoinTable 모킹
+        JoinTable joinTable = mock(JoinTable.class);
+        when(joinTable.name()).thenReturn("default_join_table");
+        when(joinTable.joinColumns()).thenReturn(new JoinColumn[0]); // 비어있음
+        when(joinTable.inverseJoinColumns()).thenReturn(new JoinColumn[0]); // 비어있음
+        when(field.getAnnotation(JoinTable.class)).thenReturn(joinTable);
+
+        mockManyToManyAnnotation(field);
+        mockCollectionFieldType(field, "com.example.Target");
+
+        // 기본 네이밍 전략 모킹 (setUp에서 이미 설정했지만 명확성을 위해 재확인)
+        when(namingStrategy.foreignKeyColumnName("owner_table", "id")).thenReturn("owner_fk");
+        when(namingStrategy.foreignKeyColumnName("target_table", "id")).thenReturn("target_fk");
+
+        // When
+        handler.resolveRelationships(ownerTypeElement, ownerEntity);
+
+        // Then
+        assertTrue(entities.containsKey("default_join_table"));
+        EntityModel joinTableEntity = entities.get("default_join_table");
+
+        // 네이밍 전략에 따라 기본 이름으로 컬럼이 생성되었는지 확인
+        assertTrue(joinTableEntity.getColumns().containsKey("owner_fk"));
+        assertTrue(joinTableEntity.getColumns().containsKey("target_fk"));
+    }
+
+    @Test
+    void testOneToMany_FK_JoinColumnsSizeMismatch_ShouldFail() {
+        // Given
+        VariableElement field = mockField("targets");
+        TypeElement ownerTypeElement = mockOwnerTypeElement(field);
+        mockOneToManyAnnotation(field);
+
+        // Owner 복합 PK 2개
+        ColumnModel ownerPk1 = ColumnModel.builder().columnName("id1").javaType("Long").isPrimaryKey(true).build();
+        ColumnModel ownerPk2 = ColumnModel.builder().columnName("id2").javaType("Long").isPrimaryKey(true).build();
+        ownerEntity.getColumns().put("id1", ownerPk1);
+        ownerEntity.getColumns().put("id2", ownerPk2);
+        when(context.findAllPrimaryKeyColumns(ownerEntity)).thenReturn(List.of(ownerPk1, ownerPk2));
+        when(field.getAnnotation(JoinTable.class)).thenReturn(null);
+        when(field.getAnnotation(JoinColumn.class)).thenReturn(null);
+        when(field.getAnnotation(JoinColumns.class)).thenReturn(null);
+
+        // hasJoinColumn=true를 만들기 위해 @JoinColumns 1개만 제공 → 불일치 유도
+        mockJoinColumnsAnnotation(field, new String[]{"fk_id1"}, new String[]{"id1"});
+
+        mockCollectionFieldType(field, "com.example.Target");
+
+        // When
+        handler.resolveRelationships(ownerTypeElement, ownerEntity);
+
+        // Then
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("@JoinColumns size mismatch"), eq(field));
+    }
+
+    @Test
+    void testOneToMany_FK_ImplicitFkTypeMismatch_ShouldReportError() {
+        // Given
+        VariableElement field = mockField("targets");
+        TypeElement ownerTypeElement = mockOwnerTypeElement(field);
+        mockOneToManyAnnotation(field);
+
+        // hasJoinColumn=true (하지만 name/referencedColumnName은 비워 기본 네이밍을 쓰게)
+        mockJoinColumnAnnotation(field, "", "", true);
+
+        // Owner PK (Long)
+        ColumnModel ownerPk = ColumnModel.builder().columnName("id").javaType("Long").isPrimaryKey(true).build();
+        ownerEntity.getColumns().put("id", ownerPk);
+        when(context.findAllPrimaryKeyColumns(ownerEntity)).thenReturn(List.of(ownerPk));
+
+        // 기본 네이밍: owner_table_id
+        when(namingStrategy.foreignKeyColumnName(ownerEntity.getTableName(), "id")).thenReturn("owner_table_id");
+
+        // Target에 동일 이름의 컬럼이 이미 있는데 타입은 String → 타입 충돌 기대
+        targetEntity.getColumns().put("owner_table_id",
+                ColumnModel.builder().columnName("owner_table_id").javaType("String").build());
+
+        mockCollectionFieldType(field, "com.example.Target");
+
+        // When
+        handler.resolveRelationships(ownerTypeElement, ownerEntity);
+
+        // Then
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("Type mismatch for implicit foreign key column 'owner_table_id'"), eq(field));
+    }
+
+    @Test
+    void testOneToMany_JoinTable_OwnerJoinColumnsSizeMismatch_ShouldFail() {
+        // Given
+        VariableElement field = mockField("targets");
+        TypeElement ownerTypeElement = mockOwnerTypeElement(field);
+        mockOneToManyAnnotation(field);
+
+        // JoinTable에 owner측 1개만, target측 1개 제공
+        mockJoinTableAnnotation(field, "jt_owner_mismatch",
+                new String[]{"owner_id"}, new String[]{"target_id"});
+
+        // Owner는 복합 PK 2개 → 불일치 유발
+        ColumnModel ownerPk1 = ColumnModel.builder().columnName("id1").javaType("Long").isPrimaryKey(true).build();
+        ColumnModel ownerPk2 = ColumnModel.builder().columnName("id2").javaType("Long").isPrimaryKey(true).build();
+        ownerEntity.getColumns().put("id1", ownerPk1);
+        ownerEntity.getColumns().put("id2", ownerPk2);
+        when(context.findAllPrimaryKeyColumns(ownerEntity)).thenReturn(List.of(ownerPk1, ownerPk2));
+
+        // Target은 단일 PK
+        ColumnModel targetPk = ColumnModel.builder().columnName("id").javaType("Long").isPrimaryKey(true).build();
+        targetEntity.getColumns().put("id", targetPk);
+        when(context.findAllPrimaryKeyColumns(targetEntity)).thenReturn(List.of(targetPk));
+
+        mockCollectionFieldType(field, "com.example.Target");
+
+        // When
+        handler.resolveRelationships(ownerTypeElement, ownerEntity);
+
+        // Then
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("JoinTable.joinColumns 개수가 Owner PK 개수와 일치해야 합니다"), eq(field));
+    }
+
+    @Test
+    void testOneToMany_JoinTable_InverseJoinColumnsSizeMismatch_ShouldFail() {
+        // Given
+        VariableElement field = mockField("targets");
+        TypeElement ownerTypeElement = mockOwnerTypeElement(field);
+        mockOneToManyAnnotation(field);
+
+        // JoinTable에 owner측 1개, target측 1개만 제공 → target 복합 PK와 불일치 유발
+        mockJoinTableAnnotation(field, "jt_target_mismatch",
+                new String[]{"owner_id"}, new String[]{"target_id"});
+
+        // Owner 단일 PK
+        ColumnModel ownerPk = ColumnModel.builder().columnName("id").javaType("Long").isPrimaryKey(true).build();
+        ownerEntity.getColumns().put("id", ownerPk);
+        when(context.findAllPrimaryKeyColumns(ownerEntity)).thenReturn(List.of(ownerPk));
+
+        // Target 복합 PK 2개
+        ColumnModel targetPk1 = ColumnModel.builder().columnName("id1").javaType("Long").isPrimaryKey(true).build();
+        ColumnModel targetPk2 = ColumnModel.builder().columnName("id2").javaType("Long").isPrimaryKey(true).build();
+        targetEntity.getColumns().put("id1", targetPk1);
+        targetEntity.getColumns().put("id2", targetPk2);
+        when(context.findAllPrimaryKeyColumns(targetEntity)).thenReturn(List.of(targetPk1, targetPk2));
+
+        mockCollectionFieldType(field, "com.example.Target");
+
+        // When
+        handler.resolveRelationships(ownerTypeElement, ownerEntity);
+
+        // Then
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("JoinTable.inverseJoinColumns 개수가 Target PK 개수와 일치해야 합니다"), eq(field));
+    }
+
+    @Test
+    void testManyToMany_OwnerJoinColumnsSizeMismatch_ShouldFail() {
+        // Given
+        VariableElement field = mockField("targets");
+        TypeElement ownerTypeElement = mockOwnerTypeElement(field);
+        mockManyToManyAnnotation(field);
+
+        // JoinTable에 owner측 1개만, target측 1개 제공
+        mockJoinTableAnnotation(field, "mtm_owner_mismatch",
+                new String[]{"owner_id"}, new String[]{"target_id"});
+
+        // Owner 복합 PK 2개 → 불일치
+        ColumnModel ownerPk1 = ColumnModel.builder().columnName("id1").javaType("Long").isPrimaryKey(true).build();
+        ColumnModel ownerPk2 = ColumnModel.builder().columnName("id2").javaType("Long").isPrimaryKey(true).build();
+        ownerEntity.getColumns().put("id1", ownerPk1);
+        ownerEntity.getColumns().put("id2", ownerPk2);
+        when(context.findAllPrimaryKeyColumns(ownerEntity)).thenReturn(List.of(ownerPk1, ownerPk2));
+
+        // Target 단일 PK
+        ColumnModel targetPk = ColumnModel.builder().columnName("id").javaType("Long").isPrimaryKey(true).build();
+        targetEntity.getColumns().put("id", targetPk);
+        when(context.findAllPrimaryKeyColumns(targetEntity)).thenReturn(List.of(targetPk));
+
+        mockCollectionFieldType(field, "com.example.Target");
+
+        // When
+        handler.resolveRelationships(ownerTypeElement, ownerEntity);
+
+        // Then
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("The number of @JoinColumn annotations for " + ownerEntity.getTableName()),
+                eq(field));
+    }
+
+    @Test
+    void testManyToMany_InverseJoinColumnsSizeMismatch_ShouldFail() {
+        // Given
+        VariableElement field = mockField("targets");
+        TypeElement ownerTypeElement = mockOwnerTypeElement(field);
+        mockManyToManyAnnotation(field);
+
+        // JoinTable에 owner측 1개, target측 1개만 제공 → target 복합 PK와 불일치 유발
+        mockJoinTableAnnotation(field, "mtm_target_mismatch",
+                new String[]{"owner_id"}, new String[]{"target_id"});
+
+        // Owner 단일 PK
+        ColumnModel ownerPk = ColumnModel.builder().columnName("id").javaType("Long").isPrimaryKey(true).build();
+        ownerEntity.getColumns().put("id", ownerPk);
+        when(context.findAllPrimaryKeyColumns(ownerEntity)).thenReturn(List.of(ownerPk));
+
+        // Target 복합 PK 2개
+        ColumnModel targetPk1 = ColumnModel.builder().columnName("id1").javaType("Long").isPrimaryKey(true).build();
+        ColumnModel targetPk2 = ColumnModel.builder().columnName("id2").javaType("Long").isPrimaryKey(true).build();
+        targetEntity.getColumns().put("id1", targetPk1);
+        targetEntity.getColumns().put("id2", targetPk2);
+        when(context.findAllPrimaryKeyColumns(targetEntity)).thenReturn(List.of(targetPk1, targetPk2));
+
+        mockCollectionFieldType(field, "com.example.Target");
+
+        // When
+        handler.resolveRelationships(ownerTypeElement, ownerEntity);
+
+        // Then
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("The number of @InverseJoinColumn annotations for " + targetEntity.getTableName()),
+                eq(field));
+    }
+
+
+    private VariableElement mockField(String name) {
+        VariableElement field = mock(VariableElement.class);
+        Name fieldName = mock(Name.class);
+        lenient().when(fieldName.toString()).thenReturn(name);
+        lenient().when(field.getSimpleName()).thenReturn(fieldName);
+        when(field.getKind()).thenReturn(ElementKind.FIELD);
+        lenient().when(field.getModifiers()).thenReturn(Collections.emptySet());
+        when(field.getAnnotation(Transient.class)).thenReturn(null);
+        return field;
+    }
+
+    private TypeElement mockOwnerTypeElement() {
+        TypeElement typeElement = mock(TypeElement.class);
+        VariableElement field = mockField("targetField");
+        doReturn(List.of(field)).when(typeElement).getEnclosedElements();
+        return typeElement;
+    }
+
+    private TypeElement mockOwnerTypeElement(VariableElement... fields) {
+        TypeElement typeElement = mock(TypeElement.class);
+        doReturn(Arrays.asList(fields)).when(typeElement).getEnclosedElements();
+        return typeElement;
+    }
+
+    private TypeElement mockTypeElement(String qualifiedName) {
+        TypeElement typeElement = mock(TypeElement.class);
+        Name name = mock(Name.class);
+        lenient().when(name.toString()).thenReturn(qualifiedName);
+        lenient().when(typeElement.getQualifiedName()).thenReturn(name);
+        return typeElement;
+    }
+
+    private void mockFieldType(VariableElement field, TypeElement targetType) {
+        DeclaredType declaredType = mock(DeclaredType.class);
+        when(declaredType.asElement()).thenReturn(targetType);
+        when(field.asType()).thenReturn(declaredType);
+    }
+
+    private void mockCollectionFieldType(VariableElement field, String targetTypeName) {
+        DeclaredType collectionType = mock(DeclaredType.class);
+        DeclaredType targetType = mock(DeclaredType.class);
+        TypeElement targetElement = mockTypeElement(targetTypeName);
+
+        lenient().when(targetType.asElement()).thenReturn(targetElement);
+        lenient().doReturn(List.of(targetElement)).when(targetElement).getEnclosedElements();
+        DeclaredType targetGenericType = mock(DeclaredType.class);
+        lenient().when(targetGenericType.asElement()).thenReturn(targetElement);
+        lenient().doReturn(List.of(targetGenericType)).when(collectionType).getTypeArguments();
+        lenient().when(field.asType()).thenReturn(collectionType);
+    }
+
+    private void mockManyToOneAnnotation(VariableElement field, boolean optional) {
+        ManyToOne manyToOne = mock(ManyToOne.class);
+        lenient().when(manyToOne.optional()).thenReturn(optional);
+        lenient().when(manyToOne.cascade()).thenReturn(new jakarta.persistence.CascadeType[0]);
+        lenient().when(manyToOne.fetch()).thenReturn(FetchType.EAGER);
+        when(field.getAnnotation(ManyToOne.class)).thenReturn(manyToOne);
+
+        // 다른 어노테이션들은 null
+        when(field.getAnnotation(OneToOne.class)).thenReturn(null);
+        when(field.getAnnotation(OneToMany.class)).thenReturn(null);
+        when(field.getAnnotation(ManyToMany.class)).thenReturn(null);
+    }
+
+    private void mockOneToManyAnnotation(VariableElement field) {
+        OneToMany oneToMany = mock(OneToMany.class);
+        lenient().when(oneToMany.mappedBy()).thenReturn(""); // 단방향
+        lenient().when(oneToMany.cascade()).thenReturn(new jakarta.persistence.CascadeType[0]);
+        lenient().when(oneToMany.fetch()).thenReturn(FetchType.LAZY);
+        lenient().when(oneToMany.orphanRemoval()).thenReturn(false);
+        when(field.getAnnotation(OneToMany.class)).thenReturn(oneToMany);
+
+        // 다른 어노테이션들은 null
+        when(field.getAnnotation(ManyToOne.class)).thenReturn(null);
+        when(field.getAnnotation(OneToOne.class)).thenReturn(null);
+        when(field.getAnnotation(ManyToMany.class)).thenReturn(null);
+    }
+
+    private void mockManyToManyAnnotation(VariableElement field) {
+        ManyToMany manyToMany = mock(ManyToMany.class);
+        when(manyToMany.mappedBy()).thenReturn(""); // 소유측
+        lenient().when(manyToMany.cascade()).thenReturn(new jakarta.persistence.CascadeType[0]);
+        lenient().when(manyToMany.fetch()).thenReturn(FetchType.LAZY);
+        when(field.getAnnotation(ManyToMany.class)).thenReturn(manyToMany);
+
+        // 다른 어노테이션들은 null
+        when(field.getAnnotation(ManyToOne.class)).thenReturn(null);
+        when(field.getAnnotation(OneToOne.class)).thenReturn(null);
+        when(field.getAnnotation(OneToMany.class)).thenReturn(null);
+    }
+
+    private void mockJoinColumnAnnotation(VariableElement field, String name, String referencedColumnName, boolean nullable) {
+        JoinColumn joinColumn = mock(JoinColumn.class);
+        lenient().when(joinColumn.name()).thenReturn(name);
+        lenient().when(joinColumn.referencedColumnName()).thenReturn(referencedColumnName);
+        lenient().when(joinColumn.nullable()).thenReturn(nullable);
+
+        ForeignKey foreignKey = mock(ForeignKey.class);
+        lenient().when(foreignKey.name()).thenReturn("");
+        lenient().when(joinColumn.foreignKey()).thenReturn(foreignKey);
+
+        when(field.getAnnotation(JoinColumn.class)).thenReturn(joinColumn);
+        when(field.getAnnotation(JoinColumns.class)).thenReturn(null);
+        lenient().when(field.getAnnotation(JoinTable.class)).thenReturn(null);
+    }
+
+    private JoinColumns mockJoinColumnsAnnotation(VariableElement field, String[] names, String[] referencedColumnNames) {
+        JoinColumn[] joinColumns = new JoinColumn[names.length];
+        for (int i = 0; i < names.length; i++) {
+            JoinColumn jc = mock(JoinColumn.class);
+            lenient().when(jc.name()).thenReturn(names[i]);
+            lenient().when(jc.referencedColumnName()).thenReturn(referencedColumnNames[i]);
+            lenient().when(jc.nullable()).thenReturn(true);
+
+            ForeignKey fk = mock(ForeignKey.class);
+            lenient().when(fk.name()).thenReturn("");
+            lenient().when(jc.foreignKey()).thenReturn(fk);
+
+            joinColumns[i] = jc;
+        }
+
+        JoinColumns joinColumnsAnno = mock(JoinColumns.class);
+        when(joinColumnsAnno.value()).thenReturn(joinColumns);
+        when(field.getAnnotation(JoinColumns.class)).thenReturn(joinColumnsAnno);
+        when(field.getAnnotation(JoinColumn.class)).thenReturn(null);
+
+        return joinColumnsAnno;
+    }
+
+    private void mockJoinTableAnnotation(VariableElement field, String tableName,
+                                         String[] joinColumnNames, String[] inverseJoinColumnNames) {
+        jakarta.persistence.JoinColumn[] joinColumns = new jakarta.persistence.JoinColumn[joinColumnNames.length];
+        for (int i = 0; i < joinColumnNames.length; i++) {
+            jakarta.persistence.JoinColumn jc = mock(jakarta.persistence.JoinColumn.class);
+            lenient().when(jc.name()).thenReturn(joinColumnNames[i]);
+            lenient().when(jc.referencedColumnName()).thenReturn("");
+            jakarta.persistence.ForeignKey fk = mock(jakarta.persistence.ForeignKey.class);
+            lenient().when(fk.name()).thenReturn("");
+            lenient().when(jc.foreignKey()).thenReturn(fk);
+            joinColumns[i] = jc;
+        }
+
+        jakarta.persistence.JoinColumn[] inverseJoinColumns = new jakarta.persistence.JoinColumn[inverseJoinColumnNames.length];
+        for (int i = 0; i < inverseJoinColumnNames.length; i++) {
+            jakarta.persistence.JoinColumn jc = mock(jakarta.persistence.JoinColumn.class);
+            lenient().when(jc.name()).thenReturn(inverseJoinColumnNames[i]);
+            lenient().when(jc.referencedColumnName()).thenReturn("");
+            jakarta.persistence.ForeignKey fk = mock(jakarta.persistence.ForeignKey.class);
+            lenient().when(fk.name()).thenReturn("");
+            lenient().when(jc.foreignKey()).thenReturn(fk);
+            inverseJoinColumns[i] = jc;
+        }
+
+        jakarta.persistence.JoinTable joinTable = mock(jakarta.persistence.JoinTable.class);
+        lenient().when(joinTable.name()).thenReturn(tableName);
+        lenient().when(joinTable.joinColumns()).thenReturn(joinColumns);
+        lenient().when(joinTable.inverseJoinColumns()).thenReturn(inverseJoinColumns);
+
+        lenient().when(field.getAnnotation(jakarta.persistence.JoinTable.class)).thenReturn(joinTable);
+    }
+
+
+}


### PR DESCRIPTION
## 배경

- 단방향 `@OneToMany`에서 `@JoinColumn` 유무에 따라 **FK 전략/조인 테이블 전략**이 달라져야 하나, 기존 구현은 FK 전략으로만 처리되어 스펙과 불일치.
- to-one 기본 FK 컬럼명이 `<테이블명>_<PK>`라 **동일 테이블을 여러 필드로 참조 시 컬럼명 충돌** 가능.
- `@ManyToMany` 조인테이블 생성 시 **역측 PK 타입을 owner 측으로 잘못 참조**하는 버그 존재.
- `optional=false`와 `@JoinColumn(nullable=true)` 간 **제약 상충**으로 DDL/런타임 불일치 위험.

## 변경 사항 (What)

1. **분기 도입**
    - `@OneToMany`(단방향)에서
        - `@JoinColumn(s)` 존재 → 자식(FK)
        - 미존재/`@JoinTable` 지정 → 조인테이블
        - 동시 지정 시 에러 리포팅
2. **네이밍 통일**
    - to-one FK 기본명: **`<필드명>_<참조PK>`**
3. **nullable 규칙 강화**
    - `optional=false` → **NOT NULL 강제**
    - PK/`@MapsId` FK → **항상 NOT NULL**
4. **조인테이블 생성/매핑 보강**
    - `@OneToMany` JoinTable 경로 구현(양측 FK → PK 승격)
    - `@ManyToMany` 역측 컬럼 타입 매핑 버그 수정(`referencedPks` 사용)
    - record accessor 사용 일관화, 도달 불가 분기 제거
5. **테스트 케이스 대폭 보강**
    - `@OneToMany` FK/JoinTable 정상/오류 분기
    - `@JoinTable` + `@JoinColumn(s)` 동시 지정 에러
    - 복합키 `@JoinColumns` 개수 불일치, 암묵 FK 타입 충돌
    - `@ManyToMany` owner/inverse 개수 불일치
    - `@MapsId` 전체/부분, `@Transient` 무시, 중복 조인테이블 1회 생성 보장 등

## 기대 효과 (Why)

- JPA 스펙과 일치하는 **관계 전략 선택**으로 모델-DDL 간 일관성 향상
- to-one 네이밍 충돌 제거로 **다중 참조 안전성** 확보
- nullable 정책 정합화로 **런타임/DDL 괴리 축소**
- 조인테이블 역측 타입 참조 버그 제거로 **스키마 정확도** 향상

## 호환성/마이그레이션

- **스키마 변경 가능성**
    - to-one FK 컬럼명 기본값이 `<필드명>_<PK>`로 바뀔 수 있음
    - `optional=false`인 연관의 FK 컬럼은 **NOT NULL**로 강화
- 기존 DB 스키마를 사용 중이면, 마이그레이션 시 FK 컬럼명/NULL 제약 확인 필요

## 테스트

- 단위 테스트 다수 추가/갱신 (관계 분기, 복합키, 개수 불일치, 타입 충돌, MapsId 등)
- 주요 분기/에러 메시지까지 검증하여 회귀 방지

## 참고

- Labels: `area:processor`, `type:bug`, `priority:P1`
- 변경 파일: `RelationshipHandler` 및 테스트

## 체크리스트

- [x]  단방향 `@OneToMany` 분기 동작 확인
- [x]  `@JoinTable` + `@JoinColumn(s)` 동시 지정시 에러
- [x]  to-one 기본 FK 네이밍 변경 반영
- [x]  `optional=false` → NOT NULL 강제
- [x]  `@ManyToMany` 역측 PK 타입 참조 버그 수정
- [x]  회귀 테스트 추가/통과