### PR TITLE
[P1] FK 생성 원자화(사전 검증→적용), 제네릭 가드 추가, 최종 PK 검증을 `@MapsId` 반영 이후로 이동

### DIFF
--- a/jinx-processor/src/main/java/org/jinx/handler/EntityHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/EntityHandler.java
@@ -63,15 +63,7 @@ public class EntityHandler {
         // 8. 보조 테이블 처리 및 상속 관계 처리 -> PK가 확정된 뒤에 FK 생성
         processJoinedTables(typeElement, entity);
 
-        // 9. 최종 PK 검증: JOINED/SecondaryTable 처리까지 끝난 후에도 PK가 없다면 invalid
-        if (context.findAllPrimaryKeyColumns(entity).isEmpty()) {
-            context.getMessager().printMessage(
-                    Diagnostic.Kind.ERROR,
-                    "Entity '" + entity.getEntityName() + "' must have a primary key.",
-                    typeElement
-            );
-            entity.setValid(false);
-        }
+        // @MapsId 기반 PK 승격 반영 이후(2차 패스)로 검증 시점(PK)을 지연
     }
 
     public void runDeferredJoinedFks() {

--- a/jinx-processor/src/main/java/org/jinx/handler/EntityHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/EntityHandler.java
@@ -71,10 +71,16 @@ public class EntityHandler {
         for (int i = 0; i < size; i++) {
             EntityModel child = context.getDeferredEntities().poll();
             if (child == null) break;
-            processInheritanceJoin(
-                    context.getElementUtils().getTypeElement(child.getEntityName()),
-                    child
-            );
+            if (!child.isValid()) continue;
+
+            TypeElement te = context.getElementUtils().getTypeElement(child.getEntityName());
+            if (te == null) {
+                context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                        "Deferred JOINED: cannot resolve TypeElement for " + child.getEntityName() + " – re-queue");
+                context.getDeferredEntities().offer(child);
+                continue;
+            }
+            processInheritanceJoin(te, child);
             // 부모가 여전히 없으면 processInheritanceJoin 내부에서 다시 enqueue
             // 하지만 여기서는 '이번 라운드' 스냅샷만 처리해서 무한루프 방지
         }

--- a/jinx-processor/src/main/java/org/jinx/handler/RelationshipHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/RelationshipHandler.java
@@ -141,7 +141,7 @@ public class RelationshipHandler {
                     : context.getNaming().foreignKeyColumnName(fieldName, referencedPkName);
 
             // 중복 FK 이름 검증
-            if (toAdd.containsKey(fkColumnName)) {
+            if (fkColumnNames.contains(fkColumnName) ||toAdd.containsKey(fkColumnName)) {
                 context.getMessager().printMessage(Diagnostic.Kind.ERROR,
                         "Duplicate FK column name '" + fkColumnName + "' in "
                                 + ownerEntity.getEntityName() + "." + field.getSimpleName(), field);
@@ -187,6 +187,13 @@ public class RelationshipHandler {
                                     " but existing column has type " + existing.getJavaType(), field);
                     ownerEntity.setValid(false);
                     return;
+                }
+                // 타입이 일치하면 관계 제약(@MapsId/nullable)도 기존 컬럼에 반영
+                if (makePk && !existing.isPrimaryKey()) {
+                    existing.setPrimaryKey(true);
+                }
+                if (existing.isNullable() != isNullable) {
+                    fkColumn.setNullable(isNullable);
                 }
             }
 
@@ -301,7 +308,7 @@ public class RelationshipHandler {
                     : context.getNaming().foreignKeyColumnName(ownerEntity.getTableName(), refName);
 
             // 중복 FK 이름 검증
-            if (toAdd.containsKey(fkName)) {
+            if (fkNames.contains(fkName) ||toAdd.containsKey(fkName)) {
                 context.getMessager().printMessage(Diagnostic.Kind.ERROR,
                         "Duplicate FK column name '" + fkName + "' in "
                                 + targetEntityModel.getEntityName() + "." + field.getSimpleName(), field);

--- a/jinx-processor/src/main/java/org/jinx/handler/RelationshipHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/RelationshipHandler.java
@@ -36,27 +36,23 @@ public class RelationshipHandler {
         ManyToMany manyToMany = field.getAnnotation(ManyToMany.class);
         OneToMany oneToMany = field.getAnnotation(OneToMany.class);
 
-        // @ManyToOne 또는 @OneToOne (to-one 관계)
         if (manyToOne != null || oneToOne != null) {
             processToOneRelationship(field, ownerEntity, manyToOne, oneToOne);
             return;
         }
 
-        // @OneToMany (단방향만, mappedBy 없음)
         if (oneToMany != null && oneToMany.mappedBy().isEmpty()) {
             JoinTable jt = field.getAnnotation(JoinTable.class);
             JoinColumns jcs = field.getAnnotation(JoinColumns.class);
             JoinColumn jc = field.getAnnotation(JoinColumn.class);
             boolean hasJoinColumn = (jcs != null && jcs.value().length > 0) || (jc != null);
 
-            // @JoinTable과 @JoinColumn(s) 동시 사용 검증
             if (jt != null && hasJoinColumn) {
                 context.getMessager().printMessage(Diagnostic.Kind.ERROR,
                         "@OneToMany에 @JoinTable과 @JoinColumn(s)를 함께 사용할 수 없습니다.", field);
                 return;
             }
 
-            // 분기: @JoinColumn(s) 있으면 FK 방식, 없으면 JoinTable 방식
             if (hasJoinColumn) {
                 processUnidirectionalOneToMany_FK(field, ownerEntity, oneToMany);
             } else {
@@ -65,7 +61,6 @@ public class RelationshipHandler {
             return;
         }
 
-        // @ManyToMany (소유측만, mappedBy 없음)
         if (manyToMany != null && manyToMany.mappedBy().isEmpty()) {
             processOwningManyToMany(field, ownerEntity, manyToMany);
         }
@@ -88,6 +83,7 @@ public class RelationshipHandler {
         if (refPkList.isEmpty()) {
             context.getMessager().printMessage(Diagnostic.Kind.ERROR,
                     "Entity " + referencedEntity.getEntityName() + " must have a primary key to be referenced.", field);
+            ownerEntity.setValid(false);
             return;
         }
 
@@ -105,6 +101,7 @@ public class RelationshipHandler {
             context.getMessager().printMessage(Diagnostic.Kind.ERROR,
                     "Composite primary key on " + referencedEntity.getEntityName() +
                             " requires explicit @JoinColumns on " + ownerEntity.getEntityName() + "." + field.getSimpleName(), field);
+            ownerEntity.setValid(false);
             return;
         }
 
@@ -112,15 +109,17 @@ public class RelationshipHandler {
             context.getMessager().printMessage(Diagnostic.Kind.ERROR,
                     "@JoinColumns size mismatch on " + ownerEntity.getEntityName() + "." + field.getSimpleName() +
                             ". Expected " + refPkList.size() + " (from referenced PK), but got " + joinColumns.size() + ".", field);
+            ownerEntity.setValid(false);
             return;
         }
 
+        Map<String, ColumnModel> toAdd = new LinkedHashMap<>();
         List<String> fkColumnNames = new ArrayList<>();
         List<String> referencedPkNames = new ArrayList<>();
         MapsId mapsId = field.getAnnotation(MapsId.class);
         String mapsIdAttr = (mapsId != null && !mapsId.value().isEmpty()) ? mapsId.value() : null;
 
-        // FK 컬럼 생성
+        // loop1: 사전 검증
         for (int i = 0; i < refPkList.size(); i++) {
             JoinColumn jc = joinColumns.isEmpty() ? null : joinColumns.get(i);
 
@@ -132,46 +131,53 @@ public class RelationshipHandler {
                 context.getMessager().printMessage(Diagnostic.Kind.ERROR,
                         "Attribute referencedColumnName='" + referencedPkName + "' not found in PKs of "
                                 + referencedEntity.getEntityName(), field);
+                ownerEntity.setValid(false);
                 return;
             }
 
-            // FK 컬럼명 결정 (필드명 기반)
             String fieldName = field.getSimpleName().toString();
             String fkColumnName = (jc != null && !jc.name().isEmpty())
                     ? jc.name()
-                    : context.getNaming().foreignKeyColumnName(
-                    fieldName, referencedPkName);
+                    : context.getNaming().foreignKeyColumnName(fieldName, referencedPkName);
 
-            // @MapsId 처리
+            // 중복 FK 이름 검증
+            if (toAdd.containsKey(fkColumnName)) {
+                context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                        "Duplicate FK column name '" + fkColumnName + "' in "
+                                + ownerEntity.getEntityName() + "." + field.getSimpleName(), field);
+                ownerEntity.setValid(false);
+                return;
+            }
+
             boolean makePk;
             if (mapsId == null) {
                 makePk = false;
             } else if (mapsIdAttr == null) {
-                makePk = true; // 전체 ID 공유
+                makePk = true;
             } else {
-                // 휴리스틱: FK가 가리키는 참조 PK명이 attr과 일치하면 PK 승격
                 makePk = referencedPkName.equalsIgnoreCase(mapsIdAttr)
                         || referencedPkName.endsWith("_" + mapsIdAttr);
             }
 
-            // JPA 의도상 optional=false면 연관관계가 반드시 존재해야 하므로, DDL에서도 NOT NULL을 보장..
             boolean associationOptional =
                     (manyToOne != null) ? manyToOne.optional() : oneToOne.optional();
-
             boolean columnNullableFromAnno =
                     (jc != null) ? jc.nullable() : associationOptional;
-
-            // PK는 무조건 NOT NULL, 그리고 optional=false면 NOT NULL 강제
             boolean isNullable = !makePk && (associationOptional && columnNullableFromAnno);
+
+            if (!associationOptional && jc != null && jc.nullable()) {
+                context.getMessager().printMessage(Diagnostic.Kind.WARNING,
+                        "@JoinColumn(nullable=true) conflicts with optional=false; treating as NOT NULL.", field);
+            }
 
             ColumnModel fkColumn = ColumnModel.builder()
                     .columnName(fkColumnName)
                     .javaType(referencedPkColumn.getJavaType())
                     .isPrimaryKey(makePk)
-                    .isNullable(!makePk && isNullable) // PK 컬럼은 non-null
+                    .isNullable(isNullable)
                     .build();
 
-            // 기존 컬럼과 타입 충돌 검증
+            // 타입 충돌 검증
             if (ownerEntity.getColumns().containsKey(fkColumnName)) {
                 ColumnModel existing = ownerEntity.getColumns().get(fkColumnName);
                 if (!existing.getJavaType().equals(fkColumn.getJavaType())) {
@@ -179,14 +185,21 @@ public class RelationshipHandler {
                             "Type mismatch for column '" + fkColumnName + "' on " + ownerEntity.getEntityName() +
                                     ". FK requires type " + fkColumn.getJavaType() +
                                     " but existing column has type " + existing.getJavaType(), field);
+                    ownerEntity.setValid(false);
+                    return;
                 }
-            } else {
-                ownerEntity.getColumns().put(fkColumnName, fkColumn);
             }
 
+            // 신규 컬럼 보류
+            if (!ownerEntity.getColumns().containsKey(fkColumnName)) {
+                toAdd.put(fkColumnName, fkColumn);
+            }
             fkColumnNames.add(fkColumnName);
             referencedPkNames.add(referencedPkName);
         }
+
+        // loop2: 적용
+        ownerEntity.getColumns().putAll(toAdd);
 
         // FK 제약 조건명 결정
         String explicitFkName = joinColumns.stream()
@@ -218,10 +231,33 @@ public class RelationshipHandler {
 
     /**
      * 단방향 @OneToMany FK 방식 처리
-     * 타겟 엔티티에 FK 컬럼을 추가
      */
     private void processUnidirectionalOneToMany_FK(VariableElement field, EntityModel ownerEntity, OneToMany oneToMany) {
-        TypeMirror targetType = ((DeclaredType) field.asType()).getTypeArguments().get(0);
+        // 제네릭 타입 유효성 검사
+        if (!(field.asType() instanceof DeclaredType declaredType)) {
+            context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    "@OneToMany 필드는 제네릭 컬렉션 타입이어야 합니다. field=" + field.getSimpleName(), field);
+            return;
+        }
+
+        List<? extends TypeMirror> typeArgs = declaredType.getTypeArguments();
+        if (typeArgs == null || typeArgs.isEmpty() || !(typeArgs.get(0) instanceof DeclaredType)) {
+            context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    "@OneToMany 필드의 제네릭 타입 파라미터를 확인할 수 없습니다. field=" + field.getSimpleName(), field);
+            return;
+        }
+
+        var types = context.getTypeUtils();
+        var elems = context.getElementUtils();
+        TypeMirror lhs = types.erasure(field.asType());
+        TypeMirror rhs = types.erasure(elems.getTypeElement("java.util.Collection").asType());
+        if (!types.isAssignable(lhs, rhs)) {
+            context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    "@OneToMany 필드는 java.util.Collection의 서브타입이어야 합니다. field=" + field.getSimpleName(), field);
+            return;
+        }
+
+        TypeMirror targetType = typeArgs.get(0);
         TypeElement targetEntityElement = (TypeElement) ((DeclaredType) targetType).asElement();
         EntityModel targetEntityModel = context.getSchemaModel().getEntities()
                 .get(targetEntityElement.getQualifiedName().toString());
@@ -231,6 +267,7 @@ public class RelationshipHandler {
         if (ownerPks.isEmpty()) {
             context.getMessager().printMessage(Diagnostic.Kind.ERROR,
                     "Entity " + ownerEntity.getEntityName() + " must have a primary key for @OneToMany relationship.", field);
+            targetEntityModel.setValid(false);
             return;
         }
 
@@ -243,25 +280,34 @@ public class RelationshipHandler {
             context.getMessager().printMessage(Diagnostic.Kind.ERROR,
                     "@JoinColumns size mismatch on " + ownerEntity.getEntityName() + "." + field.getSimpleName()
                             + ". Expected " + ownerPks.size() + ", but got " + jlist.size() + ".", field);
+            targetEntityModel.setValid(false);
             return;
         }
 
+        Map<String, ColumnModel> toAdd = new LinkedHashMap<>();
         List<String> fkNames = new ArrayList<>();
         List<String> refNames = new ArrayList<>();
 
-        // FK 컬럼 생성 (타겟 엔티티에 추가)
+        // loop1: 사전 검증
         for (int i = 0; i < ownerPks.size(); i++) {
             ColumnModel ownerPk = ownerPks.get(i);
-            // j != null이 항상 성립 하므로 분기 제거
-            JoinColumn j = jlist.get(i);
+            JoinColumn j = jlist.isEmpty() ? null : jlist.get(i);
 
             String refName = (j != null && !j.referencedColumnName().isEmpty())
                     ? j.referencedColumnName() : ownerPk.getColumnName();
 
-            // FK 컬럼명 결정 (네이밍 통일: 테이블_컬럼 형식)
             String fkName = (j != null && !j.name().isEmpty())
                     ? j.name()
                     : context.getNaming().foreignKeyColumnName(ownerEntity.getTableName(), refName);
+
+            // 중복 FK 이름 검증
+            if (toAdd.containsKey(fkName)) {
+                context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                        "Duplicate FK column name '" + fkName + "' in "
+                                + targetEntityModel.getEntityName() + "." + field.getSimpleName(), field);
+                targetEntityModel.setValid(false);
+                return;
+            }
 
             ColumnModel fkColumn = ColumnModel.builder()
                     .columnName(fkName)
@@ -277,14 +323,21 @@ public class RelationshipHandler {
                             "Type mismatch for implicit foreign key column '" + fkName + "' in " +
                                     targetEntityModel.getEntityName() + ". Expected type " + fkColumn.getJavaType() +
                                     " but found existing column with type " + existing.getJavaType(), field);
+                    targetEntityModel.setValid(false);
+                    return;
                 }
-            } else {
-                targetEntityModel.getColumns().put(fkName, fkColumn);
             }
 
+            // 신규 컬럼 보류
+            if (!targetEntityModel.getColumns().containsKey(fkName)) {
+                toAdd.put(fkName, fkColumn);
+            }
             fkNames.add(fkName);
             refNames.add(refName);
         }
+
+        // loop2: 적용
+        targetEntityModel.getColumns().putAll(toAdd);
 
         // FK 제약 조건명 결정
         String constraintName = jlist.stream()
@@ -295,7 +348,7 @@ public class RelationshipHandler {
                 .orElseGet(() -> context.getNaming().fkName(targetEntityModel.getTableName(), fkNames,
                         ownerEntity.getTableName(), refNames));
 
-        // 관계 모델 생성 (타겟 엔티티에 추가)
+        // 관계 모델 생성
         RelationshipModel rel = RelationshipModel.builder()
                 .type(RelationshipType.ONE_TO_MANY)
                 .columns(fkNames)
@@ -312,11 +365,32 @@ public class RelationshipHandler {
 
     /**
      * 단방향 @OneToMany JoinTable 방식 처리
-     * 별도의 조인 테이블 생성
      */
     private void processUnidirectionalOneToMany_JoinTable(VariableElement field, EntityModel ownerEntity, OneToMany oneToMany) {
-        // 타겟(자식) 엔티티
-        TypeMirror targetType = ((DeclaredType) field.asType()).getTypeArguments().get(0);
+        if (!(field.asType() instanceof DeclaredType declaredType)) {
+            context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    "@OneToMany 필드는 제네릭 컬렉션 타입이어야 합니다. field=" + field.getSimpleName(), field);
+            return;
+        }
+
+        List<? extends TypeMirror> typeArgs = declaredType.getTypeArguments();
+        if (typeArgs == null || typeArgs.isEmpty() || !(typeArgs.get(0) instanceof DeclaredType)) {
+            context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    "@OneToMany 필드의 제네릭 타입 파라미터를 확인할 수 없습니다. field=" + field.getSimpleName(), field);
+            return;
+        }
+
+        var types = context.getTypeUtils();
+        var elems = context.getElementUtils();
+        TypeMirror lhs = types.erasure(field.asType());
+        TypeMirror rhs = types.erasure(elems.getTypeElement("java.util.Collection").asType());
+        if (!types.isAssignable(lhs, rhs)) {
+            context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    "@OneToMany 필드는 java.util.Collection의 서브타입이어야 합니다. field=" + field.getSimpleName(), field);
+            return;
+        }
+
+        TypeMirror targetType = typeArgs.get(0);
         TypeElement targetEntityElement = (TypeElement) ((DeclaredType) targetType).asElement();
         EntityModel targetEntity = context.getSchemaModel().getEntities()
                 .get(targetEntityElement.getQualifiedName().toString());
@@ -341,15 +415,13 @@ public class RelationshipHandler {
                 ? jt.name()
                 : context.getNaming().joinTableName(ownerEntity.getTableName(), targetEntity.getTableName());
 
-        // 중복 생성 방지
         if (context.getSchemaModel().getEntities().containsKey(joinTableName)) {
             return;
         }
 
-        JoinColumn[] joinColumns = (jt != null) ? jt.joinColumns() : new JoinColumn[0]; // owner측
-        JoinColumn[] inverseJoinColumns = (jt != null) ? jt.inverseJoinColumns() : new JoinColumn[0]; // target측
+        JoinColumn[] joinColumns = (jt != null) ? jt.joinColumns() : new JoinColumn[0];
+        JoinColumn[] inverseJoinColumns = (jt != null) ? jt.inverseJoinColumns() : new JoinColumn[0];
 
-        // 개수 일치 검증
         if (joinColumns.length > 0 && joinColumns.length != ownerPks.size()) {
             context.getMessager().printMessage(Diagnostic.Kind.ERROR,
                     "JoinTable.joinColumns 개수가 Owner PK 개수와 일치해야 합니다: expected " + ownerPks.size()
@@ -363,7 +435,6 @@ public class RelationshipHandler {
             return;
         }
 
-        // FK 제약 조건명 추출
         String ownerFkConstraint = Arrays.stream(joinColumns)
                 .map(JoinColumn::foreignKey).map(ForeignKey::name)
                 .filter(n -> n != null && !n.isEmpty()).findFirst().orElse(null);
@@ -371,7 +442,6 @@ public class RelationshipHandler {
                 .map(JoinColumn::foreignKey).map(ForeignKey::name)
                 .filter(n -> n != null && !n.isEmpty()).findFirst().orElse(null);
 
-        // 조인 컬럼 매핑 해결
         Map<String,String> ownerFkToPkMap = resolveJoinColumnMapping(joinColumns, ownerPks, ownerEntity.getTableName());
         Map<String,String> targetFkToPkMap = resolveJoinColumnMapping(inverseJoinColumns, targetPks, targetEntity.getTableName());
 
@@ -380,48 +450,10 @@ public class RelationshipHandler {
                 ownerFkConstraint, targetFkConstraint
         );
 
-        // 조인 테이블 생성 및 관계 추가
-        EntityModel joinTableEntity = createJoinTableEntity_ForOneToMany(details, ownerPks, targetPks);
+        EntityModel joinTableEntity = createJoinTableEntity(details, ownerPks, targetPks);
         addRelationshipsToJoinTable(joinTableEntity, details);
 
         context.getSchemaModel().getEntities().putIfAbsent(joinTableEntity.getEntityName(), joinTableEntity);
-    }
-
-    /**
-     * OneToMany용 조인 테이블 엔티티 생성
-     */
-    private EntityModel createJoinTableEntity_ForOneToMany(JoinTableDetails details,
-                                                           List<ColumnModel> ownerPks,
-                                                           List<ColumnModel> targetPks) {
-        EntityModel joinTableEntity = EntityModel.builder()
-                .entityName(details.joinTableName()) // record accessor 사용
-                .tableName(details.joinTableName())
-                .tableType(EntityModel.TableType.JOIN_TABLE)
-                .build();
-
-        // owner 측 FK들 → PK로 승격
-        details.ownerFkToPkMap().forEach((fkName, pkName) -> {
-            ColumnModel pk = ownerPks.stream()
-                    .filter(p -> p.getColumnName().equals(pkName))
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalStateException(
-                            "Owner PK '" + pkName + "' not found while creating join table '" + details.joinTableName() +"'"));
-            joinTableEntity.getColumns().put(fkName, ColumnModel.builder()
-                    .columnName(fkName).javaType(pk.getJavaType()).isPrimaryKey(true).isNullable(false).build());
-        });
-
-        // target 측 FK들 → PK로 승격 (버그 수정: targetPks 사용)
-        details.inverseFkToPkMap().forEach((fkName, pkName) -> {
-            ColumnModel pk = targetPks.stream() // ← 수정됨: targetPks 사용
-                    .filter(p -> p.getColumnName().equals(pkName))
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalStateException(
-                            "Target PK '" + pkName + "' not found while creating join table '" + details.joinTableName() +"'"));
-            joinTableEntity.getColumns().put(fkName, ColumnModel.builder()
-                    .columnName(fkName).javaType(pk.getJavaType()).isPrimaryKey(true).isNullable(false).build());
-        });
-
-        return joinTableEntity;
     }
 
     /**
@@ -429,9 +461,32 @@ public class RelationshipHandler {
      */
     private void processOwningManyToMany(VariableElement field, EntityModel ownerEntity, ManyToMany manyToMany) {
         JoinTable joinTable = field.getAnnotation(JoinTable.class);
-        TypeElement referencedTypeElement = getReferencedTypeElement(((DeclaredType) field.asType()).getTypeArguments().get(0));
-        if (referencedTypeElement == null) return;
 
+        if (!(field.asType() instanceof DeclaredType declaredType)) {
+            context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    "@ManyToMany 필드는 제네릭 컬렉션 타입이어야 합니다. field=" + field.getSimpleName(), field);
+            return;
+        }
+
+        List<? extends TypeMirror> typeArgs = declaredType.getTypeArguments();
+        if (typeArgs == null || typeArgs.isEmpty() || !(typeArgs.get(0) instanceof DeclaredType)) {
+            context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    "@ManyToMany 필드의 제네릭 타입 파라미터를 확인할 수 없습니다. field=" + field.getSimpleName(), field);
+            return;
+        }
+
+        var types = context.getTypeUtils();
+        var elems = context.getElementUtils();
+        TypeMirror lhs = types.erasure(field.asType());
+        TypeMirror rhs = types.erasure(elems.getTypeElement("java.util.Collection").asType());
+        if (!types.isAssignable(lhs, rhs)) {
+            context.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    "@ManyToMany 필드는 java.util.Collection의 서브타입이어야 합니다. field=" + field.getSimpleName(), field);
+            return;
+        }
+
+        TypeMirror targetType = typeArgs.get(0);
+        TypeElement referencedTypeElement = (TypeElement) ((DeclaredType) targetType).asElement();
         EntityModel referencedEntity = context.getSchemaModel().getEntities()
                 .get(referencedTypeElement.getQualifiedName().toString());
         if (referencedEntity == null) return;
@@ -449,7 +504,6 @@ public class RelationshipHandler {
                 ? joinTable.name()
                 : context.getNaming().joinTableName(ownerEntity.getTableName(), referencedEntity.getTableName());
 
-        // 중복 생성 방지
         if (context.getSchemaModel().getEntities().containsKey(joinTableName)) {
             return;
         }
@@ -457,7 +511,6 @@ public class RelationshipHandler {
         JoinColumn[] joinColumns = (joinTable != null) ? joinTable.joinColumns() : new JoinColumn[0];
         JoinColumn[] inverseJoinColumns = (joinTable != null) ? joinTable.inverseJoinColumns() : new JoinColumn[0];
 
-        // 개수 일치 검증
         if (joinColumns.length > 0 && joinColumns.length != ownerPks.size()) {
             context.getMessager().printMessage(Diagnostic.Kind.ERROR,
                     "The number of @JoinColumn annotations for " + ownerEntity.getTableName() +
@@ -473,7 +526,6 @@ public class RelationshipHandler {
             return;
         }
 
-        // FK 제약 조건명 추출
         String ownerFkConstraint = Arrays.stream(joinColumns)
                 .map(JoinColumn::foreignKey).map(ForeignKey::name)
                 .filter(n -> n != null && !n.isEmpty()).findFirst().orElse(null);
@@ -482,47 +534,37 @@ public class RelationshipHandler {
                 .map(JoinColumn::foreignKey).map(ForeignKey::name)
                 .filter(n -> n != null && !n.isEmpty()).findFirst().orElse(null);
 
-        // 조인 컬럼 매핑 해결
         Map<String, String> ownerFkToPkMap = resolveJoinColumnMapping(joinColumns, ownerPks, ownerEntity.getTableName());
         Map<String, String> inverseFkToPkMap = resolveJoinColumnMapping(inverseJoinColumns, referencedPks, referencedEntity.getTableName());
 
         JoinTableDetails details = new JoinTableDetails(joinTableName, ownerFkToPkMap, inverseFkToPkMap,
                 ownerEntity, referencedEntity, ownerFkConstraint, inverseFkConstraint);
 
-        // 조인 테이블 생성 및 관계 추가
         EntityModel joinTableEntity = createJoinTableEntity(details, ownerPks, referencedPks);
         addRelationshipsToJoinTable(joinTableEntity, details);
 
         context.getSchemaModel().getEntities().putIfAbsent(joinTableEntity.getEntityName(), joinTableEntity);
     }
 
-    /**
-     * 조인 컬럼 매핑 해결
-     */
     private Map<String, String> resolveJoinColumnMapping(JoinColumn[] joinColumns, List<ColumnModel> referencedPks, String entityTableName) {
         Map<String, String> mapping = new LinkedHashMap<>();
-
         if (joinColumns == null || joinColumns.length == 0) {
-            // 기본 매핑: 테이블명_컬럼명 형식
             referencedPks.forEach(pk -> mapping.put(
                     context.getNaming().foreignKeyColumnName(entityTableName, pk.getColumnName()),
                     pk.getColumnName()
             ));
         } else {
-            // 명시적 매핑
             for (int i = 0; i < joinColumns.length; i++) {
                 JoinColumn jc = joinColumns[i];
                 String pkName = jc.referencedColumnName().isEmpty()
                         ? referencedPks.get(i).getColumnName()
                         : jc.referencedColumnName();
-
                 String fkName = jc.name().isEmpty()
                         ? context.getNaming().foreignKeyColumnName(entityTableName, pkName)
                         : jc.name();
-
                 if (mapping.containsKey(fkName)) {
                     context.getMessager().printMessage(Diagnostic.Kind.ERROR,
-                            "Duplicate FK column '"+ fkName +"' in join table mapping for " + entityTableName);
+                            "Duplicate FK column '" + fkName + "' in join table mapping for " + entityTableName);
                     continue;
                 }
                 mapping.put(fkName, pkName);
@@ -531,34 +573,29 @@ public class RelationshipHandler {
         return mapping;
     }
 
-    /**
-     * ManyToMany용 조인 테이블 엔티티 생성
-     */
     private EntityModel createJoinTableEntity(JoinTableDetails details, List<ColumnModel> ownerPks, List<ColumnModel> referencedPks) {
         EntityModel joinTableEntity = EntityModel.builder()
-                .entityName(details.joinTableName()) // record accessor 사용
+                .entityName(details.joinTableName())
                 .tableName(details.joinTableName())
                 .tableType(EntityModel.TableType.JOIN_TABLE)
                 .build();
 
-        // owner 측 FK들 → PK로 승격
         details.ownerFkToPkMap().forEach((fkName, pkName) -> {
             ColumnModel pk = ownerPks.stream()
                     .filter(p -> p.getColumnName().equals(pkName))
                     .findFirst()
                     .orElseThrow(() -> new IllegalStateException(
-                            "Owner PK '" + pkName + "' not found while creating join table '" + details.joinTableName() +"'"));
+                            "Owner PK '" + pkName + "' not found while creating join table '" + details.joinTableName() + "'"));
             joinTableEntity.getColumns().put(fkName, ColumnModel.builder()
                     .columnName(fkName).javaType(pk.getJavaType()).isPrimaryKey(true).isNullable(false).build());
         });
 
-        // referenced 측 FK들 → PK로 승격 (버그 수정: referencedPks 사용)
         details.inverseFkToPkMap().forEach((fkName, pkName) -> {
-            ColumnModel pk = referencedPks.stream() // ← 수정됨: referencedPks 사용
+            ColumnModel pk = referencedPks.stream()
                     .filter(p -> p.getColumnName().equals(pkName))
                     .findFirst()
                     .orElseThrow(() -> new IllegalStateException(
-                            "Referenced PK '" + pkName + "' not found while creating join table '" + details.joinTableName() +"'"));
+                            "Referenced PK '" + pkName + "' not found while creating join table '" + details.joinTableName() + "'"));
             joinTableEntity.getColumns().put(fkName, ColumnModel.builder()
                     .columnName(fkName).javaType(pk.getJavaType()).isPrimaryKey(true).isNullable(false).build());
         });
@@ -566,11 +603,7 @@ public class RelationshipHandler {
         return joinTableEntity;
     }
 
-    /**
-     * 조인 테이블에 FK 관계 추가
-     */
     private void addRelationshipsToJoinTable(EntityModel joinTableEntity, JoinTableDetails details) {
-        // owner 측 관계
         List<String> ownerFkColumns = new ArrayList<>(details.ownerFkToPkMap().keySet());
         List<String> ownerPkColumns = new ArrayList<>(details.ownerFkToPkMap().values());
 
@@ -586,7 +619,6 @@ public class RelationshipHandler {
                 .build();
         joinTableEntity.getRelationships().put(ownerRel.getConstraintName(), ownerRel);
 
-        // referenced/target 측 관계
         List<String> targetFkColumns = new ArrayList<>(details.inverseFkToPkMap().keySet());
         List<String> targetPkColumns = new ArrayList<>(details.inverseFkToPkMap().values());
 
@@ -603,9 +635,6 @@ public class RelationshipHandler {
         joinTableEntity.getRelationships().put(targetRel.getConstraintName(), targetRel);
     }
 
-    /**
-     * 타입에서 참조되는 TypeElement 추출
-     */
     private TypeElement getReferencedTypeElement(TypeMirror typeMirror) {
         if (typeMirror instanceof DeclaredType declaredType && declaredType.asElement() instanceof TypeElement) {
             return (TypeElement) declaredType.asElement();
@@ -613,16 +642,10 @@ public class RelationshipHandler {
         return null;
     }
 
-    /**
-     * JPA CascadeType 배열을 내부 CascadeType 리스트로 변환
-     */
     private List<CascadeType> toCascadeList(jakarta.persistence.CascadeType[] arr) {
         return arr == null ? Collections.emptyList() : Arrays.stream(arr).toList();
     }
 
-    /**
-     * 조인 테이블 상세 정보를 담는 record
-     */
     private record JoinTableDetails(
             String joinTableName,
             Map<String, String> ownerFkToPkMap,

--- a/jinx-processor/src/test/java/org/jinx/processor/JpaSqlGeneratorProcessorTest.java
+++ b/jinx-processor/src/test/java/org/jinx/processor/JpaSqlGeneratorProcessorTest.java
@@ -1,332 +1,233 @@
 package org.jinx.processor;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.testing.compile.Compilation;
-import com.google.testing.compile.Compiler;
-import com.google.testing.compile.JavaFileObjects;
-import org.junit.jupiter.api.DisplayName;
+import jakarta.persistence.Converter;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.MappedSuperclass;
+import org.jinx.context.ProcessingContext;
+import org.jinx.handler.EntityHandler;
+import org.jinx.handler.InheritanceHandler;
+import org.jinx.handler.RelationshipHandler;
+import org.jinx.model.EntityModel;
+import org.jinx.model.SchemaModel;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.tools.JavaFileObject;
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
-import java.util.stream.Collectors;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.*;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.tools.Diagnostic;
+import java.lang.reflect.Field;
+import java.util.*;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class JpaSqlGeneratorProcessorTest {
 
-    private static Map<String, Object> readSchemaRoot(Compilation comp) throws Exception {
-        JavaFileObject jsonFile = comp.generatedFiles().stream()
-                .filter(f -> f.getName().endsWith(".json") && f.getName().contains("schema"))
-                .findFirst()
-                .orElseThrow(() -> new IllegalStateException("schema file not generated"));
+    @Mock ProcessingEnvironment processingEnv;
+    @Mock Messager messager;
+    @Mock Elements elements;
+    @Mock RoundEnvironment roundEnv;
 
-        String json;
-        try (BufferedReader br = new BufferedReader(
-                new InputStreamReader(jsonFile.openInputStream(), StandardCharsets.UTF_8))) {
-            json = br.lines().collect(Collectors.joining("\n"));
-        }
+    JpaSqlGeneratorProcessor processor;
 
-        ObjectMapper mapper = JpaSqlGeneratorProcessor.OBJECT_MAPPER.copy()
-                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    @BeforeEach
+    void setup() {
+        lenient().when(processingEnv.getMessager()).thenReturn(messager);
+        lenient().when(processingEnv.getElementUtils()).thenReturn(elements);
 
-        return mapper.readValue(json, new TypeReference<>() {});
+        processor = new JpaSqlGeneratorProcessor();
+        processor.init(processingEnv);
     }
 
     @Test
-    @DisplayName("기본 @Entity → schema.json 생성")
-    void basicEntityProducesSchema() throws Exception {
-        JavaFileObject user = JavaFileObjects.forSourceLines(
-                "com.example.User",
-                "package com.example;",
-                "import jakarta.persistence.*;",
-                "@Entity",
-                "public class User {",
-                "  @Id Long id;",
-                "  String name;",
-                "}");
+    void converter_autoApply_withGeneric_addsMapping() throws Exception {
+        // Given: @Converter(autoApply=true) on a class implementing AttributeConverter<Target,String>
+        TypeElement converterType = mockTypeElement("com.example.MyLocalDateConverter");
+        Converter converterAnno = mock(Converter.class);
+        when(converterAnno.autoApply()).thenReturn(true);
+        when(converterType.getAnnotation(Converter.class)).thenReturn(converterAnno);
+        when(converterType.getKind()).thenReturn(ElementKind.CLASS);
 
-        Compilation c = Compiler.javac()
-                .withProcessors(new JpaSqlGeneratorProcessor())
-                .compile(user);
+        // DeclaredType: jakarta.persistence.AttributeConverter<java.time.LocalDate, java.lang.String>
+        DeclaredType attrConv = mock(DeclaredType.class);
+        when(attrConv.toString())
+                .thenReturn("jakarta.persistence.AttributeConverter<java.time.LocalDate,java.lang.String>");
+        TypeMirror targetType = mockTypeMirror("java.time.LocalDate");
+        doReturn(List.of(targetType)).when(attrConv).getTypeArguments();
+        doReturn(List.of(attrConv)).when(converterType).getInterfaces();
 
-        assertThat(c.status()).isEqualTo(Compilation.Status.SUCCESS);
+        // Round env returns just this converter; others empty; processingOver=false
+        doReturn(Set.of(converterType)).when(roundEnv).getElementsAnnotatedWith(Converter.class);
+        when(roundEnv.getElementsAnnotatedWith(MappedSuperclass.class)).thenReturn(Set.of());
+        when(roundEnv.getElementsAnnotatedWith(Embeddable.class)).thenReturn(Set.of());
+        when(roundEnv.getElementsAnnotatedWith(Entity.class)).thenReturn(Set.of());
+        when(roundEnv.processingOver()).thenReturn(false);
 
-        Map<String, Object> root = readSchemaRoot(c);
-        assertThat(root).containsKey("version");
+        // When
+        processor.process(Set.of(), roundEnv);
 
-        @SuppressWarnings("unchecked")
-        Map<String, Object> entities = (Map<String, Object>) root.get("entities");
-        assertThat(entities).containsKey("com.example.User");
+        // Then: mapping added into ProcessingContext.autoApplyConverters
+        ProcessingContext ctx = getPrivate(processor, "context");
+        Map<String, String> map = ctx.getAutoApplyConverters();
+        assertEquals("com.example.MyLocalDateConverter", map.get("java.time.LocalDate"));
+        verify(messager, never()).printMessage(eq(Diagnostic.Kind.WARNING), anyString(), any());
     }
 
     @Test
-    @DisplayName("@Converter(autoApply=true) 적용")
-    void handlesAutoApplyConverter() throws Exception {
-        JavaFileObject conv = JavaFileObjects.forSourceLines(
-                "com.example.BoolYnConv",
-                "package com.example;",
-                "import jakarta.persistence.*;",
-                "@Converter(autoApply=true)",
-                "public class BoolYnConv implements AttributeConverter<Boolean,String>{",
-                "  public String convertToDatabaseColumn(Boolean a){return a==null?null:(a?\"Y\":\"N\");}",
-                "  public Boolean convertToEntityAttribute(String d){return \"Y\".equals(d);}}");
+    void converter_autoApply_missingGeneric_emitsWarning() {
+        // Given: @Converter(autoApply=true), but no generic type args resolved
+        TypeElement converterType = mockTypeElement("com.example.BadConverter");
+        Converter converterAnno = mock(Converter.class);
+        when(converterAnno.autoApply()).thenReturn(true);
+        when(converterType.getAnnotation(Converter.class)).thenReturn(converterAnno);
+        when(converterType.getKind()).thenReturn(ElementKind.CLASS);
 
-        JavaFileObject user = JavaFileObjects.forSourceLines(
-                "com.example.User",
-                "package com.example;",
-                "import jakarta.persistence.*;",
-                "@Entity public class User{",
-                "  @Id Long id;",
-                "  Boolean active;",
-                "}");
+        DeclaredType attrConv = mock(DeclaredType.class);
+        when(attrConv.toString()).thenReturn("jakarta.persistence.AttributeConverter");
+        when(attrConv.getTypeArguments()).thenReturn(List.of()); // empty -> unresolved
+        doReturn(List.of(attrConv)).when(converterType).getInterfaces();
 
-        Compilation c = Compiler.javac()
-                .withOptions("--add-opens",
-                        "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED")
-                .withProcessors(new JpaSqlGeneratorProcessor())
-                .compile(conv, user);
+        doReturn(Set.of(converterType)).when(roundEnv).getElementsAnnotatedWith(Converter.class);
+        when(roundEnv.getElementsAnnotatedWith(MappedSuperclass.class)).thenReturn(Set.of());
+        when(roundEnv.getElementsAnnotatedWith(Embeddable.class)).thenReturn(Set.of());
+        when(roundEnv.getElementsAnnotatedWith(Entity.class)).thenReturn(Set.of());
+        when(roundEnv.processingOver()).thenReturn(false);
 
-        assertThat(c.status()).isEqualTo(Compilation.Status.SUCCESS);
+        when(processingEnv.getMessager()).thenReturn(messager);
 
-        Map<String, Object> root = readSchemaRoot(c);
-        @SuppressWarnings("unchecked")
-        Map<String, Object> columns = (Map<String, Object>)
-                ((Map<?,?>)((Map<?,?>)root.get("entities"))
-                        .get("com.example.User"))
-                        .get("columns");
+        // When
+        processor.process(Set.of(), roundEnv);
 
-        @SuppressWarnings("unchecked")
-        Map<String, Object> active = (Map<String, Object>) columns.get("active");
-        assertThat(active.get("conversionClass"))
-                .isEqualTo("com.example.BoolYnConv");
+        // Then: WARNING logged, no crash
+        verify(messager).printMessage(
+                eq(Diagnostic.Kind.WARNING),
+                ArgumentMatchers.contains("@Converter(autoApply=true) generic target type unresolved"),
+                eq(converterType)
+        );
     }
 
     @Test
-    @DisplayName("@MappedSuperclass · @Embeddable 필드 병합")
-    void handlesMappedSuperclassAndEmbeddable() throws Exception {
-        JavaFileObject base = JavaFileObjects.forSourceLines(
-                "com.example.Base",
-                "package com.example;",
-                "import jakarta.persistence.*;",
-                "import java.time.*;",
-                "@MappedSuperclass",
-                "public class Base{",
-                "  @Column(name=\"created_at\") LocalDateTime createdAt; }");
+    void processingOver_relationshipResolution_skipsWhenTypeElementNull_andWarns() throws Exception {
+        // Given: processingOver=true, one entity in schema, but elements.getTypeElement() returns null
+        // Replace context with spy (to avoid saveModelToJson side effects)
+        ProcessingContext realCtx = (ProcessingContext) getPrivate(processor, "context");
+        ProcessingContext ctx = Mockito.spy(realCtx);
+        doNothing().when(ctx).saveModelToJson();
+        setPrivate(processor, "context", ctx);
 
-        JavaFileObject addr = JavaFileObjects.forSourceLines(
-                "com.example.Address",
-                "package com.example;",
-                "import jakarta.persistence.*;",
-                "@Embeddable",
-                "public class Address{ String city; String street; }");
+        // Swap handlers with mocks (no side effects)
+        InheritanceHandler inh = mock(InheritanceHandler.class);
+        RelationshipHandler rel = mock(RelationshipHandler.class);
+        EntityHandler ent = mock(EntityHandler.class);
+        setPrivate(processor, "inheritanceHandler", inh);
+        setPrivate(processor, "relationshipHandler", rel);
+        setPrivate(processor, "entityHandler", ent);
 
-        JavaFileObject user = JavaFileObjects.forSourceLines(
-                "com.example.User",
-                "package com.example;",
-                "import jakarta.persistence.*;",
-                "@Entity",
-                "public class User extends Base{",
-                "  @Id Long id;",
-                "  @Embedded Address address; }");
+        // Put one valid entity into schema
+        EntityModel em = EntityModel.builder()
+                .entityName("com.example.MissingType")
+                .tableName("t_missing")
+                .build();
+        ctx.getSchemaModel().getEntities().put("com.example.MissingType", em);
 
-        Compilation c = Compiler.javac()
-                .withOptions("--add-opens",
-                        "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED")
-                .withProcessors(new JpaSqlGeneratorProcessor())
-                .compile(base, addr, user);
+        // Make elements.getTypeElement return null for that name
+        when(elements.getTypeElement("com.example.MissingType")).thenReturn(null);
 
-        assertThat(c.status()).isEqualTo(Compilation.Status.SUCCESS);
+        // Round env has no new annotated elements, but processingOver=true
+        when(roundEnv.getElementsAnnotatedWith(any(Class.class))).thenReturn(Set.of());
+        when(roundEnv.processingOver()).thenReturn(true);
 
-        Map<String, Object> root = readSchemaRoot(c);
-        @SuppressWarnings("unchecked")
-        Map<String, Object> cols = (Map<String, Object>)
-                ((Map<?,?>)((Map<?,?>)root.get("entities"))
-                        .get("com.example.User"))
-                        .get("columns");
+        // When
+        processor.process(Set.of(), roundEnv);
 
-        assertThat(cols).containsKey("created_at"); // MappedSuperclass
-        assertThat(cols).containsKey("city");       // Embeddable
-        assertThat(cols).containsKey("street");     // Embeddable
-    }
-
-    /*
-     * Additional unit tests appended to increase coverage of JPA mapping scenarios.
-     * Testing stack: JUnit 5 (Jupiter), Google Truth assertions, and Google Compile Testing.
-     * Focus: schema column derivation, field exclusions, attribute/column overrides, and converter precedence.
-     */
-
-    @Test
-    @DisplayName("@Transient fields are excluded from schema columns")
-    void transientFieldsExcludedFromSchema() throws Exception {
-        JavaFileObject user = JavaFileObjects.forSourceLines(
-                "com.example.User",
-                "package com.example;",
-                "import jakarta.persistence.*;",
-                "@Entity",
-                "public class User {",
-                "  @Id Long id;",
-                "  @Transient String temp;",
-                "  String name;",
-                "}"
+        // Then: WARNING emitted, and relationship handler NOT invoked
+        verify(messager).printMessage(
+                eq(Diagnostic.Kind.WARNING),
+                eq("Skip relationship resolution: cannot resolve TypeElement for com.example.MissingType")
         );
-
-        Compilation c = Compiler.javac()
-                .withProcessors(new JpaSqlGeneratorProcessor())
-                .compile(user);
-
-        assertThat(c.status()).isEqualTo(Compilation.Status.SUCCESS);
-
-        Map<String, Object> root = readSchemaRoot(c);
-        @SuppressWarnings("unchecked")
-        Map<String, Object> columns = (Map<String, Object>)
-                ((Map<?,?>)((Map<?,?>)root.get("entities"))
-                        .get("com.example.User"))
-                        .get("columns");
-
-        // Ensure transient field is not exported while a regular field is present.
-        assertThat(columns.containsKey("temp")).isFalse();
-        assertThat(columns.containsKey("name")).isTrue();
+        verify(rel, never()).resolveRelationships(any(), any());
     }
 
     @Test
-    @DisplayName("@Column(name=...) is respected when deriving column keys")
-    void columnAnnotationOverridesName() throws Exception {
-        JavaFileObject user = JavaFileObjects.forSourceLines(
-                "com.example.User",
-                "package com.example;",
-                "import jakarta.persistence.*;",
-                "@Entity",
-                "public class User {",
-                "  @Id Long id;",
-                "  @Column(name=\"full_name\") String name;",
-                "}"
+    void processingOver_finalPkValidation_errorsWhenNoPk_andInvalidatesEntity() throws Exception {
+        // Given: processingOver=true, one entity without PKs
+        ProcessingContext realCtx = (ProcessingContext) getPrivate(processor, "context");
+        ProcessingContext ctx = Mockito.spy(realCtx);
+        doNothing().when(ctx).saveModelToJson();
+        setPrivate(processor, "context", ctx);
+
+        // Mock handlers to no-op
+        InheritanceHandler inh = mock(InheritanceHandler.class);
+        RelationshipHandler rel = mock(RelationshipHandler.class);
+        EntityHandler ent = mock(EntityHandler.class);
+        setPrivate(processor, "inheritanceHandler", inh);
+        setPrivate(processor, "relationshipHandler", rel);
+        setPrivate(processor, "entityHandler", ent);
+
+        // Entity has no PK columns
+        EntityModel em = EntityModel.builder()
+                .entityName("com.example.NoPk")
+                .tableName("no_pk")
+                .build();
+        ctx.getSchemaModel().getEntities().put("com.example.NoPk", em);
+
+        // getTypeElement should return a non-null element for error attachment
+        TypeElement te = mockTypeElement("com.example.NoPk");
+        when(elements.getTypeElement("com.example.NoPk")).thenReturn(te);
+
+        when(roundEnv.getElementsAnnotatedWith(any(Class.class))).thenReturn(Set.of());
+        when(roundEnv.processingOver()).thenReturn(true);
+
+        // When
+        processor.process(Set.of(), roundEnv);
+
+        // Then: ERROR logged with the TypeElement, and entity invalidated
+        verify(messager).printMessage(
+                eq(Diagnostic.Kind.ERROR),
+                eq("Entity 'com.example.NoPk' must have a primary key."),
+                eq(te)
         );
-
-        Compilation c = Compiler.javac()
-                .withProcessors(new JpaSqlGeneratorProcessor())
-                .compile(user);
-
-        assertThat(c.status()).isEqualTo(Compilation.Status.SUCCESS);
-
-        Map<String, Object> root = readSchemaRoot(c);
-        @SuppressWarnings("unchecked")
-        Map<String, Object> columns = (Map<String, Object>)
-                ((Map<?,?>)((Map<?,?>)root.get("entities"))
-                        .get("com.example.User"))
-                        .get("columns");
-
-        // The overridden column name should be used as the key.
-        assertThat(columns.containsKey("full_name")).isTrue();
+        assertFalse(em.isValid(), "Entity should be marked invalid when no PKs");
     }
 
-    @Test
-    @DisplayName("@AttributeOverride on @Embedded field renames embedded column(s)")
-    void attributeOverrideOnEmbeddedField() throws Exception {
-        JavaFileObject addr = JavaFileObjects.forSourceLines(
-                "com.example.Address",
-                "package com.example;",
-                "import jakarta.persistence.*;",
-                "@Embeddable",
-                "public class Address {",
-                "  String city;",
-                "  String street;",
-                "}"
-        );
 
-        JavaFileObject user = JavaFileObjects.forSourceLines(
-                "com.example.User",
-                "package com.example;",
-                "import jakarta.persistence.*;",
-                "@Entity",
-                "public class User {",
-                "  @Id Long id;",
-                "  @Embedded",
-                "  @AttributeOverrides({",
-                "    @AttributeOverride(name=\"street\", column=@Column(name=\"str_name\"))",
-                "  })",
-                "  Address address;",
-                "}"
-        );
-
-        Compilation c = Compiler.javac()
-                .withOptions("--add-opens",
-                        "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED")
-                .withProcessors(new JpaSqlGeneratorProcessor())
-                .compile(addr, user);
-
-        assertThat(c.status()).isEqualTo(Compilation.Status.SUCCESS);
-
-        Map<String, Object> root = readSchemaRoot(c);
+    private static <T> T getPrivate(Object target, String field) throws Exception {
+        Field f = target.getClass().getDeclaredField(field);
+        f.setAccessible(true);
         @SuppressWarnings("unchecked")
-        Map<String, Object> columns = (Map<String, Object>)
-                ((Map<?,?>)((Map<?,?>)root.get("entities"))
-                        .get("com.example.User"))
-                        .get("columns");
-
-        // Ensure both a default embedded column and an overridden column are present.
-        assertThat(columns.containsKey("city")).isTrue();
-        assertThat(columns.containsKey("str_name")).isTrue();
+        T val = (T) f.get(target);
+        return val;
     }
 
-    @Test
-    @DisplayName("Field-level @Convert overrides @Converter(autoApply=true)")
-    void fieldLevelConvertOverridesAutoApply() throws Exception {
-        JavaFileObject convYn = JavaFileObjects.forSourceLines(
-                "com.example.BoolYnConv",
-                "package com.example;",
-                "import jakarta.persistence.*;",
-                "@Converter(autoApply=true)",
-                "public class BoolYnConv implements AttributeConverter<Boolean,String>{",
-                "  public String convertToDatabaseColumn(Boolean a){return a==null?null:(a?\"Y\":\"N\");}",
-                "  public Boolean convertToEntityAttribute(String d){return \"Y\".equals(d);} }"
-        );
-
-        JavaFileObject conv10 = JavaFileObjects.forSourceLines(
-                "com.example.Bool10Conv",
-                "package com.example;",
-                "import jakarta.persistence.*;",
-                "public class Bool10Conv implements AttributeConverter<Boolean,String>{",
-                "  public String convertToDatabaseColumn(Boolean a){return a==null?null:(a?\"1\":\"0\");}",
-                "  public Boolean convertToEntityAttribute(String d){return \"1\".equals(d);} }"
-        );
-
-        JavaFileObject user = JavaFileObjects.forSourceLines(
-                "com.example.User",
-                "package com.example;",
-                "import jakarta.persistence.*;",
-                "@Entity",
-                "public class User {",
-                "  @Id Long id;",
-                "  @Convert(converter=Bool10Conv.class)",
-                "  Boolean active;",
-                "}"
-        );
-
-        Compilation c = Compiler.javac()
-                .withOptions("--add-opens",
-                        "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED")
-                .withProcessors(new JpaSqlGeneratorProcessor())
-                .compile(convYn, conv10, user);
-
-        assertThat(c.status()).isEqualTo(Compilation.Status.SUCCESS);
-
-        Map<String, Object> root = readSchemaRoot(c);
-        @SuppressWarnings("unchecked")
-        Map<String, Object> columns = (Map<String, Object>)
-                ((Map<?,?>)((Map<?,?>)root.get("entities"))
-                        .get("com.example.User"))
-                        .get("columns");
-
-        @SuppressWarnings("unchecked")
-        Map<String, Object> active = (Map<String, Object>) columns.get("active");
-        assertThat(active.get("conversionClass"))
-                .isEqualTo("com.example.Bool10Conv");
+    private static void setPrivate(Object target, String field, Object value) throws Exception {
+        Field f = target.getClass().getDeclaredField(field);
+        f.setAccessible(true);
+        f.set(target, value);
     }
 
+    private static TypeElement mockTypeElement(String qname) {
+        TypeElement te = mock(TypeElement.class);
+        Name name = mock(Name.class);
+        lenient().when(name.toString()).thenReturn(qname);
+        lenient().when(te.getQualifiedName()).thenReturn(name);
+        return te;
+    }
+
+    private static TypeMirror mockTypeMirror(String display) {
+        TypeMirror tm = mock(TypeMirror.class);
+        lenient().when(tm.toString()).thenReturn(display);
+        return tm;
+    }
 }


### PR DESCRIPTION
## 제목

[P1] FK 생성 원자화(사전 검증→적용), 제네릭 가드 추가, 최종 PK 검증을 @MapsId 반영 이후로 이동

## 요약

- **문제 1 — 부분 오염:** FK를 생성하는 도중 오류가 나면, 이전 루프에서 추가된 일부 컬럼이 남아 **복합키 시나리오에서 모델이 오염**되었습니다.
    
    → **해결:** FK 계산/검증을 1차 루프에서 모두 수행하고, **오류가 없을 때만** 2차 루프에서 일괄 적용하여 **원자성**을 보장했습니다.
    
- **문제 2 — 제네릭 가드 부재:** `Collection` 제네릭 인자를 바로 `.get(0)`로 접근해 raw/와일드카드 등에서 **런타임 예외**가 날 수 있었습니다.
    
    → **해결:** `DeclaredType`/`typeArgs`/`Collection` 서브타입 검사를 추가하고, 미충족 시 **명시적 컴파일 ERROR**를 출력합니다.
    
- **문제 3 — PK 검증 시점:** 최종 PK 검증이 관계 해석 전 수행되어, **@MapsId 승격 전 상태**에서 오탐(“PK 없음”)이 발생했습니다.
    
    → **해결:** 최종 PK 검증을 **관계 해석 이후(2차 패스)** 로 이동했습니다.
    

## 주요 변경사항

- **RelationshipHandler**
    - `processToOneRelationship`, `processUnidirectionalOneToMany_FK`: **사전 검증(loop1) → 적용(loop2)** 패턴 도입
        - 타입 불일치/중복 FK명/미존재 referencedColumnName 등 발견 시: `ERROR` + `ownerEntity/targetEntity.setValid(false)` + `return`
        - 적용은 `toAdd`(보류 맵)에 모아 **일괄 putAll**(원자적 적용)
    - `processUnidirectionalOneToMany_JoinTable`, `processOwningManyToMany`:
        - **제네릭 가드**(DeclaredType 체크, typeArgs 비어있음/비-Declared 방지, `Collection` 서브타입 확인) 추가
        - **개수 일치 검증 강화**: `@JoinColumns`/`joinColumns`/`inverseJoinColumns` vs PK 수
        - **JoinTableDetails** 레코드 도입 + **참조 사이드 버그 수정**(owner/referenced 각각의 PK 리스트를 올바르게 사용)
    - **에러 메시지 개선**: 필드명/테이블명 포함
- **EntityHandler**
    - 메서드 말미의 **최종 PK 검증 제거(지연)** — @MapsId 승격 이후로 이관
- **JpaSqlGeneratorProcessor**
    - `relationshipHandler.resolveRelationships(...)` **이후** 전체 엔티티에 대해 **2차 패스 PK 검증** 수행
    - 증분/다중 라운드에서 `TypeElement`를 FQN으로 재조회하고, 불가 시 WARN 로그로 스킵
    - `@Converter(autoApply=true)` 제네릭 미해결 시 **WARNING** 출력
- **테스트**
    - **제네릭 가드**
        - raw 컬렉션 → `ERROR` 메시지(필드명 포함) 검증
        - 비-Declared 인자(와일드카드/원시타입 등) → `ERROR` 메시지 검증
        - 정상 제네릭 → 기존 동작 유지(관계/컬럼 생성)
    - **복합키/타입 충돌/중복 FK명**
        - 복합키 + 타입 충돌: `ERROR` + `valid=false` + 컬럼/관계 **미생성**
        - `@JoinColumns` 동일 name(중복) → `ERROR` + **미생성**
        - 정상 복합키 → **정확히 1회** FK/관계 생성
    - **OneToMany(FK) 대칭 케이스** 포함
    - **@JoinTable 개수 불일치**(owner/target/inverse) 경로에 대한 실패 테스트 추가
    - **@Converter(autoApply=true)** 제네릭 미해결 경고 테스트 추가

## 왜 이렇게 바꿨나요?

- APT 컨텍스트에서는 한 번 오염된 모델을 되돌리기 어렵습니다. **검증과 적용을 분리**해 원자성을 확보하는 것이 가장 단순하면서도 안전합니다.
- 제네릭 가드를 통해 사용자에게 **명확한 컴파일 오류 메시지**를 제공하고, 내부 예외/크래시를 제거합니다.
- @MapsId는 관계 해석 중에 PK 승격이 이루어지므로, **검증 시점 이동**이 필수입니다.

## 호환성/리스크

- **호환성:** 에러 상황에 대한 동작이 “조용한 진행” → “명시적 실패 + 적용 중단”으로 바뀌었습니다.
    
    기존에 잘못된 모델이 “부분적으로라도” 생성되던 케이스는 이제 **명확히 실패**합니다(의도된 변경).
    
- **리스크:** 관계 해석/검증 순서 변경으로 예외적 모델에 대한 처리 순서가 달라질 수 있음.
    
    → 단위 테스트로 커버했고, 문제 시 **에러 로그가 더 빨리/명확히** 노출됩니다.
    

## 롤백 플랜

- 문제가 있으면 `RelationshipHandler`의 loop1/loop2 분리 커밋만 리버트하여 기존 즉시 추가 방식으로 되돌릴 수 있습니다(다만 부분 오염 리스크 재발생).

## 체크리스트

- [x]  원자화(2단계) 적용: to-one, one-to-many(FK)
- [x]  제네릭 가드: one-to-many(FK/JoinTable), many-to-many
- [x]  PK 검증 2차 패스 이동 + FQN 기반 TypeElement 조회
- [x]  @Converter(autoApply=true) 제네릭 미해결 WARNING
- [x]  단위 테스트 추가 및 기존 테스트 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 2차 패스로 기본 키 검증 추가 및 지연 처리된 JOIN/FK 재시도 메커니즘 도입
  - FK 컬럼을 검증 후 일괄 적용(지연 반영)하도록 개선
  - 조인 테이블 생성 로직 중앙화 및 Converter autoApply 대상 타입 탐지 강화

- Bug Fixes
  - 조기 PK 검사 제거로 불필요한 오류 방지 및 중복 FK/타입 불일치 검출 강화
  - nullable/optional 충돌 시 일관된 처리 및 상세 오류/경고 메시지 추가
  - 제네릭/컬렉션 필드 검증 강화로 잘못된 스키마 변경 차단

- Tests
  - 프로세서 테스트를 Mockito 기반 단위 테스트로 전환 및 시나리오·목킹 대폭 확대
<!-- end of auto-generated comment: release notes by coderabbit.ai -->