### PR TITLE
PR: InheritanceHandler 강화 — JOINED/TPC/SINGLE_TABLE 정합성, NPE/중복 가드, 테스트 안정화

### DIFF
--- a/jinx-core/src/main/java/org/jinx/model/EntityModel.java
+++ b/jinx-core/src/main/java/org/jinx/model/EntityModel.java
@@ -23,6 +23,7 @@ public class EntityModel {
     @Builder.Default private String comment = null; // Added for @Table(comment)
     private InheritanceType inheritance;
     private String parentEntity;
+    @Builder.Default private String fqcn = null;
     @Builder.Default private TableType tableType = TableType.ENTITY;
     @Builder.Default private Map<String, ColumnModel> columns = new HashMap<>();
     @Builder.Default private Map<String, IndexModel> indexes = new HashMap<>();
@@ -72,5 +73,9 @@ public class EntityModel {
 
     public boolean hasColumn(String tableName, String columnName) {
         return columns.containsKey(colKey(tableName, columnName));
+    }
+
+    public boolean isJavaBackedEntity() {
+        return fqcn != null && !fqcn.isBlank() && tableType == TableType.ENTITY;
     }
 }

--- a/jinx-processor/src/main/java/org/jinx/handler/EntityHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/EntityHandler.java
@@ -160,6 +160,7 @@ public class EntityHandler {
         return EntityModel.builder()
                 .entityName(entityName)
                 .tableName(tableName)
+                .fqcn(typeElement.getQualifiedName().toString())
                 .isValid(true)
                 .build();
     }

--- a/jinx-processor/src/main/java/org/jinx/handler/EntityHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/EntityHandler.java
@@ -119,10 +119,11 @@ public class EntityHandler {
             if (child == null) break;
             if (!child.isValid()) continue;
 
-            TypeElement te = context.getElementUtils().getTypeElement(child.getEntityName());
+            String childName = child.getFqcn() != null ? child.getFqcn() : child.getEntityName();
+            TypeElement te = context.getElementUtils().getTypeElement(childName);
             if (te == null) {
                 context.getMessager().printMessage(Diagnostic.Kind.ERROR,
-                        "Deferred processing: cannot resolve TypeElement for " + child.getEntityName() + " – re-queue");
+                        "Deferred processing: cannot resolve TypeElement for " + childName + " – re-queue");
                 context.getDeferredEntities().offer(child);
                 continue;
             }

--- a/jinx-processor/src/main/java/org/jinx/handler/InheritanceHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/InheritanceHandler.java
@@ -29,6 +29,7 @@ public class InheritanceHandler {
                 DiscriminatorColumn discriminatorColumn = typeElement.getAnnotation(DiscriminatorColumn.class);
                 if (discriminatorColumn != null) {
                     ColumnModel dColumn = ColumnModel.builder()
+                            .tableName(entityModel.getTableName())
                             .columnName(discriminatorColumn.name().isEmpty() ? "dtype" : discriminatorColumn.name())
                             .javaType("java.lang.String")
                             .isPrimaryKey(false)
@@ -123,9 +124,9 @@ public class InheritanceHandler {
      */
     private String normalizeType(String javaType) {
         if (javaType == null) return null;
-        
+        String jt = javaType.trim();
         // 기본 타입 정규화
-        return switch (javaType) {
+        return switch (jt) {
             case "java.lang.Boolean" -> "boolean";
             case "java.lang.Byte" -> "byte";
             case "java.lang.Short" -> "short";
@@ -311,7 +312,8 @@ public class InheritanceHandler {
         context.getSchemaModel().getEntities().values().stream()
                 .filter(childCandidate -> !childCandidate.getEntityName().equals(parentEntity.getEntityName()))
                 .forEach(childEntity -> {
-                    TypeElement childType = context.getElementUtils().getTypeElement(childEntity.getEntityName());
+                    String fqcn = childEntity.getFqcn() == null ? childEntity.getEntityName() : childEntity.getFqcn();
+                    TypeElement childType = context.getElementUtils().getTypeElement(fqcn);
                     if (childType != null && context.getTypeUtils().isSubtype(childType.asType(), parentType.asType())) {
                         processSingleTablePerClassChild(childEntity, parentEntity);
                         checkIdentityStrategy(childType, childEntity); // Check children too

--- a/jinx-processor/src/main/java/org/jinx/processor/JpaSqlGeneratorProcessor.java
+++ b/jinx-processor/src/main/java/org/jinx/processor/JpaSqlGeneratorProcessor.java
@@ -135,11 +135,12 @@ public class JpaSqlGeneratorProcessor extends AbstractProcessor {
             // 1. 상속 해석
             for (EntityModel entityModel : context.getSchemaModel().getEntities().values()) {
                 if (!entityModel.isValid()) continue;
-                TypeElement typeElement = context.getElementUtils().getTypeElement(entityModel.getEntityName());
+                String entityName = entityModel.getFqcn() != null ? entityModel.getFqcn() : entityModel.getEntityName();
+                TypeElement typeElement = context.getElementUtils().getTypeElement(entityName);
                 if (typeElement == null) {
                     context.getMessager().printMessage(
                         Diagnostic.Kind.ERROR,
-                        "Cannot resolve TypeElement for entity '" + entityModel.getEntityName() + "'."
+                        "Cannot resolve TypeElement for entity '" + entityName + "'."
                     );
                     entityModel.setValid(false);
                     continue;

--- a/jinx-processor/src/test/java/org/jinx/handler/InheritanceHandlerTest.java
+++ b/jinx-processor/src/test/java/org/jinx/handler/InheritanceHandlerTest.java
@@ -1,313 +1,347 @@
-//package org.jinx.handler;
-//
-//import jakarta.persistence.*;
-//import org.jinx.context.ProcessingContext;
-//import org.jinx.model.*;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Nested;
-//import org.junit.jupiter.api.Test;
-//import org.mockito.Mockito;
-//
-//import javax.annotation.processing.Messager;
-//import javax.annotation.processing.ProcessingEnvironment;
-//import javax.lang.model.element.Element;
-//import javax.lang.model.element.ElementKind;
-//import javax.lang.model.element.TypeElement;
-//import javax.lang.model.element.VariableElement;
-//import javax.lang.model.type.TypeMirror;
-//import javax.lang.model.util.Elements;
-//import javax.lang.model.util.Types;
-//import javax.tools.Diagnostic;
-//import java.util.List;
-//import java.util.Map;
-//
-//import static com.google.common.truth.Truth.assertThat;
-//import static org.mockito.Mockito.*;
-//
-//class InheritanceHandlerTest {
-//
-//    private ProcessingContext mockContext(SchemaModel model,
-//                                          Elements elements,
-//                                          Types types,
-//                                          Messager messager) {
-//
-//        ProcessingEnvironment env = mock(ProcessingEnvironment.class);
-//        when(env.getElementUtils()).thenReturn(elements);
-//        when(env.getTypeUtils()).thenReturn(types);
-//        when(env.getMessager()).thenReturn(messager);
-//        return new ProcessingContext(env, model);
-//    }
-//
-//    @Test
-//    void singleTable_addsDiscriminatorColumn() {
-//        EntityModel parent = EntityModel.builder()
-//                .entityName("com.example.Parent")
-//                .tableName("Parent")
-//                .build();
-//
-//        SchemaModel schema = SchemaModel.builder()
-//                .entities(Map.of(parent.getEntityName(), parent))
-//                .build();
-//
-//        TypeElement parentType = mock(TypeElement.class);
-//
-//        Inheritance inh = mock(Inheritance.class);
-//        when(inh.strategy()).thenReturn(InheritanceType.SINGLE_TABLE);
-//        when(parentType.getAnnotation(Inheritance.class)).thenReturn(inh);
-//
-//        DiscriminatorColumn disc = mock(DiscriminatorColumn.class);
-//        when(disc.name()).thenReturn("dtype");
-//        when(parentType.getAnnotation(DiscriminatorColumn.class)).thenReturn(disc);
-//
-//        ProcessingContext ctx = mockContext(schema,
-//                mock(Elements.class),
-//                mock(Types.class),
-//                mock(Messager.class));
-//
-//        InheritanceHandler handler = new InheritanceHandler(ctx);
-//
-//        handler.resolveInheritance(parentType, parent);
-//
-//        assertThat(parent.getInheritance()).isEqualTo(InheritanceType.SINGLE_TABLE);
-//        assertThat(parent.getColumns()).containsKey("dtype");
-//    }
-//
-//    @Test
-//    void joinedInheritance_populatesChildEntity() {
-//        ColumnModel idCol = ColumnModel.builder()
-//                .columnName("id")
-//                .javaType("java.lang.Long")
-//                .isPrimaryKey(true)
-//                .build();
-//
-//        EntityModel parent = EntityModel.builder()
-//                .entityName("com.example.Parent")
-//                .tableName("Parent")
-//                .columns(Map.of("id", idCol))
-//                .build();
-//
-//        EntityModel child = EntityModel.builder()
-//                .entityName("com.example.Child")
-//                .tableName("Child")
-//                .build();
-//
-//        SchemaModel schema = SchemaModel.builder()
-//                .entities(Map.of(
-//                        parent.getEntityName(), parent,
-//                        child.getEntityName(), child))
-//                .build();
-//
-//        TypeElement parentType = mock(TypeElement.class);
-//        TypeElement childType  = mock(TypeElement.class);
-//        TypeMirror  parentTm   = mock(TypeMirror.class);
-//        TypeMirror  childTm    = mock(TypeMirror.class);
-//
-//        when(parentType.asType()).thenReturn(parentTm);
-//        when(childType.asType()).thenReturn(childTm);
-//
-//        Inheritance inh = mock(Inheritance.class);
-//        when(inh.strategy()).thenReturn(InheritanceType.JOINED);
-//        when(parentType.getAnnotation(Inheritance.class)).thenReturn(inh);
-//
-//        Elements elements = mock(Elements.class);
-//        when(elements.getTypeElement("com.example.Child")).thenReturn(childType);
-//        when(elements.getTypeElement("com.example.Parent")).thenReturn(parentType);
-//
-//        Types types = mock(Types.class);
-//        when(types.isSubtype(childTm, parentTm)).thenReturn(true);
-//
-//        ProcessingContext ctx = mockContext(schema, elements, types, mock(Messager.class));
-//        InheritanceHandler handler = new InheritanceHandler(ctx);
-//
-//        handler.resolveInheritance(parentType, parent);
-//
-//        assertThat(child.getInheritance()).isEqualTo(InheritanceType.JOINED);
-//        assertThat(child.getParentEntity()).isEqualTo(parent.getEntityName());
-//        assertThat(child.getColumns()).containsKey("id");
-//        assertThat(child.getColumns().get("id").isPrimaryKey()).isTrue();
-//        assertThat(child.getRelationships()).isNotEmpty();
-//        RelationshipModel rel = child.getRelationships().get(0);
-//        assertThat(rel.getReferencedTable()).isEqualTo("Parent");
-//        assertThat(rel.getColumn()).isEqualTo("id");
-//    }
-//
-//    @Test
-//    void singleTable_duplicateDiscriminatorColumnShouldTriggerError() {
-//        EntityModel parent = EntityModel.builder()
-//                .entityName("com.example.Parent")
-//                .tableName("Parent")
-//                .columns(Map.of("dtype", ColumnModel.builder().columnName("dtype").build()))
-//                .build();
-//
-//        SchemaModel schema = SchemaModel.builder()
-//                .entities(Map.of(parent.getEntityName(), parent))
-//                .build();
-//
-//        TypeElement parentType = mock(TypeElement.class);
-//
-//        Inheritance inh = mock(Inheritance.class);
-//        when(inh.strategy()).thenReturn(InheritanceType.SINGLE_TABLE);
-//        when(parentType.getAnnotation(Inheritance.class)).thenReturn(inh);
-//
-//        DiscriminatorColumn disc = mock(DiscriminatorColumn.class);
-//        when(disc.name()).thenReturn("dtype");
-//        when(parentType.getAnnotation(DiscriminatorColumn.class)).thenReturn(disc);
-//
-//        Messager messager = mock(Messager.class);
-//
-//        ProcessingContext ctx = mockContext(schema, mock(Elements.class), mock(Types.class), messager);
-//        InheritanceHandler handler = new InheritanceHandler(ctx);
-//
-//        handler.resolveInheritance(parentType, parent);
-//
-//        assertThat(parent.isValid()).isFalse();
-//    }
-//
-//    @Nested
-//    @DisplayName("추가 커버리지 테스트")
-//    class CoverageIncreaseTests {
-//
-//        @Test
-//        @DisplayName("[SINGLE_TABLE] @DiscriminatorValue 애너테이션을 처리해야 한다")
-//        void singleTable_shouldProcessDiscriminatorValue() {
-//            // Arrange
-//            EntityModel parent = EntityModel.builder().entityName("com.example.Parent").build();
-//            TypeElement parentType = mock(TypeElement.class);
-//            Inheritance inh = mock(Inheritance.class);
-//            when(inh.strategy()).thenReturn(InheritanceType.SINGLE_TABLE);
-//            when(parentType.getAnnotation(Inheritance.class)).thenReturn(inh);
-//
-//            DiscriminatorValue dv = mock(DiscriminatorValue.class);
-//            when(dv.value()).thenReturn("PARENT_ENTITY");
-//            when(parentType.getAnnotation(DiscriminatorValue.class)).thenReturn(dv);
-//
-//            ProcessingContext ctx = mockContext(null, null, null, null);
-//            InheritanceHandler handler = new InheritanceHandler(ctx);
-//
-//            // Act
-//            handler.resolveInheritance(parentType, parent);
-//
-//            // Assert
-//            assertThat(parent.getDiscriminatorValue()).isEqualTo("PARENT_ENTITY");
-//        }
-//
-//        @Test
-//        @DisplayName("[JOINED] 부모 엔티티에 PK가 없으면 에러 처리되어야 한다")
-//        void joined_shouldInvalidateParent_whenNoPrimaryKey() {
-//            // Arrange
-//            EntityModel parent = EntityModel.builder().entityName("com.example.Parent").build(); // PK 컬럼 없음
-//            TypeElement parentType = mock(TypeElement.class);
-//            Inheritance inh = mock(Inheritance.class);
-//            when(inh.strategy()).thenReturn(InheritanceType.JOINED);
-//            when(parentType.getAnnotation(Inheritance.class)).thenReturn(inh);
-//
-//            ProcessingContext ctx = mockContext(SchemaModel.builder().build(), null, null, null);
-//            InheritanceHandler handler = new InheritanceHandler(ctx);
-//
-//            // Act
-//            handler.resolveInheritance(parentType, parent);
-//
-//            // Assert
-//            assertThat(parent.isValid()).isFalse();
-//        }
-//
-//        @Test
-//        @DisplayName("[JOINED] 자식 엔티티에 중복된 PK 컬럼이 있으면 에러 처리되어야 한다")
-//        void joined_shouldInvalidateChild_withDuplicatePkColumn() {
-//            // Arrange
-//            ColumnModel idCol = ColumnModel.builder().columnName("id").javaType("long").isPrimaryKey(true).build();
-//            EntityModel parent = EntityModel.builder().entityName("com.example.Parent").tableName("Parent").columns(Map.of("id", idCol)).build();
-//            EntityModel child = EntityModel.builder().entityName("com.example.Child").tableName("Child").columns(Map.of("id", mock(ColumnModel.class))).build(); // 중복 컬럼
-//            SchemaModel schema = SchemaModel.builder().entities(Map.of(parent.getEntityName(), parent, child.getEntityName(), child)).build();
-//
-//            TypeElement parentType = mock(TypeElement.class);
-//            TypeElement childType = mock(TypeElement.class);
-//            when(parentType.asType()).thenReturn(mock(TypeMirror.class));
-//            when(childType.asType()).thenReturn(mock(TypeMirror.class));
-//
-//            Inheritance inh = mock(Inheritance.class);
-//            when(inh.strategy()).thenReturn(InheritanceType.JOINED);
-//            when(parentType.getAnnotation(Inheritance.class)).thenReturn(inh);
-//
-//            Elements elements = mock(Elements.class);
-//            when(elements.getTypeElement("com.example.Child")).thenReturn(childType);
-//            Types types = mock(Types.class);
-//            when(types.isSubtype(any(), any())).thenReturn(true);
-//            Messager messager = mock(Messager.class);
-//            ProcessingContext ctx = mockContext(schema, elements, types, messager);
-//            InheritanceHandler handler = new InheritanceHandler(ctx);
-//
-//            // Act
-//            handler.resolveInheritance(parentType, parent);
-//
-//            // Assert
-//            assertThat(child.isValid()).isFalse();
-//            verify(messager).printMessage(eq(Diagnostic.Kind.ERROR), anyString());
-//        }
-//
-//        @Test
-//        @DisplayName("[TABLE_PER_CLASS] 부모 컬럼을 자식 엔티티에 복사해야 한다")
-//        void tablePerClass_shouldCopyParentColumnsToChild() {
-//            // Arrange
-//            ColumnModel idCol = ColumnModel.builder().columnName("id").javaType("long").isPrimaryKey(true).build();
-//            ColumnModel nameCol = ColumnModel.builder().columnName("name").javaType("String").build();
-//            EntityModel parent = EntityModel.builder().entityName("com.example.Parent").tableName("Parent").columns(Map.of("id", idCol, "name", nameCol)).build();
-//            EntityModel child = EntityModel.builder().entityName("com.example.Child").tableName("Child").build();
-//            SchemaModel schema = SchemaModel.builder().entities(Map.of(parent.getEntityName(), parent, child.getEntityName(), child)).build();
-//
-//            TypeElement parentType = mock(TypeElement.class);
-//            TypeElement childType = mock(TypeElement.class);
-//            when(parentType.asType()).thenReturn(mock(TypeMirror.class));
-//            when(childType.asType()).thenReturn(mock(TypeMirror.class));
-//
-//            Inheritance inh = mock(Inheritance.class);
-//            when(inh.strategy()).thenReturn(InheritanceType.TABLE_PER_CLASS);
-//            when(parentType.getAnnotation(Inheritance.class)).thenReturn(inh);
-//
-//            Elements elements = mock(Elements.class);
-//            when(elements.getTypeElement("com.example.Child")).thenReturn(childType);
-//            Types types = mock(Types.class);
-//            when(types.isSubtype(any(), any())).thenReturn(true);
-//            ProcessingContext ctx = mockContext(schema, elements, types, mock(Messager.class));
-//            InheritanceHandler handler = new InheritanceHandler(ctx);
-//
-//            // Act
-//            handler.resolveInheritance(parentType, parent);
-//
-//            // Assert
-//            assertThat(child.getInheritance()).isEqualTo(InheritanceType.TABLE_PER_CLASS);
-//            assertThat(child.getColumns()).containsKey("id");
-//            assertThat(child.getColumns()).containsKey("name");
-//            assertThat(child.getColumns().get("id").isPrimaryKey()).isTrue();
-//        }
-//
-//        @Test
-//        @DisplayName("[TABLE_PER_CLASS] IDENTITY 전략 사용 시 경고를 출력해야 한다")
-//        void tablePerClass_shouldWarnOnIdentityStrategy() {
-//            // Arrange
-//            EntityModel parent = EntityModel.builder().entityName("com.example.Parent").build();
-//            TypeElement parentType = mock(TypeElement.class);
-//            VariableElement idField = mock(VariableElement.class);
-//            when(idField.getKind()).thenReturn(ElementKind.FIELD);
-//            when(idField.getAnnotation(Id.class)).thenReturn(mock(Id.class));
-//            GeneratedValue gv = mock(GeneratedValue.class);
-//            when(gv.strategy()).thenReturn(GenerationType.IDENTITY);
-//            when(idField.getAnnotation(GeneratedValue.class)).thenReturn(gv);
-//            when(parentType.getEnclosedElements()).thenReturn((List) List.of(idField)); // Raw list for mock
-//
-//            Inheritance inh = mock(Inheritance.class);
-//            when(inh.strategy()).thenReturn(InheritanceType.TABLE_PER_CLASS);
-//            when(parentType.getAnnotation(Inheritance.class)).thenReturn(inh);
-//
-//            Messager messager = mock(Messager.class);
-//            ProcessingContext ctx = mockContext(SchemaModel.builder().build(), null, null, messager);
-//            InheritanceHandler handler = new InheritanceHandler(ctx);
-//
-//            // Act
-//            handler.resolveInheritance(parentType, parent);
-//
-//            // Assert
-//            verify(messager).printMessage(eq(Diagnostic.Kind.WARNING), anyString(), eq(idField));
-//        }
-//    }
-//}
+package org.jinx.handler;
+
+import jakarta.persistence.*;
+import org.jinx.context.ProcessingContext;
+import org.jinx.model.*;
+import org.jinx.testing.mother.EntityModelMother;
+import org.jinx.testing.util.AnnotationProxies;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.annotation.processing.Messager;
+import javax.lang.model.element.*;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+import javax.tools.Diagnostic;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class InheritanceHandlerTest {
+
+    @Mock private ProcessingContext context;
+    @Mock private Messager messager;
+    @Mock private Elements elements;
+    @Mock private Types types;
+    @Mock private SchemaModel schemaModel;
+
+    private InheritanceHandler handler;
+    private Map<String, EntityModel> entities;
+
+    @BeforeEach
+    void setUp() {
+        handler = new InheritanceHandler(context);
+        when(context.getMessager()).thenReturn(messager);
+        lenient().when(context.getElementUtils()).thenReturn(elements);
+        lenient().when(context.getTypeUtils()).thenReturn(types);
+        lenient().when(context.getSchemaModel()).thenReturn(schemaModel);
+        entities = new HashMap<>();
+        lenient().when(schemaModel.getEntities()).thenReturn(entities);
+    }
+
+    // ---------- SINGLE_TABLE ----------
+
+    @Test
+    @DisplayName("SINGLE_TABLE: DiscriminatorColumn/Value 반영 및 중복 방지")
+    void singleTable_discriminator_added_and_duplicate_guard() {
+        // === parentType 명시적 모킹 ===
+        TypeElement parentType = mock(TypeElement.class);
+        Name parentName = mock(Name.class);
+        lenient().when(parentName.toString()).thenReturn("com.example.Parent");
+        lenient().when(parentType.getQualifiedName()).thenReturn(parentName);
+
+        // annotations
+        when(parentType.getAnnotation(Inheritance.class))
+                .thenReturn(AnnotationProxies.inheritance(InheritanceType.SINGLE_TABLE));
+        when(parentType.getAnnotation(DiscriminatorColumn.class))
+                .thenReturn(AnnotationProxies.discriminatorColumn("dtype_col"));
+        when(parentType.getAnnotation(DiscriminatorValue.class))
+                .thenReturn(AnnotationProxies.discriminatorValue("P"));
+
+        // model
+        EntityModel parent = EntityModelMother.javaEntity("com.example.Parent", "parent");
+
+        // act
+        handler.resolveInheritance(parentType, parent);
+
+        // assert
+        assertEquals(InheritanceType.SINGLE_TABLE, parent.getInheritance());
+        ColumnModel d = parent.findColumn(null, "dtype_col");
+        assertNotNull(d);
+        assertEquals("java.lang.String", d.getJavaType());
+        assertFalse(d.isNullable());
+        assertEquals("P", parent.getDiscriminatorValue());
+
+        // duplicate guard: 같은 이름 컬럼이 이미 있으면 에러 + invalid
+        EntityModel parent2 = EntityModelMother.javaEntity("com.example.Parent2", "parent2");
+        parent2.putColumn(ColumnModel.builder().tableName("parent2").columnName("dtype").javaType("java.lang.String").build());
+
+        // === parentType2 명시적 모킹 ===
+        TypeElement parentType2 = mock(TypeElement.class);
+        Name parentName2 = mock(Name.class);
+        lenient().when(parentName2.toString()).thenReturn("com.example.Parent2");
+        lenient().when(parentType2.getQualifiedName()).thenReturn(parentName2);
+        when(parentType2.getAnnotation(Inheritance.class))
+                .thenReturn(AnnotationProxies.inheritance(InheritanceType.SINGLE_TABLE));
+        when(parentType2.getAnnotation(DiscriminatorColumn.class))
+                .thenReturn(AnnotationProxies.discriminatorColumn("dtype")); // 이미 존재
+
+        handler.resolveInheritance(parentType2, parent2);
+
+        assertFalse(parent2.isValid());
+        verify(messager, atLeastOnce()).printMessage(eq(Diagnostic.Kind.ERROR), contains("Duplicate column name 'dtype'"), any());
+    }
+
+    // ---------- JOINED ----------
+
+    @Test
+    @DisplayName("JOINED: 부모 PK 기준으로 자식 FK(PK) 컬럼 생성 + 관계(FK) 생성")
+    void joined_child_pk_and_fk_relation_created() {
+        // parent & child 엔티티 모델 준비
+        EntityModel parent = EntityModelMother.javaEntityWithPkIdLong("com.example.Parent", "parent");
+        entities.put(parent.getEntityName(), parent);
+        EntityModel child = EntityModelMother.javaEntity("com.example.Child", "child");
+        entities.put(child.getEntityName(), child);
+
+        // === TypeElement 및 관련 객체들 명시적 모킹 ===
+        TypeElement parentType = mock(TypeElement.class);
+        TypeMirror parentTypeMirror = mock(TypeMirror.class);
+        Name parentName = mock(Name.class);
+        lenient().when(parentName.toString()).thenReturn("com.example.Parent");
+        lenient().when(parentType.getQualifiedName()).thenReturn(parentName);
+        when(parentType.asType()).thenReturn(parentTypeMirror);
+        when(parentType.getAnnotation(Inheritance.class))
+                .thenReturn(AnnotationProxies.inheritance(InheritanceType.JOINED));
+
+        TypeElement childType = mock(TypeElement.class);
+        TypeMirror childTypeMirror = mock(TypeMirror.class);
+        when(childType.asType()).thenReturn(childTypeMirror);
+        when(elements.getTypeElement("com.example.Child")).thenReturn(childType);
+        when(types.isSubtype(childTypeMirror, parentTypeMirror)).thenReturn(true);
+
+        // PK 조회 모킹
+        when(context.findAllPrimaryKeyColumns(parent))
+                .thenReturn(List.of(parent.findColumn("parent","id")));
+
+        // Naming 모킹
+        var naming = mock(org.jinx.context.Naming.class);
+        when(context.getNaming()).thenReturn(naming);
+        when(naming.fkName(eq("child"), eq(List.of("id")), eq("parent"), eq(List.of("id"))))
+                .thenReturn("FK_child_parent");
+
+        // act
+        handler.resolveInheritance(parentType, parent);
+
+        // assert: child에 id(=PK, not null) 추가
+        ColumnModel id = child.findColumn("child", "id");
+        assertNotNull(id, "child.id must be created");
+        assertTrue(id.isPrimaryKey());
+        assertFalse(id.isNullable());
+        assertEquals("java.lang.Long", id.getJavaType());
+
+        // 관계 생성
+        RelationshipModel fk = child.getRelationships().get("FK_child_parent");
+        assertNotNull(fk);
+        assertEquals(RelationshipType.JOINED_INHERITANCE, fk.getType());
+        assertEquals("child", fk.getTableName());
+        assertEquals(List.of("id"), fk.getColumns());
+        assertEquals("parent", fk.getReferencedTable());
+        assertEquals(List.of("id"), fk.getReferencedColumns());
+
+        assertEquals(InheritanceType.JOINED, child.getInheritance());
+        assertEquals(parent.getEntityName(), child.getParentEntity());
+    }
+
+    @Test
+    @DisplayName("JOINED: @PrimaryKeyJoinColumns 개수 불일치 → IllegalState + child invalid")
+    void joined_pkjoin_size_mismatch_marks_child_invalid() {
+        EntityModel parent = EntityModelMother.javaEntityWithPkIdLong("com.example.Parent", "parent");
+        entities.put(parent.getEntityName(), parent);
+        EntityModel child = EntityModelMother.javaEntity("com.example.Child", "child");
+        entities.put(child.getEntityName(), child);
+
+        // === TypeElement 명시적 모킹 ===
+        TypeElement parentType = mock(TypeElement.class);
+        TypeMirror parentTypeMirror = mock(TypeMirror.class);
+        Name parentName = mock(Name.class);
+        lenient().when(parentName.toString()).thenReturn("com.example.Parent");
+        lenient().when(parentType.getQualifiedName()).thenReturn(parentName);
+        when(parentType.asType()).thenReturn(parentTypeMirror);
+        when(parentType.getAnnotation(Inheritance.class))
+                .thenReturn(AnnotationProxies.inheritance(InheritanceType.JOINED));
+
+        TypeElement childType = mock(TypeElement.class);
+        TypeMirror childTypeMirror = mock(TypeMirror.class);
+        when(childType.asType()).thenReturn(childTypeMirror);
+        when(elements.getTypeElement("com.example.Child")).thenReturn(childType);
+        when(types.isSubtype(childTypeMirror, parentTypeMirror)).thenReturn(true);
+
+        // parent PK 1개 모킹
+        when(context.findAllPrimaryKeyColumns(parent))
+                .thenReturn(List.of(parent.findColumn("parent","id")));
+
+        // child에 @PrimaryKeyJoinColumns 2개(불일치) 설정
+        PrimaryKeyJoinColumn p1 = AnnotationProxies.pkJoin("cid1", "id");
+        PrimaryKeyJoinColumn p2 = AnnotationProxies.pkJoin("cid2", "id");
+        when(childType.getAnnotation(PrimaryKeyJoinColumns.class))
+                .thenReturn(AnnotationProxies.pkJoins(p1, p2));
+
+        // act
+        handler.resolveInheritance(parentType, parent);
+
+        // assert: child invalid, 컬럼 미커밋
+        assertFalse(child.isValid());
+        assertNull(child.findColumn("child", "cid1"));
+        assertTrue(child.getRelationships().isEmpty());
+        verify(messager, atLeastOnce()).printMessage(eq(Diagnostic.Kind.ERROR), contains("PK mapping mismatch"));
+    }
+
+    @Test
+    @DisplayName("JOINED: 자식에 동일명 컬럼이 있으나 타입/PK/NULL 조건 불일치 → 에러 후 미커밋")
+    void joined_existing_child_column_mismatch() {
+        EntityModel parent = EntityModelMother.javaEntityWithPkIdLong("com.example.Parent", "parent");
+        entities.put(parent.getEntityName(), parent);
+
+        EntityModel child = EntityModelMother.javaEntity("com.example.Child", "child");
+        child.putColumn(ColumnModel.builder() // child에 id 컬럼이 이미 존재하지만 nullable=true로 잘못 선언
+                .tableName("child").columnName("id").javaType("java.lang.Long")
+                .isPrimaryKey(false).isNullable(true).build());
+        entities.put(child.getEntityName(), child);
+
+        // === TypeElement 명시적 모킹 ===
+        TypeElement parentType = mock(TypeElement.class);
+        TypeMirror parentTypeMirror = mock(TypeMirror.class);
+        Name parentName = mock(Name.class);
+        lenient().when(parentName.toString()).thenReturn("com.example.Parent");
+        lenient().when(parentType.getQualifiedName()).thenReturn(parentName);
+        when(parentType.asType()).thenReturn(parentTypeMirror);
+        when(parentType.getAnnotation(Inheritance.class))
+                .thenReturn(AnnotationProxies.inheritance(InheritanceType.JOINED));
+
+        TypeElement childType = mock(TypeElement.class);
+        TypeMirror childTypeMirror = mock(TypeMirror.class);
+        when(childType.asType()).thenReturn(childTypeMirror);
+        when(elements.getTypeElement("com.example.Child")).thenReturn(childType);
+        when(types.isSubtype(childTypeMirror, parentTypeMirror)).thenReturn(true);
+        when(childType.getAnnotation(PrimaryKeyJoinColumn.class)).thenReturn(null);
+        when(childType.getAnnotation(PrimaryKeyJoinColumns.class)).thenReturn(null);
+
+        when(context.findAllPrimaryKeyColumns(parent))
+                .thenReturn(List.of(parent.findColumn("parent","id")));
+
+        // act
+        handler.resolveInheritance(parentType, parent);
+
+        // 먼저 기본 FK 생성 WARNING 찍히는지
+        verify(messager, atLeastOnce()).printMessage(
+                eq(Diagnostic.Kind.WARNING),
+                contains("creating a default foreign key"),
+                eq(childType)
+        );
+
+        // 컬럼 조건 불일치 ERROR 찍히는지 (3-인자)
+        verify(messager, atLeastOnce()).printMessage(
+                eq(Diagnostic.Kind.ERROR),
+                contains("JOINED column mismatch"),
+                eq(childType)
+        );
+
+        // assert: child invalid, 관계 없음, 컬럼 그대로(수정 X)
+        assertFalse(child.isValid());
+        assertTrue(child.getRelationships().isEmpty());
+        ColumnModel still = child.findColumn("child","id");
+        assertNotNull(still);
+        assertTrue(still.isNullable());
+        assertFalse(still.isPrimaryKey());
+    }
+
+    // ---------- TABLE_PER_CLASS ----------
+
+    @Test
+    @DisplayName("TABLE_PER_CLASS: 부모 컬럼/제약 복제 + IDENTITY 경고 출력")
+    void tpc_copies_columns_and_constraints_and_warns_identity() {
+        // parent with columns & constraint
+        EntityModel parent = EntityModelMother.javaEntity("com.example.Parent", "parent");
+        parent.putColumn(ColumnModel.builder()
+                .tableName("parent").columnName("id").javaType("java.lang.Long")
+                .isPrimaryKey(true).isNullable(false).build());
+        parent.putColumn(ColumnModel.builder()
+                .tableName("parent").columnName("name").javaType("java.lang.String")
+                .isPrimaryKey(false).isNullable(true).build());
+        parent.getConstraints().put("UK_parent_name", ConstraintModel.builder()
+                .name("UK_parent_name").type(ConstraintType.UNIQUE)
+                .columns(new ArrayList<>(List.of("name")))
+                .build());
+        entities.put(parent.getEntityName(), parent);
+
+        EntityModel child = EntityModelMother.javaEntity("com.example.Child", "child");
+        entities.put(child.getEntityName(), child);
+
+        // === TypeElement 명시적 모킹 ===
+        TypeElement parentType = mock(TypeElement.class);
+        TypeMirror parentTypeMirror = mock(TypeMirror.class);
+        Name parentName = mock(Name.class);
+        lenient().when(parentName.toString()).thenReturn("com.example.Parent");
+        lenient().when(parentType.asType()).thenReturn(parentTypeMirror);
+        when(parentType.getAnnotation(Inheritance.class))
+                .thenReturn(AnnotationProxies.inheritance(InheritanceType.TABLE_PER_CLASS));
+
+        TypeElement childType = mock(TypeElement.class);
+        TypeMirror childTypeMirror = mock(TypeMirror.class);
+        when(childType.asType()).thenReturn(childTypeMirror);
+        when(elements.getTypeElement("com.example.Child")).thenReturn(childType);
+        when(types.isSubtype(childTypeMirror, parentTypeMirror)).thenReturn(true);
+
+        // child 필드에 ID + GeneratedValue(IDENTITY) -> WARNING 기대
+        VariableElement idField = mock(VariableElement.class);
+        when(idField.getKind()).thenReturn(ElementKind.FIELD);
+        when(idField.getSimpleName()).thenReturn(NameStub.of("id"));
+        when(idField.getAnnotation(Id.class)).thenReturn(mock(Id.class));
+        lenient().when(idField.getAnnotation(EmbeddedId.class)).thenReturn(null);
+        lenient().when(idField.getAnnotation(GeneratedValue.class)).thenReturn(AnnotationProxies.generated(GenerationType.IDENTITY));
+        doReturn(List.of(idField)).when(childType).getEnclosedElements();
+
+        // act
+        handler.resolveInheritance(parentType, parent);
+
+        // assert: child가 부모 컬럼/제약 복제 받음
+        ColumnModel cId = child.findColumn("child", "id");
+        ColumnModel cName = child.findColumn("child", "name");
+        assertNotNull(cId);
+        assertNotNull(cName);
+        assertEquals("child", cId.getTableName());
+        assertEquals("child", cName.getTableName());
+        assertTrue(cId.isPrimaryKey());
+        assertFalse(cId.isNullable());
+        assertTrue(child.getConstraints().containsKey("UK_parent_name"));
+
+        // WARNING 출력 확인
+        verify(messager, atLeastOnce()).printMessage(eq(Diagnostic.Kind.WARNING), contains("IDENTITY"), eq(idField));
+        assertEquals(InheritanceType.TABLE_PER_CLASS, child.getInheritance());
+        assertEquals(parent.getEntityName(), child.getParentEntity());
+    }
+
+    // ---- helpers ----
+
+    /** Name mocking helper (간단한 CharSequence 스텁) */
+    static final class NameStub implements Name {
+        private final String v;
+        private NameStub(String v) { this.v = v; }
+        static NameStub of(String v) { return new NameStub(v); }
+        @Override public boolean contentEquals(CharSequence cs) { return v.contentEquals(cs); }
+        @Override public int length() { return v.length(); }
+        @Override public char charAt(int index) { return v.charAt(index); }
+        @Override public CharSequence subSequence(int start, int end) { return v.subSequence(start, end); }
+        @Override public String toString() { return v; }
+    }
+}

--- a/jinx-processor/src/test/java/org/jinx/testing/mother/EntityModelMother.java
+++ b/jinx-processor/src/test/java/org/jinx/testing/mother/EntityModelMother.java
@@ -5,12 +5,34 @@ import org.jinx.model.EntityModel;
 
 public final class EntityModelMother {
     public static EntityModel usersWithPkIdLong() {
-        EntityModel e = EntityModel.builder().entityName("User").tableName("users").build();
+        EntityModel e = EntityModel.builder().entityName("User").tableName("users").fqcn("com.example.User").build();
         e.putColumn(ColumnModel.builder()
                 .tableName("users")
                 .columnName("id")
                 .javaType("java.lang.Long")
                 .isPrimaryKey(true)
+                .build());
+        return e;
+    }
+
+    public static EntityModel javaEntity(String fqcn, String table) {
+        return EntityModel.builder()
+                .entityName(fqcn) // FQCN을 스키마 키로 사용
+                .fqcn(fqcn)
+                .tableName(table)
+                .tableType(EntityModel.TableType.ENTITY)
+                .isValid(true)
+                .build();
+    }
+
+    public static EntityModel javaEntityWithPkIdLong(String fqcn, String table) {
+        EntityModel e = javaEntity(fqcn, table);
+        e.putColumn(ColumnModel.builder()
+                .tableName(table)
+                .columnName("id")
+                .javaType("java.lang.Long")
+                .isPrimaryKey(true)
+                .isNullable(false)
                 .build());
         return e;
     }

--- a/jinx-processor/src/test/java/org/jinx/testing/util/AnnotationMocks.java
+++ b/jinx-processor/src/test/java/org/jinx/testing/util/AnnotationMocks.java
@@ -1,9 +1,8 @@
 package org.jinx.testing.util;
 
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OrderColumn;
+import jakarta.persistence.*;
 import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 
 import java.lang.annotation.Annotation;
 

--- a/jinx-processor/src/test/java/org/jinx/testing/util/AnnotationProxies.java
+++ b/jinx-processor/src/test/java/org/jinx/testing/util/AnnotationProxies.java
@@ -1,0 +1,134 @@
+package org.jinx.testing.util;
+
+import jakarta.persistence.*;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.*;
+import java.util.*;
+
+public final class AnnotationProxies {
+    private AnnotationProxies() {}
+
+    // 공용 프록시 팩토리
+    @SuppressWarnings("unchecked")
+    public static <A extends Annotation> A of(Class<A> type, Map<String, Object> members) {
+        InvocationHandler h = new AnnotationIH(type, members);
+        return (A) Proxy.newProxyInstance(
+                type.getClassLoader(),
+                new Class<?>[]{type},
+                h
+        );
+    }
+
+    // 개별 편의 메서드들
+    public static Inheritance inheritance(InheritanceType strategy) {
+        return of(Inheritance.class, Map.of("strategy", strategy));
+    }
+
+    public static DiscriminatorColumn discriminatorColumn(String name) {
+        return of(DiscriminatorColumn.class, Map.of("name", name == null ? "" : name));
+    }
+
+    public static DiscriminatorValue discriminatorValue(String value) {
+        return of(DiscriminatorValue.class, Map.of("value", value));
+    }
+
+    public static PrimaryKeyJoinColumn pkJoin(String name, String referenced) {
+        return of(PrimaryKeyJoinColumn.class, Map.of(
+                "name", name == null ? "" : name,
+                "referencedColumnName", referenced == null ? "" : referenced
+        ));
+    }
+
+    public static PrimaryKeyJoinColumns pkJoins(PrimaryKeyJoinColumn... items) {
+        return of(PrimaryKeyJoinColumns.class, Map.of("value", items));
+    }
+
+    public static GeneratedValue generated(GenerationType strategy) {
+        return of(GeneratedValue.class, Map.of("strategy", strategy));
+    }
+
+    // --- InvocationHandler 구현: annotation 규약 준수 ---
+    private static final class AnnotationIH implements InvocationHandler {
+        private final Class<? extends Annotation> type;
+        private final Map<String, Object> members;
+
+        AnnotationIH(Class<? extends Annotation> type, Map<String, Object> members) {
+            this.type = type;
+            this.members = new HashMap<>(members);
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            String name = method.getName();
+            if (name.equals("annotationType") && method.getParameterCount() == 0) {
+                return type;
+            }
+            if (members.containsKey(name) && method.getParameterCount() == 0) {
+                return members.get(name);
+            }
+            if (name.equals("toString") && method.getParameterCount() == 0) {
+                return "@" + type.getName() + members.toString();
+            }
+            if (name.equals("hashCode") && method.getParameterCount() == 0) {
+                return annotationHashCode();
+            }
+            if (name.equals("equals") && method.getParameterCount() == 1) {
+                return annotationEquals(args[0]);
+            }
+            // 디폴트 멤버 값이 있는 경우 처리
+            Object def = defaultValue(method);
+            if (def != null && method.getParameterCount() == 0) {
+                return def;
+            }
+            throw new AbstractMethodError("Unhandled method: " + method);
+        }
+
+        private Object defaultValue(Method m) {
+            return m.getDefaultValue();
+        }
+
+        private boolean annotationEquals(Object other) {
+            if (other == this) return true;
+            if (!(other instanceof Annotation a)) return false;
+            if (!a.annotationType().equals(this.type)) return false;
+
+            for (Method m : type.getDeclaredMethods()) {
+                try {
+                    Object v1 = members.containsKey(m.getName()) ? members.get(m.getName())
+                            : (m.getDefaultValue() != null ? m.getDefaultValue() : null);
+                    Object v2 = m.invoke(a);
+                    if (!Objects.deepEquals(v1, v2)) return false;
+                } catch (Exception e) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private int annotationHashCode() {
+            int result = 0;
+            for (Method m : type.getDeclaredMethods()) {
+                Object v = members.containsKey(m.getName()) ? members.get(m.getName()) : m.getDefaultValue();
+                int nameHash = 127 * m.getName().hashCode();
+                result += nameHash ^ (v == null ? 0 : deepHashCode(v));
+            }
+            return result;
+        }
+
+        private static int deepHashCode(Object value) {
+            if (value == null) return 0;
+            Class<?> c = value.getClass();
+            if (!c.isArray()) return value.hashCode();
+            if (value instanceof Object[]) return Arrays.deepHashCode((Object[]) value);
+            if (value instanceof int[]) return Arrays.hashCode((int[]) value);
+            if (value instanceof long[]) return Arrays.hashCode((long[]) value);
+            if (value instanceof byte[]) return Arrays.hashCode((byte[]) value);
+            if (value instanceof short[]) return Arrays.hashCode((short[]) value);
+            if (value instanceof char[]) return Arrays.hashCode((char[]) value);
+            if (value instanceof boolean[]) return Arrays.hashCode((boolean[]) value);
+            if (value instanceof float[]) return Arrays.hashCode((float[]) value);
+            if (value instanceof double[]) return Arrays.hashCode((double[]) value);
+            return 0;
+        }
+    }
+}

--- a/jinx-processor/src/test/java/org/jinx/testing/util/AnnotationProxies.java
+++ b/jinx-processor/src/test/java/org/jinx/testing/util/AnnotationProxies.java
@@ -97,7 +97,7 @@ public final class AnnotationProxies {
                     Object v1 = members.containsKey(m.getName()) ? members.get(m.getName())
                             : (m.getDefaultValue() != null ? m.getDefaultValue() : null);
                     Object v2 = m.invoke(a);
-                    if (!Objects.deepEquals(v1, v2)) return false;
+                    if (!deepEqualsNormalized(v1, v2)) return false;
                 } catch (Exception e) {
                     return false;
                 }
@@ -113,6 +113,26 @@ public final class AnnotationProxies {
                 result += nameHash ^ (v == null ? 0 : deepHashCode(v));
             }
             return result;
+        }
+
+        private static boolean deepEqualsNormalized(Object a, Object b) {
+            if (a == b) return true;
+            if (a == null || b == null) return false;
+
+            Class<?> ca = a.getClass(), cb = b.getClass();
+            if (ca.isArray() && cb.isArray()) {
+                if (a instanceof Object[] ao && b instanceof Object[] bo) return Arrays.deepEquals(ao, bo);
+                if (a instanceof int[] ai && b instanceof int[] bi) return Arrays.equals(ai, bi);
+                if (a instanceof long[] al && b instanceof long[] bl) return Arrays.equals(al, bl);
+                if (a instanceof short[] as && b instanceof short[] bs) return Arrays.equals(as, bs);
+                if (a instanceof byte[] ab && b instanceof byte[] bb) return Arrays.equals(ab, bb);
+                if (a instanceof char[] ac && b instanceof char[] bc) return Arrays.equals(ac, bc);
+                if (a instanceof boolean[] ab1 && b instanceof boolean[] bb1) return Arrays.equals(ab1, bb1);
+                if (a instanceof float[] af && b instanceof float[] bf) return Arrays.equals(af, bf);
+                if (a instanceof double[] ad && b instanceof double[] bd) return Arrays.equals(ad, bd);
+                return false;
+            }
+            return Objects.equals(a, b);
         }
 
         private static int deepHashCode(Object value) {


### PR DESCRIPTION
# PR: InheritanceHandler 강화 — JOINED/TPC/SINGLE_TABLE 정합성, NPE/중복 가드, 테스트 안정화

## 요약
`InheritanceHandler`의 상속 전략 처리(SINGLE_TABLE/JOINED/TABLE_PER_CLASS)를 전반적으로 강화했습니다.  
검증 로직을 명시화하고, NPE·중복·정합성 이슈를 차단했으며, 테스트를 실제 어노테이션 프록시 기반으로 안정화했습니다.

---

## 변경 내용 (What)
### JOINED
- 부모 PK → 자식 FK(PK) 생성 로직을 **검증 → 커밋** 2단계로 분리
- 자식에 동일명 컬럼이 이미 있을 경우 타입/PK/NULL 조건 미일치 시 **ERROR** 로깅 후 미커밋
- FK 제약명에 대한 **null/blank 및 중복(대소문자 무시) 가드**
- `@PrimaryKeyJoinColumn` 미지정 시 **기본 FK 생성 + WARNING** 안내

### TABLE_PER_CLASS
- 부모 **컬럼/제약 복제** 시 null-safe 복제로 **NPE 방지**
- 복제 컬럼 **tableName 보정**
- 부모/자식 `@GeneratedValue(IDENTITY/AUTO)` 사용 시 **WARNING** 출력

### SINGLE_TABLE
- `@DiscriminatorColumn/@DiscriminatorValue` 반영
- Discriminator 컬럼명 **중복 가드**(중복 시 ERROR + invalid 플래그)

### 공통/모델 정리
- 상속 자식 탐색 시 `EntityModel.isJavaBackedEntity()` 필터 → 컬렉션/조인 테이블 오탐 방지
- `TypeElement` 조회는 **`EntityModel.fqcn`(FQCN)** 사용
- 타입 비교용 `normalizeType` 도입(원시/래퍼/패키지명 차이 흡수)
- `Locale.ROOT` 기반 정규화 적용

---

## 동기 (Why)
- 기존 로직은 중간 단계에서 부분 커밋/오염 위험이 있었고, FK 제약명/컬럼명 중복, 참조 컬렉션 NPE 등이 발생 가능했습니다.
- 엔티티 탐색 시 FQCN 정합성이 보장되지 않아 `TypeElement` 조회 실패 문제가 있었습니다.
- 테스트에서 Mockito 어노테이션 모킹으로 `ClassCastException`이 발생했습니다.

---

## 테스트 (How)
- **AnnotationProxies**: 실제 어노테이션 프록시 생성 유틸 도입 → 모킹 어노테이션 ClassCastException 제거
- **NameStub/EntityModelMother** 확장
- 커버리지:
  - SINGLE_TABLE: Discriminator 추가 + 중복 가드
  - JOINED:
    - 정상: 자식 PK/FK 컬럼 생성 + 관계 생성
    - 오류: `@PrimaryKeyJoinColumns` 개수 불일치 → ERROR + 미커밋
    - 오류: 자식 기존 컬럼의 타입/PK/NULL 불일치 → ERROR + 미커밋
    - 경고: 기본 FK 생성 경고 로그
  - TABLE_PER_CLASS: 컬럼/제약 복제 + IDENTITY 경고 출력 검증

---

## 마이그레이션/주의사항
- **Java 기반 엔티티**(`isJavaBackedEntity=true`)는 `entityName` ↔ 타입 혼동 방지를 위해 `fqcn` 필드에 **FQCN을 반드시 저장**하도록 생성 경로를 정리했습니다.  
  (컬렉션/조인 테이블 등 Java 비백엔드 엔티티에는 해당 없음)

---

## 스크린샷/로그(발췌)
- JOINED mismatch: `JOINED column mismatch ... expected{...} actual{...}`
- JOINED default FK: `Jinx is creating a default foreign key ...`
- TPC IDENTITY: `IDENTITY generation strategy in TABLE_PER_CLASS inheritance may cause duplicate IDs...`

---

## 체크리스트
- [x] 단위 테스트 모두 통과
- [x] NPE/중복 가드 추가
- [x] FQCN 정합성 반영
- [x] FK는 RelationshipHandler 전담(Constraint 복제에서 제외)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - Java 기반 엔티티 식별을 위한 FQCN 지원 및 공개 접근자 추가
  - 테스트용 동적 애노테이션 프록시 유틸리티 및 테스트 엔티티 팩토리 도입
- 버그 수정
  - JOINED 상속 처리 강화: 타입 해석 방어적 처리, FK 제약명 유효성·중복 검사, 조인 매핑 개선
  - TABLE_PER_CLASS 복사 시 널 안전성 및 컬럼/제약 복사 일관성 개선
- 테스트
  - SINGLE_TABLE, JOINED, TABLE_PER_CLASS 전반에 대한 포괄적 단위 테스트 추가 및 재구성
<!-- end of auto-generated comment: release notes by coderabbit.ai -->