### PR TITLE
PR: Support @DiscriminatorColumn defaults & validation in InheritanceHandler

### DIFF
--- a/jinx-core/src/main/java/org/jinx/model/ColumnModel.java
+++ b/jinx-core/src/main/java/org/jinx/model/ColumnModel.java
@@ -57,6 +57,8 @@ public class ColumnModel {
 
     public long getAttributeHash() {
         return Objects.hash(columnName, javaType, length, precision, scale, isNullable, isUnique, defaultValue,
-                temporalType, enumerationType, enumStringMapping, java.util.Arrays.hashCode(enumValues), mapKeyTemporalType, java.util.Arrays.hashCode(mapKeyEnumValues));
+                temporalType, enumerationType, enumStringMapping,
+                java.util.Arrays.hashCode(enumValues), mapKeyTemporalType, java.util.Arrays.hashCode(mapKeyEnumValues),
+                columnKind, discriminatorType, columnDefinition, options);
     }
 }

--- a/jinx-core/src/main/java/org/jinx/model/ColumnModel.java
+++ b/jinx-core/src/main/java/org/jinx/model/ColumnModel.java
@@ -46,6 +46,14 @@ public class ColumnModel {
     @Builder.Default private String mapKeyType = null; // e.g., "entity:fieldName" or null
     @Builder.Default private String[] mapKeyEnumValues = new String[]{}; // For @MapKeyEnumerated
     @Builder.Default private TemporalType mapKeyTemporalType = null; // For @MapKeyTemporal
+    @Builder.Default private ColumnKind columnKind = ColumnKind.NORMAL;
+
+    // Discriminator metadata
+    private jakarta.persistence.DiscriminatorType discriminatorType; // optional
+    private String columnDefinition; // optional
+    private String options; // optional (JPA 3.2)
+
+    public enum ColumnKind { NORMAL, DISCRIMINATOR }
 
     public long getAttributeHash() {
         return Objects.hash(columnName, javaType, length, precision, scale, isNullable, isUnique, defaultValue,

--- a/jinx-core/src/main/java/org/jinx/model/EntityModel.java
+++ b/jinx-core/src/main/java/org/jinx/model/EntityModel.java
@@ -31,7 +31,10 @@ public class EntityModel {
     @Builder.Default private Map<String, RelationshipModel> relationships = new HashMap<>();
     @Builder.Default private List<SecondaryTableModel> secondaryTables = new ArrayList<>();
     @Builder.Default private boolean isValid = true;
+
     @Builder.Default private String discriminatorValue = null;
+
+    public enum ColumnKind { NORMAL, DISCRIMINATOR }
 
     public enum TableType {
         ENTITY, JOIN_TABLE, COLLECTION_TABLE

--- a/jinx-processor/src/main/java/org/jinx/handler/InheritanceHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/InheritanceHandler.java
@@ -26,26 +26,6 @@ public class InheritanceHandler {
         switch (inheritance.strategy()) {
             case SINGLE_TABLE:
                 entityModel.setInheritance(InheritanceType.SINGLE_TABLE);
-                DiscriminatorColumn discriminatorColumn = typeElement.getAnnotation(DiscriminatorColumn.class);
-                if (discriminatorColumn != null) {
-                    ColumnModel dColumn = ColumnModel.builder()
-                            .tableName(entityModel.getTableName())
-                            .columnName(discriminatorColumn.name().isEmpty() ? "dtype" : discriminatorColumn.name())
-                            .javaType("java.lang.String")
-                            .isPrimaryKey(false)
-                            .isNullable(false)
-                            .generationStrategy(GenerationStrategy.NONE)
-                            .build();
-                    if (entityModel.hasColumn(null, dColumn.getColumnName())) {
-                        context.getMessager().printMessage(Diagnostic.Kind.ERROR,
-                                "Duplicate column name '" + dColumn.getColumnName() + "' for discriminator in entity " + entityModel.getEntityName(), typeElement);
-                        entityModel.setValid(false);
-                        return;
-                    }
-                    if (!entityModel.hasColumn(null, dColumn.getColumnName())) {
-                        entityModel.putColumn(dColumn);
-                    }
-                }
                 DiscriminatorValue discriminatorValue = typeElement.getAnnotation(DiscriminatorValue.class);
                 if (discriminatorValue != null) {
                     entityModel.setDiscriminatorValue(discriminatorValue.value());
@@ -61,6 +41,88 @@ public class InheritanceHandler {
                 checkIdentityStrategy(typeElement, entityModel); // Check for IDENTITY strategy
                 break;
         }
+        handleDiscriminator(typeElement, entityModel, inheritance.strategy());
+    }
+
+    private void handleDiscriminator(TypeElement typeElement, EntityModel entityModel, InheritanceType strategy) {
+        DiscriminatorColumn dc = typeElement.getAnnotation(DiscriminatorColumn.class);
+
+        boolean isSingleTable = strategy == InheritanceType.SINGLE_TABLE;
+        boolean isJoined = strategy == InheritanceType.JOINED;
+
+        // SINGLE_TABLE: 없으면 기본 생성, JOINED: 있으면 생성
+        if (dc == null && !isSingleTable) return;
+
+        String rawName = (dc != null && !dc.name().isEmpty()) ? dc.name() : "DTYPE";
+        String name = rawName.trim();
+
+        DiscriminatorType dtype = (dc != null) ? dc.discriminatorType() : DiscriminatorType.STRING;
+        int len = (dc != null) ? dc.length() : 31;
+
+        String columnDef = (dc != null) ? dc.columnDefinition() : "";
+        String options = (dc != null) ? dc.options() : "";
+
+        List<String> errors = new ArrayList<>();
+
+        // 1) columnDefinition vs options 상호배타
+        if (!columnDef.isBlank() && !options.isBlank()) {
+            errors.add("@DiscriminatorColumn: columnDefinition and options cannot be used together");
+        }
+
+        // 2) 중복 컬럼명 체크
+        if (entityModel.hasColumn(null, name)) {
+            errors.add("Duplicate column name '" + name + "' for discriminator in entity " + entityModel.getEntityName());
+        }
+
+        // 3) 길이/타입 유효성
+        if ((dtype == DiscriminatorType.STRING || dtype == DiscriminatorType.CHAR) && len <= 0) {
+            errors.add("Invalid discriminator length: " + len + " (must be > 0)");
+        }
+
+        boolean needCharAdjust = false;
+        if (dtype == DiscriminatorType.CHAR && len != 1) {
+            // 경고 + 자동 보정
+            needCharAdjust = true;
+            len = 1;
+        }
+
+        if (!errors.isEmpty()) {
+            for (String e : errors) {
+                context.getMessager().printMessage(Diagnostic.Kind.ERROR, e, typeElement);
+            }
+            entityModel.setValid(false);
+            return;
+        }
+
+        if (needCharAdjust) {
+            context.getMessager().printMessage(
+                    Diagnostic.Kind.WARNING,
+                    "@DiscriminatorColumn(length) adjusted to 1 for CHAR type",
+                    typeElement
+            );
+        }
+
+        // 타입 매핑
+        String javaType = switch (dtype) {
+            case STRING, CHAR -> "java.lang.String";
+            case INTEGER -> "java.lang.Integer";
+        };
+
+        ColumnModel col = ColumnModel.builder()
+                .tableName(entityModel.getTableName())
+                .columnName(name)
+                .javaType(javaType)
+                .isPrimaryKey(false)
+                .isNullable(false)
+                .generationStrategy(GenerationStrategy.NONE)
+                .columnKind(ColumnModel.ColumnKind.DISCRIMINATOR)
+                .discriminatorType(dtype)
+                .columnDefinition(columnDef.isBlank() ? null : columnDef)
+                .options(options.isBlank() ? null : options)
+                .length((dtype == DiscriminatorType.STRING || dtype == DiscriminatorType.CHAR) ? len : null)
+                .build();
+
+        entityModel.putColumn(col);
     }
 
     private void checkIdentityStrategy(TypeElement typeElement, EntityModel entityModel) {

--- a/jinx-processor/src/main/java/org/jinx/handler/InheritanceHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/InheritanceHandler.java
@@ -107,8 +107,7 @@ public class InheritanceHandler {
             case STRING, CHAR -> "java.lang.String";
             case INTEGER -> "java.lang.Integer";
         };
-
-        ColumnModel col = ColumnModel.builder()
+        ColumnModel.ColumnModelBuilder colb = ColumnModel.builder()
                 .tableName(entityModel.getTableName())
                 .columnName(name)
                 .javaType(javaType)
@@ -118,10 +117,12 @@ public class InheritanceHandler {
                 .columnKind(ColumnModel.ColumnKind.DISCRIMINATOR)
                 .discriminatorType(dtype)
                 .columnDefinition(columnDef.isBlank() ? null : columnDef)
-                .options(options.isBlank() ? null : options)
-                .length((dtype == DiscriminatorType.STRING || dtype == DiscriminatorType.CHAR) ? len : null)
-                .build();
+                .options(options.isBlank() ? null : options);
 
+        if (dtype == DiscriminatorType.STRING || dtype == DiscriminatorType.CHAR) {
+            colb.length(len);
+        }
+        ColumnModel col = colb.build();
         entityModel.putColumn(col);
     }
 

--- a/jinx-processor/src/test/java/org/jinx/handler/InheritanceHandlerDiscriminatorTest.java
+++ b/jinx-processor/src/test/java/org/jinx/handler/InheritanceHandlerDiscriminatorTest.java
@@ -1,0 +1,214 @@
+package org.jinx.handler;
+
+import jakarta.persistence.*;
+import org.jinx.context.ProcessingContext;
+import org.jinx.model.ColumnModel;
+import org.jinx.model.EntityModel;
+import org.jinx.testing.mother.EntityModelMother;
+import org.jinx.testing.util.AnnotationProxies;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.annotation.processing.Messager;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+import javax.tools.Diagnostic;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class InheritanceHandlerDiscriminatorTest {
+
+    @Mock private ProcessingContext context;
+    @Mock private Messager messager;
+    @Mock private Elements elements;
+    @Mock private Types types;
+    @Mock private org.jinx.model.SchemaModel schemaModel;
+
+    private InheritanceHandler handler;
+    private Map<String, EntityModel> entities;
+
+    @BeforeEach
+    void setUp() {
+        handler = new InheritanceHandler(context);
+        lenient().when(context.getMessager()).thenReturn(messager);
+        lenient().when(context.getElementUtils()).thenReturn(elements);
+        lenient().when(context.getTypeUtils()).thenReturn(types);
+        lenient().when(context.getSchemaModel()).thenReturn(schemaModel);
+        entities = new HashMap<>();
+        lenient().when(schemaModel.getEntities()).thenReturn(entities);
+    }
+
+    // ---- helpers ----
+    private TypeElement mockType(String fqcn) {
+        TypeElement te = mock(TypeElement.class);
+        Name qn = mock(Name.class);
+        lenient().when(qn.toString()).thenReturn(fqcn);
+        lenient().when(te.getQualifiedName()).thenReturn(qn);
+        lenient().when(te.asType()).thenReturn(mock(TypeMirror.class));
+        return te;
+    }
+
+    private EntityModel newEntity(String fqcn, String table) {
+        EntityModel em = EntityModelMother.javaEntity(fqcn, table);
+        entities.put(em.getEntityName(), em);
+        return em;
+    }
+
+    private ColumnModel getDisc(EntityModel e, String name) {
+        return e.findColumn(e.getTableName(), name);
+    }
+
+    // === CASES ===
+
+    @Test
+    @DisplayName("SINGLE_TABLE: @DiscriminatorColumn 없으면 기본 DTYPE(String, len=31) 생성")
+    void singleTable_default_created_when_missing_annotation() {
+        TypeElement type = mockType("com.example.St");
+        when(type.getAnnotation(Inheritance.class))
+                .thenReturn(AnnotationProxies.inheritance(InheritanceType.SINGLE_TABLE));
+
+        EntityModel e = newEntity("com.example.St", "st");
+
+        handler.resolveInheritance(type, e);
+
+        ColumnModel col = getDisc(e, "DTYPE");
+        assertNotNull(col);
+        assertEquals("java.lang.String", col.getJavaType());
+        assertFalse(col.isNullable());
+        assertEquals(ColumnModel.ColumnKind.DISCRIMINATOR, col.getColumnKind());
+        assertEquals(DiscriminatorType.STRING, col.getDiscriminatorType());
+        assertEquals(31, col.getLength());
+        assertNull(col.getColumnDefinition());
+        assertNull(col.getOptions());
+    }
+
+    @Test
+    @DisplayName("JOINED: @DiscriminatorColumn 없으면 생성하지 않음")
+    void joined_missing_discriminator_not_created() {
+        TypeElement type = mockType("com.example.J");
+        when(type.getAnnotation(Inheritance.class))
+                .thenReturn(AnnotationProxies.inheritance(InheritanceType.JOINED));
+
+        // JOINED는 자식 탐색이 있어서 빈 엔티티 맵으로 돌려 부수효과 방지
+        lenient().when(schemaModel.getEntities()).thenReturn(new HashMap<>());
+
+        EntityModel e = newEntity("com.example.J", "j");
+        handler.resolveInheritance(type, e);
+
+        assertNull(getDisc(e, "DTYPE"));
+    }
+
+    @Test
+    @DisplayName("JOINED: @DiscriminatorColumn 지정 시 컬럼 생성")
+    void joined_with_discriminator_created() {
+        TypeElement type = mockType("com.example.J2");
+        when(type.getAnnotation(Inheritance.class))
+                .thenReturn(AnnotationProxies.inheritance(InheritanceType.JOINED));
+        when(type.getAnnotation(DiscriminatorColumn.class))
+                .thenReturn(AnnotationProxies.discriminatorColumnFull("DISC", DiscriminatorType.STRING, 20, "", ""));
+
+        // 자식 탐색 방지
+        lenient().when(schemaModel.getEntities()).thenReturn(new HashMap<>());
+
+        EntityModel e = newEntity("com.example.J2", "j2");
+        handler.resolveInheritance(type, e);
+
+        ColumnModel col = getDisc(e, "DISC");
+        assertNotNull(col);
+        assertEquals("java.lang.String", col.getJavaType());
+        assertEquals(20, col.getLength());
+        assertEquals(DiscriminatorType.STRING, col.getDiscriminatorType());
+    }
+
+    @Test
+    @DisplayName("columnDefinition + options 동시 지정 → ERROR & 미생성")
+    void discriminator_columnDef_and_options_both_set_error() {
+        TypeElement type = mockType("com.example.Err");
+        when(type.getAnnotation(Inheritance.class))
+                .thenReturn(AnnotationProxies.inheritance(InheritanceType.SINGLE_TABLE));
+        when(type.getAnnotation(DiscriminatorValue.class)).thenReturn(null);
+        when(type.getAnnotation(DiscriminatorColumn.class))
+                .thenReturn(AnnotationProxies.discriminatorColumnFull(
+                        "DISC", DiscriminatorType.STRING, 20, "varchar(20)", "COLLATE utf8"));
+
+        EntityModel e = newEntity("com.example.Err", "err");
+        handler.resolveInheritance(type, e);
+
+        assertNull(getDisc(e, "DISC"));
+        assertFalse(e.isValid());
+        verify(messager, atLeastOnce())
+                .printMessage(eq(Diagnostic.Kind.ERROR), contains("cannot be used together"), eq(type));
+    }
+
+    @Test
+    @DisplayName("CHAR + length != 1 → WARNING 후 length=1로 보정")
+    void discriminator_char_length_adjusted_with_warning() {
+        TypeElement type = mockType("com.example.Char");
+        when(type.getAnnotation(Inheritance.class))
+                .thenReturn(AnnotationProxies.inheritance(InheritanceType.SINGLE_TABLE));
+        when(type.getAnnotation(DiscriminatorValue.class)).thenReturn(null);
+        when(type.getAnnotation(DiscriminatorColumn.class))
+                .thenReturn(AnnotationProxies.discriminatorColumnFull("C", DiscriminatorType.CHAR, 2, "", ""));
+
+        EntityModel e = newEntity("com.example.Char", "ch");
+        handler.resolveInheritance(type, e);
+
+        ColumnModel col = getDisc(e, "C");
+        assertNotNull(col);
+        assertEquals("java.lang.String", col.getJavaType()); // CHAR도 String 매핑
+        assertEquals(1, col.getLength());
+        assertEquals(DiscriminatorType.CHAR, col.getDiscriminatorType());
+        verify(messager, atLeastOnce())
+                .printMessage(eq(Diagnostic.Kind.WARNING), contains("adjusted to 1"), eq(type));
+    }
+
+    @Test
+    @DisplayName("STRING/CHAR + length <= 0 → ERROR & 미생성")
+    void discriminator_invalid_length_error() {
+        TypeElement type = mockType("com.example.Len");
+        when(type.getAnnotation(Inheritance.class))
+                .thenReturn(AnnotationProxies.inheritance(InheritanceType.SINGLE_TABLE));
+        when(type.getAnnotation(DiscriminatorValue.class)).thenReturn(null);
+        when(type.getAnnotation(DiscriminatorColumn.class))
+                .thenReturn(AnnotationProxies.discriminatorColumnFull("S", DiscriminatorType.STRING, 0, "", ""));
+
+        EntityModel e = newEntity("com.example.Len", "len");
+        handler.resolveInheritance(type, e);
+
+        assertNull(getDisc(e, "S"));
+        assertFalse(e.isValid());
+        verify(messager, atLeastOnce())
+                .printMessage(eq(Diagnostic.Kind.ERROR), contains("Invalid discriminator length"), eq(type));
+    }
+
+    @Test
+    @DisplayName("중복 컬럼명(DTYPE 등) → ERROR & 미생성")
+    void discriminator_duplicate_name_error() {
+        TypeElement type = mockType("com.example.Dup");
+        when(type.getAnnotation(Inheritance.class))
+                .thenReturn(AnnotationProxies.inheritance(InheritanceType.SINGLE_TABLE));
+        // 애노테이션 없이 기본 DTYPE을 만들려고 할 때, 동일명 컬럼을 미리 심어둔다
+        EntityModel e = newEntity("com.example.Dup", "dup");
+        e.putColumn(ColumnModel.builder()
+                .tableName("dup").columnName("DTYPE").javaType("java.lang.String").isNullable(false).build());
+
+        handler.resolveInheritance(type, e);
+
+        // 이미 존재 → 에러, invalid
+        verify(messager, atLeastOnce())
+                .printMessage(eq(Diagnostic.Kind.ERROR), contains("Duplicate column name 'DTYPE'"), eq(type));
+        assertFalse(e.isValid());
+    }
+}

--- a/jinx-processor/src/test/java/org/jinx/testing/util/AnnotationProxies.java
+++ b/jinx-processor/src/test/java/org/jinx/testing/util/AnnotationProxies.java
@@ -151,4 +151,31 @@ public final class AnnotationProxies {
             return 0;
         }
     }
+
+    public static DiscriminatorColumn discriminatorColumnFull(
+            String name,
+            DiscriminatorType type,
+            int length,
+            String columnDefinition,
+            String options
+    ) {
+        class H implements InvocationHandler {
+            @Override public Object invoke(Object proxy, Method method, Object[] args) {
+                return switch (method.getName()) {
+                    case "annotationType" -> DiscriminatorColumn.class;
+                    case "name" -> name;
+                    case "discriminatorType" -> type;
+                    case "length" -> length;
+                    case "columnDefinition" -> columnDefinition;
+                    case "options" -> options;
+                    default -> method.getDefaultValue();
+                };
+            }
+        }
+        return (DiscriminatorColumn) Proxy.newProxyInstance(
+                DiscriminatorColumn.class.getClassLoader(),
+                new Class[]{DiscriminatorColumn.class},
+                new H()
+        );
+    }
 }


### PR DESCRIPTION
# PR: Support @DiscriminatorColumn defaults & validation in InheritanceHandler

## Summary
SINGLE_TABLE 상속에서 @DiscriminatorColumn 미지정 시 JPA 디폴트(DTYPE, STRING(31))를 자동 생성하고,
@DiscriminatorColumn이 명시된 경우 타입/길이/정의(columnDefinition/options)를 반영합니다.
중복 컬럼명 충돌을 검출하며, CHAR 길이가 1이 아니면 경고 후 1로 보정합니다.
JOINED 전략에선 애노테이션이 있을 때만 생성합니다(미지정 시 생성하지 않음).

## Why
- JPA 스펙 상 SINGLE_TABLE에서 discriminator 컬럼은 기본적으로 필요하며,
  미지정 시 기본값(DTYPE, STRING(31))이 적용됩니다.
- 스키마 생성 모델(EntityModel)에 이를 반영해 일관성/호환성을 확보하고,
  중복/잘못된 설정을 조기에 검출합니다.

## What’s Changed
- `InheritanceHandler#resolveInheritance` → `handleDiscriminator` 분리 및 호출
- 기본값 생성 로직:
  - 이름: DTYPE
  - 타입: STRING → `java.lang.String`, 길이 31
  - NOT NULL, generationStrategy=NONE
- 명시 시 반영:
  - DiscriminatorType: STRING/CHAR/INTEGER 매핑
  - length/columnDefinition/options 적용
  - CHAR + length ≠ 1 → WARNING 후 1로 보정
- 중복 컬럼명 충돌 시 ERROR 로깅 + entity invalid 처리
- JOINED: 애노테이션이 있을 때만 생성
- `ColumnModel`에 discriminator 메타 설정(columnKind=DISCRIMINATOR, discriminatorType, length, columnDefinition/options)

## Tests
새 테스트 클래스 `InheritanceHandlerDiscriminatorTest` 추가:
- `SINGLE_TABLE` 미지정 → 기본 `DTYPE` 생성 (STRING, len=31, NOT NULL)
- `JOINED` 미지정 → 생성되지 않음
- `JOINED` 지정 → 선언 반영하여 생성
- 중복 컬럼명 충돌 → ERROR + 미생성
- `CHAR` 길이 보정(≠1) → WARNING + length=1로 저장
- `STRING/CHAR` 길이 ≤ 0 → ERROR + 미생성

유틸 보완:
- `AnnotationProxies.discriminatorColumnFull(...)` 추가로 전체 파라미터 모킹 지원

## Backward Compatibility
- 기존 모델에 영향 없음.
- SINGLE_TABLE에서만 미지정 시 기본 컬럼 자동 추가(스펙 준수).
- JOINED는 명시된 경우만 생성 → 기존 동작과 충돌 없음.

## Acceptance Criteria
- 기본값 자동 생성: **충족**
- STRING/CHAR/INTEGER 타입 및 길이 적용: **충족**
- 중복 컬럼명 충돌 검출: **충족**

## Notes
- 필요 시 `columnDefinition`과 `options` 동시 지정에 대한 정책을 강화할 수 있음(현재는 둘 다 허용하되 그대로 반영).
- 추후 DiscriminatorValue, DiscriminatorType 확장 케이스가 생기면 테스트 케이스 추가 예정.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 단일 테이블 상속에서 @DiscriminatorColumn 미지정 시 기본 DTYPE 구분자 컬럼 자동 생성 및 합리적 기본값 적용
  - 구분자 컬럼 메타데이터 지원 확대: 종류, 타입, 길이, columnDefinition, options 지정 가능
  - CHAR 타입 길이 자동 보정(1로 조정) 및 경고 메시지 제공
  - 모델에 구분자 관련 값 저장 및 해시 반영

- 리팩터
  - 구분자 컬럼 처리 로직을 중앙화하여 일관성 및 검증 개선

- 테스트
  - 상속 전략 전반의 구분자 컬럼 생성/검증 케이스 추가 및 오류/경고 시나리오 검증
<!-- end of auto-generated comment: release notes by coderabbit.ai -->