### PR TITLE
**ElementCollection hardening: trim `@UniqueConstraint` column names & safe persistence of `@MapKeyColumn.columnDefinition`**

### DIFF
--- a/jinx-processor/src/main/java/org/jinx/handler/builtins/CollectionTableAdapter.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/builtins/CollectionTableAdapter.java
@@ -1,0 +1,119 @@
+package org.jinx.handler.builtins;
+
+import jakarta.persistence.CheckConstraint;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Index;
+import jakarta.persistence.UniqueConstraint;
+import org.jinx.context.ProcessingContext;
+import org.jinx.handler.TableLike;
+import org.jinx.model.ConstraintModel;
+import org.jinx.model.ConstraintType;
+import org.jinx.model.IndexModel;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+public class CollectionTableAdapter implements TableLike {
+    private final CollectionTable collectionTable;
+    private final ProcessingContext context;
+    private final String effectiveTableName;
+
+    public CollectionTableAdapter(CollectionTable collectionTable, ProcessingContext context) {
+        this.collectionTable = collectionTable;
+        this.context = context;
+        this.effectiveTableName = null;
+    }
+    
+    public CollectionTableAdapter(CollectionTable collectionTable, ProcessingContext context, String effectiveTableName) {
+        this.collectionTable = collectionTable;
+        this.context = context;
+        this.effectiveTableName = effectiveTableName;
+    }
+
+    @Override
+    public String getName() {
+        String name = collectionTable.name();
+        if (name.isEmpty()) {
+            return (effectiveTableName != null && !effectiveTableName.isEmpty())
+                   ? effectiveTableName
+                   : "_anonymous_collection_"; // 안전 폴백
+        }
+        return name;
+    }
+
+    @Override
+    public Optional<String> getSchema() {
+        return Optional.ofNullable(collectionTable.schema()).filter(s -> !s.isEmpty());
+    }
+
+    @Override
+    public Optional<String> getCatalog() {
+        return Optional.ofNullable(collectionTable.catalog()).filter(c -> !c.isEmpty());
+    }
+
+    @Override
+    public List<IndexModel> getIndexes() {
+        List<IndexModel> indexes = new ArrayList<>();
+        for (Index index : collectionTable.indexes()) {
+            // 먼저 컬럼명을 트리밍하고 빈 토큰 제거
+            List<String> columnNames = Arrays.stream(index.columnList().split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+            
+            // 빈 컬럼 리스트인 경우 건너뛰기
+            if (columnNames.isEmpty()) {
+                continue;
+            }
+            
+            // 트리밍된 컬럼 리스트로 인덱스명 생성
+            String indexName = index.name().isEmpty()
+                ? context.getNaming().ixName(getName(), columnNames)
+                : index.name();
+            
+            IndexModel indexModel = IndexModel.builder()
+                .indexName(indexName)
+                .tableName(getName())
+                .columnNames(columnNames)
+                .isUnique(index.unique())
+                .build();
+            indexes.add(indexModel);
+        }
+        return indexes;
+    }
+
+    @Override
+    public List<ConstraintModel> getConstraints() {
+        List<ConstraintModel> constraints = new ArrayList<>();
+        
+        // UniqueConstraints 처리
+        for (UniqueConstraint uc : collectionTable.uniqueConstraints()) {
+            List<String> cols = Arrays.stream(uc.columnNames())
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+            if (cols.isEmpty()) continue;
+
+            String constraintName = uc.name().isEmpty()
+                ? context.getNaming().uqName(getName(), cols)
+                : uc.name();
+
+            ConstraintModel constraint = ConstraintModel.builder()
+                .name(constraintName)
+                .type(ConstraintType.UNIQUE)
+                .tableName(getName())
+                .columns(cols)
+                .build();
+            constraints.add(constraint);
+        }
+        
+        return constraints;
+    }
+
+    @Override
+    public Optional<String> getComment() {
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
## Summary

`@CollectionTable` 처리 시 다음 두 가지를 보강했습니다.

1. `@UniqueConstraint`의 `columnNames`를 **split → trim → empty 필터링**하여 정규화
2. `@MapKeyColumn(columnDefinition=...)` 값을 `ColumnModel`의 `defaultValue`에 저장(전용 세터 부재 방지)

## What’s changed

- **CollectionTableAdapter**
    - `UniqueConstraint.columnNames` 정규화(트리밍/빈 토큰 제거)
    - 정규화된 리스트로 유니크 제약명 생성 → 이름 불일치/중복 완화
- **ElementCollectionHandler**
    - `@MapKeyColumn.columnDefinition`은 `ColumnModel`에 전용 필드가 없으므로 `defaultValue`로 안전 저장
    - 누락된 세터 호출 가능성 제거

## Rationale

- 공백이 섞인 `columnList/columnNames`로 인해 제약/인덱스 이름이 의도와 다르게 생성되는 이슈 예방
- `columnDefinition` 저장 시 API 미스매치로 인한 컴파일/런타임 오류 방지

## Compatibility

- 기존 정상 어노테이션에는 동작 변화 없음(Backward-compatible)
- Risk: Low


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 컬렉션 테이블(@CollectionTable) 인덱스·고유 제약 정보를 수집해 컬렉션 엔티티 검증에 반영합니다.
  * 외래키 컬럼명 생성이 프로젝트 네이밍 전략을 따르도록 일관화했습니다.
  * @ElementCollection의 Map 키 처리 확대: 엔티티 키와 기본 타입 모두 지원하고 MapKey 관련 어노테이션 및 컬럼 속성(길이/정밀도/스케일/정의)을 반영합니다.
  * CollectionTable 어댑터를 추가해 인덱스·제약 이름 생성과 누락 처리를 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->