### PR TITLE
PR: 정확한 SQL 타입 제어를 위한 `sqlTypeOverride` 도입 및 `columnDefinition` 처리 수정

### DIFF
--- a/jinx-core/src/main/java/org/jinx/migration/dialect/mysql/MySqlDialect.java
+++ b/jinx-core/src/main/java/org/jinx/migration/dialect/mysql/MySqlDialect.java
@@ -134,7 +134,7 @@ public class MySqlDialect extends AbstractDialect
     public String getDropPrimaryKeySql(String table, Collection<ColumnModel> currentColumns) {
         StringBuilder sb = new StringBuilder();
         for (ColumnModel col : currentColumns) {
-            if (col.isPrimaryKey() && col.getGenerationStrategy() == GenerationStrategy.IDENTITY) {
+            if (col.isPrimaryKey() && shouldUseAutoIncrement(col.getGenerationStrategy())) {
                 JavaTypeMapper.JavaType javaType = getJavaTypeMapper().map(col.getJavaType());
                 String sqlTypeForModify;
                 if (col.getSqlTypeOverride() != null && !col.getSqlTypeOverride().trim().isEmpty()) {

--- a/jinx-core/src/main/java/org/jinx/migration/dialect/mysql/MySqlDialect.java
+++ b/jinx-core/src/main/java/org/jinx/migration/dialect/mysql/MySqlDialect.java
@@ -157,7 +157,10 @@ public class MySqlDialect extends AbstractDialect
         JavaTypeMapper.JavaType javaTypeMapped = javaTypeMapper.map(javaType);
 
         String sqlType;
-        if (c.isLob()) {
+        // If sqlTypeOverride is specified, use it directly
+        if (c.getSqlTypeOverride() != null && !c.getSqlTypeOverride().isEmpty()) {
+            sqlType = c.getSqlTypeOverride();
+        } else if (c.isLob()) {
             sqlType = c.getJavaType().equals("java.lang.String") ? "TEXT" : "BLOB";
         } else if (c.isVersion()) {
             sqlType = c.getJavaType().equals("java.lang.Long") ? "BIGINT" : "TIMESTAMP";
@@ -439,6 +442,11 @@ public class MySqlDialect extends AbstractDialect
 
     // Liquibase helper
     public String getLiquibaseTypeName(ColumnModel column) {
+        // If sqlTypeOverride is specified, use it directly
+        if (column.getSqlTypeOverride() != null && !column.getSqlTypeOverride().isEmpty()) {
+            return column.getSqlTypeOverride();
+        }
+        
         String javaType = column.getJavaType();
         int length = column.getLength();
         int precision = column.getPrecision();

--- a/jinx-core/src/main/java/org/jinx/migration/dialect/mysql/MySqlDialect.java
+++ b/jinx-core/src/main/java/org/jinx/migration/dialect/mysql/MySqlDialect.java
@@ -136,9 +136,15 @@ public class MySqlDialect extends AbstractDialect
         for (ColumnModel col : currentColumns) {
             if (col.isPrimaryKey() && col.getGenerationStrategy() == GenerationStrategy.IDENTITY) {
                 JavaTypeMapper.JavaType javaType = getJavaTypeMapper().map(col.getJavaType());
+                String sqlTypeForModify;
+                if (col.getSqlTypeOverride() != null && !col.getSqlTypeOverride().trim().isEmpty()) {
+                    sqlTypeForModify = col.getSqlTypeOverride().trim();
+                } else {
+                    sqlTypeForModify = javaType.getSqlType(col.getLength(), col.getPrecision(), col.getScale());
+                }
                 sb.append("ALTER TABLE ").append(quoteIdentifier(table))
                         .append(" MODIFY COLUMN ").append(quoteIdentifier(col.getColumnName())).append(" ")
-                        .append(javaType.getSqlType(col.getLength(), col.getPrecision(), col.getScale()));
+                        .append(sqlTypeForModify);
                 if (!col.isNullable()) sb.append(" NOT NULL");
                 if (col.getDefaultValue() != null) {
                     sb.append(" DEFAULT ").append(getValueTransformer().quote(col.getDefaultValue(), javaType));
@@ -158,8 +164,8 @@ public class MySqlDialect extends AbstractDialect
 
         String sqlType;
         // If sqlTypeOverride is specified, use it directly
-        if (c.getSqlTypeOverride() != null && !c.getSqlTypeOverride().isEmpty()) {
-            sqlType = c.getSqlTypeOverride();
+        if (c.getSqlTypeOverride() != null && !c.getSqlTypeOverride().trim().isEmpty()) {
+            sqlType = c.getSqlTypeOverride().trim();
         } else if (c.isLob()) {
             sqlType = c.getJavaType().equals("java.lang.String") ? "TEXT" : "BLOB";
         } else if (c.isVersion()) {
@@ -443,8 +449,8 @@ public class MySqlDialect extends AbstractDialect
     // Liquibase helper
     public String getLiquibaseTypeName(ColumnModel column) {
         // If sqlTypeOverride is specified, use it directly
-        if (column.getSqlTypeOverride() != null && !column.getSqlTypeOverride().isEmpty()) {
-            return column.getSqlTypeOverride();
+        if (column.getSqlTypeOverride() != null && !column.getSqlTypeOverride().trim().isEmpty()) {
+            return column.getSqlTypeOverride().trim();
         }
         
         String javaType = column.getJavaType();

--- a/jinx-core/src/main/java/org/jinx/migration/dialect/mysql/MySqlDialect.java
+++ b/jinx-core/src/main/java/org/jinx/migration/dialect/mysql/MySqlDialect.java
@@ -147,6 +147,10 @@ public class MySqlDialect extends AbstractDialect
                         .replaceAll("(?i)\\bauto_increment\\b", "")
                         .replaceAll("\\s{2,}", " ")
                         .trim();
+                // 제거 결과가 비었으면 안전하게 기본 매핑으로 폴백
+                if (sqlTypeForModify.isEmpty()) {
+                    sqlTypeForModify = javaType.getSqlType(col.getLength(), col.getPrecision(), col.getScale());
+                }
                 sb.append("ALTER TABLE ").append(quoteIdentifier(table))
                         .append(" MODIFY COLUMN ").append(quoteIdentifier(col.getColumnName())).append(" ")
                         .append(sqlTypeForModify);

--- a/jinx-core/src/main/java/org/jinx/migration/liquibase/LiquibaseVisitor.java
+++ b/jinx-core/src/main/java/org/jinx/migration/liquibase/LiquibaseVisitor.java
@@ -477,8 +477,8 @@ public class LiquibaseVisitor implements TableVisitor, TableContentVisitor, Sequ
 
     private String getLiquibaseTypeName(ColumnModel c) {
         // If sqlTypeOverride is specified, use it directly
-        if (c.getSqlTypeOverride() != null && !c.getSqlTypeOverride().isEmpty()) {
-            return c.getSqlTypeOverride();
+        if (c.getSqlTypeOverride() != null && !c.getSqlTypeOverride().trim().isEmpty()) {
+            return c.getSqlTypeOverride().trim();
         }
         
         return dialectBundle.liquibase()

--- a/jinx-core/src/main/java/org/jinx/migration/liquibase/LiquibaseVisitor.java
+++ b/jinx-core/src/main/java/org/jinx/migration/liquibase/LiquibaseVisitor.java
@@ -476,6 +476,11 @@ public class LiquibaseVisitor implements TableVisitor, TableContentVisitor, Sequ
     }
 
     private String getLiquibaseTypeName(ColumnModel c) {
+        // If sqlTypeOverride is specified, use it directly
+        if (c.getSqlTypeOverride() != null && !c.getSqlTypeOverride().isEmpty()) {
+            return c.getSqlTypeOverride();
+        }
+        
         return dialectBundle.liquibase()
                 .map(lb -> lb.getLiquibaseTypeName(c))
                 .orElseGet(() -> {

--- a/jinx-core/src/main/java/org/jinx/model/ColumnModel.java
+++ b/jinx-core/src/main/java/org/jinx/model/ColumnModel.java
@@ -47,6 +47,7 @@ public class ColumnModel {
     @Builder.Default private String[] mapKeyEnumValues = new String[]{}; // For @MapKeyEnumerated
     @Builder.Default private TemporalType mapKeyTemporalType = null; // For @MapKeyTemporal
     @Builder.Default private ColumnKind columnKind = ColumnKind.NORMAL;
+    @Builder.Default private String sqlTypeOverride = null; // For @Column(columnDefinition)
 
     // Discriminator metadata
     private jakarta.persistence.DiscriminatorType discriminatorType; // optional
@@ -59,6 +60,6 @@ public class ColumnModel {
         return Objects.hash(columnName, javaType, length, precision, scale, isNullable, isUnique, defaultValue,
                 temporalType, enumerationType, enumStringMapping,
                 java.util.Arrays.hashCode(enumValues), mapKeyTemporalType, java.util.Arrays.hashCode(mapKeyEnumValues),
-                columnKind, discriminatorType, columnDefinition, options);
+                columnKind, discriminatorType, columnDefinition, options, sqlTypeOverride);
     }
 }

--- a/jinx-core/src/test/java/org/jinx/migration/SqlTypeOverrideTest.java
+++ b/jinx-core/src/test/java/org/jinx/migration/SqlTypeOverrideTest.java
@@ -1,0 +1,114 @@
+package org.jinx.migration;
+
+import org.jinx.migration.dialect.mysql.MySqlDialect;
+import org.jinx.model.ColumnModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("SqlTypeOverride DDL Generation")
+class SqlTypeOverrideTest {
+
+    private MySqlDialect dialect;
+
+    @BeforeEach
+    void setUp() {
+        dialect = new MySqlDialect();
+    }
+
+    @Test
+    @DisplayName("sqlTypeOverride가 있으면 길이/정밀도/스케일 무시하고 그대로 사용해야 한다")
+    void getColumnDefinitionSql_withSqlTypeOverride_shouldUseOverrideDirectly() {
+        // Arrange
+        ColumnModel column = ColumnModel.builder()
+                .columnName("test_column")
+                .javaType("java.lang.String")
+                .length(100)  // 무시되어야 함
+                .precision(10) // 무시되어야 함
+                .scale(2)     // 무시되어야 함
+                .sqlTypeOverride("varchar(42)")
+                .isNullable(false)
+                .build();
+
+        // Act
+        String ddl = dialect.getColumnDefinitionSql(column);
+
+        // Assert
+        assertThat(ddl).contains("varchar(42)");
+        assertThat(ddl).doesNotContain("VARCHAR(100)"); // 길이가 무시됨
+        assertThat(ddl).contains("NOT NULL");
+    }
+
+    @Test
+    @DisplayName("sqlTypeOverride가 null이면 기본 타입 매핑을 사용해야 한다")
+    void getColumnDefinitionSql_withoutSqlTypeOverride_shouldUseDefaultMapping() {
+        // Arrange
+        ColumnModel column = ColumnModel.builder()
+                .columnName("test_column")
+                .javaType("java.lang.String")
+                .length(100)
+                .sqlTypeOverride(null)
+                .isNullable(true)
+                .build();
+
+        // Act
+        String ddl = dialect.getColumnDefinitionSql(column);
+
+        // Assert
+        assertThat(ddl).contains("VARCHAR(100)"); // 기본 매핑 사용
+        assertThat(ddl).doesNotContain("NOT NULL");
+    }
+
+    @Test
+    @DisplayName("Liquibase 타입 이름에서 sqlTypeOverride가 우선되어야 한다")
+    void getLiquibaseTypeName_withSqlTypeOverride_shouldUseOverrideDirectly() {
+        // Arrange
+        ColumnModel column = ColumnModel.builder()
+                .javaType("java.lang.String")
+                .length(255)
+                .sqlTypeOverride("char(3)")
+                .build();
+
+        // Act
+        String typeName = dialect.getLiquibaseTypeName(column);
+
+        // Assert
+        assertThat(typeName).isEqualTo("char(3)");
+    }
+
+    @Test
+    @DisplayName("Liquibase 타입 이름에서 sqlTypeOverride가 없으면 기본 매핑을 사용해야 한다")
+    void getLiquibaseTypeName_withoutSqlTypeOverride_shouldUseDefaultMapping() {
+        // Arrange
+        ColumnModel column = ColumnModel.builder()
+                .javaType("java.lang.String")
+                .length(255)
+                .sqlTypeOverride(null)
+                .build();
+
+        // Act
+        String typeName = dialect.getLiquibaseTypeName(column);
+
+        // Assert
+        assertThat(typeName).isEqualTo("VARCHAR(255)");
+    }
+
+    @Test
+    @DisplayName("sqlTypeOverride가 빈 문자열이면 기본 매핑을 사용해야 한다")
+    void getLiquibaseTypeName_withEmptyOverride_shouldUseDefaultMapping() {
+        // Arrange
+        ColumnModel column = ColumnModel.builder()
+                .javaType("java.lang.String")
+                .length(255)
+                .sqlTypeOverride("")
+                .build();
+
+        // Act
+        String typeName = dialect.getLiquibaseTypeName(column);
+
+        // Assert
+        assertThat(typeName).isEqualTo("VARCHAR(255)");
+    }
+}

--- a/jinx-core/src/test/java/org/jinx/migration/SqlTypeOverrideTest.java
+++ b/jinx-core/src/test/java/org/jinx/migration/SqlTypeOverrideTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("SqlTypeOverride DDL Generation")
@@ -110,5 +112,117 @@ class SqlTypeOverrideTest {
 
         // Assert
         assertThat(typeName).isEqualTo("VARCHAR(255)");
+    }
+
+    @Test
+    @DisplayName("PK 드랍 시 sqlTypeOverride가 있으면 오버라이드 타입을 유지해야 한다")
+    void getDropPrimaryKeySql_withSqlTypeOverride_shouldPreserveOverrideType() {
+        // Arrange
+        ColumnModel identityColumn = ColumnModel.builder()
+                .columnName("id")
+                .javaType("java.lang.Long")
+                .isPrimaryKey(true)
+                .generationStrategy(org.jinx.model.GenerationStrategy.IDENTITY)
+                .sqlTypeOverride("bigint auto_increment")
+                .isNullable(false)
+                .build();
+
+        // Act
+        String dropSql = dialect.getDropPrimaryKeySql("test_table", List.of(identityColumn));
+
+        // Assert
+        assertThat(dropSql).contains("bigint auto_increment");
+        assertThat(dropSql).doesNotContain("BIGINT"); // 기본 매핑이 사용되지 않아야 함
+        assertThat(dropSql).contains("NOT NULL");
+        assertThat(dropSql).contains("DROP PRIMARY KEY");
+    }
+
+    @Test
+    @DisplayName("PK 드랍 시 sqlTypeOverride가 없으면 기본 매핑을 사용해야 한다")
+    void getDropPrimaryKeySql_withoutSqlTypeOverride_shouldUseDefaultMapping() {
+        // Arrange
+        ColumnModel identityColumn = ColumnModel.builder()
+                .columnName("id")
+                .javaType("java.lang.Long")
+                .isPrimaryKey(true)
+                .generationStrategy(org.jinx.model.GenerationStrategy.IDENTITY)
+                .sqlTypeOverride(null)
+                .isNullable(false)
+                .build();
+
+        // Act
+        String dropSql = dialect.getDropPrimaryKeySql("test_table", List.of(identityColumn));
+
+        // Assert
+        assertThat(dropSql).contains("BIGINT"); // 기본 매핑 사용
+        assertThat(dropSql).contains("NOT NULL");
+        assertThat(dropSql).contains("DROP PRIMARY KEY");
+    }
+
+    @Test
+    @DisplayName("getDropPrimaryKeySql은 sqlTypeOverride를 유지해야 한다")
+    void getDropPrimaryKeySql_shouldPreserveSqlTypeOverride() {
+        // Arrange
+        ColumnModel col = ColumnModel.builder()
+                .columnName("id")
+                .javaType("java.lang.Long")
+                .length(20)
+                .sqlTypeOverride("BIGINT(42)")
+                .isNullable(false)
+                .generationStrategy(org.jinx.model.GenerationStrategy.IDENTITY)
+                .isPrimaryKey(true)
+                .build();
+
+        // Act
+        String sql = dialect.getDropPrimaryKeySql("test_table", List.of(col));
+
+        // Assert
+        assertThat(sql).contains("MODIFY COLUMN `id` BIGINT(42)");
+        assertThat(sql).contains("NOT NULL");
+        assertThat(sql).contains("DROP PRIMARY KEY");
+        assertThat(sql).doesNotContain("BIGINT NOT NULL"); // 기본 매핑이 사용되지 않아야 함
+    }
+
+    @Test
+    @DisplayName("공백만 있는 sqlTypeOverride는 trim되어 기본 매핑을 사용해야 한다")
+    void getDropPrimaryKeySql_withWhitespaceOnlyOverride_shouldUseDefaultMapping() {
+        // Arrange
+        ColumnModel col = ColumnModel.builder()
+                .columnName("id")
+                .javaType("java.lang.Long")
+                .length(20)
+                .sqlTypeOverride("   ")  // 공백만 있는 경우
+                .isNullable(false)
+                .generationStrategy(org.jinx.model.GenerationStrategy.IDENTITY)
+                .isPrimaryKey(true)
+                .build();
+
+        // Act
+        String sql = dialect.getDropPrimaryKeySql("test_table", List.of(col));
+
+        // Assert
+        assertThat(sql).contains("MODIFY COLUMN `id` BIGINT"); // 기본 매핑 사용
+        assertThat(sql).contains("NOT NULL");
+        assertThat(sql).contains("DROP PRIMARY KEY");
+    }
+
+    @Test
+    @DisplayName("sqlTypeOverride trim 정책: 앞뒤 공백은 제거되어야 한다")
+    void getColumnDefinitionSql_shouldTrimSqlTypeOverride() {
+        // Arrange
+        ColumnModel column = ColumnModel.builder()
+                .columnName("test_column")
+                .javaType("java.lang.String")
+                .sqlTypeOverride("  varchar(42)  ")  // 앞뒤 공백
+                .isNullable(false)
+                .build();
+
+        // Act
+        String ddl = dialect.getColumnDefinitionSql(column);
+
+        // Assert
+        assertThat(ddl).contains("varchar(42)");
+        assertThat(ddl).doesNotContain("  varchar(42)  ");
+        assertThat(ddl).contains("NOT NULL");
     }
 }

--- a/jinx-processor/src/main/java/org/jinx/handler/ElementCollectionHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/ElementCollectionHandler.java
@@ -562,8 +562,7 @@ public class ElementCollectionHandler {
                                 keyColumn.setScale(mapKeyColumn.scale());
                             }
                             if (!mapKeyColumn.columnDefinition().isEmpty()) {
-                                // ColumnModel에 columnDefinition 세터가 없으므로 defaultValue 사용
-                                keyColumn.setDefaultValue(mapKeyColumn.columnDefinition());
+                                keyColumn.setSqlTypeOverride(mapKeyColumn.columnDefinition());
                             }
                         }
 

--- a/jinx-processor/src/main/java/org/jinx/handler/builtins/CollectionElementResolver.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/builtins/CollectionElementResolver.java
@@ -28,7 +28,7 @@ public class CollectionElementResolver extends AbstractColumnResolver {
                 .length(column != null ? column.length() : 255)
                 .precision(column != null ? column.precision() : 0)
                 .scale(column != null ? column.scale() : 0)
-                .defaultValue(column != null && !column.columnDefinition().isEmpty() ? column.columnDefinition() : null)
+                .sqlTypeOverride(column != null && !column.columnDefinition().isEmpty() ? column.columnDefinition() : null)
                 .generationStrategy(GenerationStrategy.NONE);
 
         applyCommonAnnotations(builder, field, type);

--- a/jinx-processor/src/main/java/org/jinx/util/ColumnBuilderFactory.java
+++ b/jinx-processor/src/main/java/org/jinx/util/ColumnBuilderFactory.java
@@ -29,7 +29,7 @@ public class ColumnBuilderFactory {
                 .length(column != null ? column.length() : 255)
                 .precision(column != null ? column.precision() : 0)
                 .scale(column != null ? column.scale() : 0)
-                .defaultValue(column != null && !column.columnDefinition().isEmpty() ? column.columnDefinition() : null)
+                .sqlTypeOverride(column != null && !column.columnDefinition().isEmpty() ? column.columnDefinition() : null)
                 .generationStrategy(GenerationStrategy.NONE);
     }
 
@@ -63,7 +63,7 @@ public class ColumnBuilderFactory {
                 .length(column != null ? column.length() : 255)
                 .precision(column != null ? column.precision() : 0)
                 .scale(column != null ? column.scale() : 0)
-                .defaultValue(column != null && !column.columnDefinition().isEmpty() ? column.columnDefinition() : null)
+                .sqlTypeOverride(column != null && !column.columnDefinition().isEmpty() ? column.columnDefinition() : null)
                 .generationStrategy(genStrategy);
         
         // Apply table name override if provided

--- a/jinx-processor/src/test/java/org/jinx/handler/builtins/CollectionElementResolverTest.java
+++ b/jinx-processor/src/test/java/org/jinx/handler/builtins/CollectionElementResolverTest.java
@@ -110,4 +110,48 @@ class CollectionElementResolverTest {
         assertThat(result.isEnumStringMapping()).isTrue();
         assertThat(result.getEnumValues()).isEqualTo(enumConstants);
     }
+
+    @Test
+    @DisplayName("@Column(columnDefinition)이 있으면 sqlTypeOverride로 설정해야 한다")
+    void resolve_withColumnDefinition_setsSqlTypeOverride() {
+        // Arrange
+        Column mockColumn = mock(Column.class);
+        when(mockColumn.columnDefinition()).thenReturn("varchar(42)");
+        when(mockColumn.nullable()).thenReturn(true);
+        when(mockColumn.unique()).thenReturn(false);
+        when(mockColumn.length()).thenReturn(255);
+        when(mockColumn.precision()).thenReturn(0);
+        when(mockColumn.scale()).thenReturn(0);
+        when(mockField.getAnnotation(Column.class)).thenReturn(mockColumn);
+        when(mockType.toString()).thenReturn("java.lang.String");
+
+        // Act
+        ColumnModel result = resolver.resolve(mockField, mockType, "items", Collections.emptyMap());
+
+        // Assert
+        assertThat(result.getSqlTypeOverride()).isEqualTo("varchar(42)");
+        assertThat(result.getDefaultValue()).isNull(); // defaultValue는 null이어야 함
+    }
+
+    @Test
+    @DisplayName("@Column(columnDefinition)이 빈 문자열이면 sqlTypeOverride를 null로 설정해야 한다")
+    void resolve_withEmptyColumnDefinition_setsNullSqlTypeOverride() {
+        // Arrange
+        Column mockColumn = mock(Column.class);
+        when(mockColumn.columnDefinition()).thenReturn("");
+        when(mockColumn.nullable()).thenReturn(true);
+        when(mockColumn.unique()).thenReturn(false);
+        when(mockColumn.length()).thenReturn(255);
+        when(mockColumn.precision()).thenReturn(0);
+        when(mockColumn.scale()).thenReturn(0);
+        when(mockField.getAnnotation(Column.class)).thenReturn(mockColumn);
+        when(mockType.toString()).thenReturn("java.lang.String");
+
+        // Act
+        ColumnModel result = resolver.resolve(mockField, mockType, "items", Collections.emptyMap());
+
+        // Assert
+        assertThat(result.getSqlTypeOverride()).isNull();
+        assertThat(result.getDefaultValue()).isNull();
+    }
 }

--- a/jinx-processor/src/test/java/org/jinx/util/ColumnBuilderFactoryTest.java
+++ b/jinx-processor/src/test/java/org/jinx/util/ColumnBuilderFactoryTest.java
@@ -136,4 +136,44 @@ class ColumnBuilderFactoryTest {
         // Assert
         assertThat(model.isPrimaryKey()).isTrue();
     }
+
+    @Test
+    @DisplayName("@Column(columnDefinition)이 있으면 sqlTypeOverride로 설정해야 한다")
+    void from_withColumnDefinition_setsSqlTypeOverride() {
+        // Arrange: @Column(columnDefinition) 애너테이션이 있는 필드
+        Column mockColumn = mock(Column.class);
+        when(mockColumn.columnDefinition()).thenReturn("varchar(42)");
+        when(mockColumn.name()).thenReturn("");
+        when(mockField.getAnnotation(Column.class)).thenReturn(mockColumn);
+
+        // Act
+        ColumnModel.ColumnModelBuilder builder = ColumnBuilderFactory.from(
+                mockField, null, "testField", mockContext, Collections.emptyMap()
+        );
+        ColumnModel model = builder.build();
+
+        // Assert
+        assertThat(model.getSqlTypeOverride()).isEqualTo("varchar(42)");
+        assertThat(model.getDefaultValue()).isNull(); // defaultValue는 null이어야 함
+    }
+
+    @Test
+    @DisplayName("@Column(columnDefinition)이 빈 문자열이면 sqlTypeOverride를 null로 설정해야 한다")
+    void from_withEmptyColumnDefinition_setsNullSqlTypeOverride() {
+        // Arrange: @Column(columnDefinition="") 애너테이션이 있는 필드
+        Column mockColumn = mock(Column.class);
+        when(mockColumn.columnDefinition()).thenReturn("");
+        when(mockColumn.name()).thenReturn("");
+        when(mockField.getAnnotation(Column.class)).thenReturn(mockColumn);
+
+        // Act
+        ColumnModel.ColumnModelBuilder builder = ColumnBuilderFactory.from(
+                mockField, null, "testField", mockContext, Collections.emptyMap()
+        );
+        ColumnModel model = builder.build();
+
+        // Assert
+        assertThat(model.getSqlTypeOverride()).isNull();
+        assertThat(model.getDefaultValue()).isNull();
+    }
 }


### PR DESCRIPTION
# PR: 정확한 SQL 타입 제어를 위한 `sqlTypeOverride` 도입 및 `columnDefinition` 처리 수정

**라벨:** `area:model` `area:dialect` `area:processor` `type:enhancement` `priority:P2`

## 요약
- `ColumnModel`에 `sqlTypeOverride` 필드를 추가하고, JPA `@Column(columnDefinition=...)`을 여기에 매핑했습니다.
- Dialect에서 DDL 및 Liquibase 타입 이름 생성 시 `sqlTypeOverride`를 최우선으로 사용합니다.
- 기존에는 `columnDefinition`을 사실상 기본값처럼 (`defaultValue`) 취급하던 혼동을 해소했습니다.

## 배경
- JPA의 `columnDefinition`은 기본값이 아니라 **명시적 SQL 타입/DDL 조각**을 의미합니다.
- 타입 추론 결과를 덮어써야 하는 합법적 수단이 필요했고, 이를 모델 차원에서 분리해 명확히 표현합니다.

## 주요 변경 사항
- **Model**
  - `ColumnModel.sqlTypeOverride` 추가 및 `getAttributeHash()` 포함.
- **Processor**
  - `CollectionElementResolver`: `@Column(columnDefinition)` → `sqlTypeOverride`에 매핑.
  - `ElementCollectionHandler`: `@MapKeyColumn(columnDefinition)`도 `sqlTypeOverride`로 반영.
- **Dialect**
  - `getColumnDefinitionSql(...)`, `getLiquibaseTypeName(...)`에서 `sqlTypeOverride`가 존재하면 이를 **그대로 사용**, 없으면 기존 매핑으로 폴백.
- **테스트**
  - `SqlTypeOverrideTest` 추가:
    - DDL이 override를 그대로 사용하고 length/precision/scale을 무시하는지 검증.
    - Liquibase 타입 이름에서 override가 우선되는지 검증.
    - null/빈 문자열 시 기본 매핑으로 폴백되는지 검증.

## 동작 정리
- `sqlTypeOverride`가 설정되면(예: `varchar(42)`), 해당 문자열을 그대로 사용하며 length/precision/scale 설정은 무시됩니다.
- 설정되지 않으면 기존 타입 매핑 로직이 동일하게 동작합니다.

## 호환성
- 내부 모델 확장으로, 외부 API 호환성에 영향 없음.
- 과거 `columnDefinition`을 `defaultValue` 용도로 오해하여 사용하던 경로는 이번에 바로잡았습니다.

## 체크리스트
- [x] 모델 필드 추가 및 해시 반영
- [x] 프로세서 경로 업데이트 (기본/Map 키 모두)
- [x] Dialect 우선순위 변경
- [x] 단위 테스트 추가 및 통과


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - @Column(columnDefinition)으로 지정한 SQL 타입을 우선 적용해 스키마 생성, Liquibase 타입명, ALTER TABLE 수정문에 반영합니다.
  - 공백 트림 및 빈/공백-only 값 무시, AUTO_INCREMENT 중복 제거(대소문자 무관) 처리, 컬렉션/맵 키 컬럼에도 동일 적용을 보장합니다.

- 테스트
  - 우선 적용 동작, 공백 처리, AUTO_INCREMENT 처리 및 컬렉션/맵 관련 단위 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->