### PR TITLE
feat(inheritance): JOINED 부모 탐색 개선 및 진단 강화

### DIFF
--- a/jinx-processor/src/test/java/org/jinx/handler/EntityHandlerInheritanceTest.java
+++ b/jinx-processor/src/test/java/org/jinx/handler/EntityHandlerInheritanceTest.java
@@ -1,0 +1,260 @@
+package org.jinx.handler;
+
+import jakarta.persistence.*;
+import org.jinx.context.Naming;
+import org.jinx.context.ProcessingContext;
+import org.jinx.descriptor.AttributeDescriptor;
+import org.jinx.model.ColumnModel;
+import org.jinx.model.EntityModel;
+import org.jinx.model.RelationshipModel;
+import org.jinx.model.RelationshipType;
+import org.jinx.model.SchemaModel;
+import org.jinx.testing.asserts.MessagerAssertions;
+import org.jinx.testing.asserts.RelationshipAssertions;
+import org.jinx.testing.mother.EntityModelMother;
+import org.jinx.testing.util.AnnotationProxies;
+import org.jinx.testing.util.SchemaCapture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import javax.lang.model.element.Name;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+class EntityHandlerInheritanceTest {
+
+    @InjectMocks private EntityHandler handler;
+
+    @Mock private ProcessingContext context;
+    @Mock private ColumnHandler columnHandler;
+    @Mock private EmbeddedHandler embeddedHandler;
+    @Mock private ConstraintHandler constraintHandler;
+    @Mock private SequenceHandler sequenceHandler;
+    @Mock private ElementCollectionHandler elementCollectionHandler;
+    @Mock private TableGeneratorHandler tableGeneratorHandler;
+    @Mock private RelationshipHandler relationshipHandler;
+
+    @Mock private Types typeUtils;
+    @Mock private Elements elementUtils;
+    @Mock private javax.annotation.processing.Messager messager;
+    @Mock private Naming naming;
+
+    @Mock private SchemaModel schemaModel;
+    @Mock private Map<String, EntityModel> entitiesMap;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(context.getTypeUtils()).thenReturn(typeUtils);
+        lenient().when(context.getElementUtils()).thenReturn(elementUtils);
+        lenient().when(context.getSchemaModel()).thenReturn(schemaModel);
+        lenient().when(context.getMessager()).thenReturn(messager);
+        lenient().when(context.getNaming()).thenReturn(naming);
+        lenient().when(schemaModel.getEntities()).thenReturn(entitiesMap);
+
+        // 기본 네이밍
+        lenient().when(naming.fkName(anyString(), anyList(), anyString(), anyList()))
+                .thenAnswer(inv -> "FK_" + inv.getArgument(0) + "_" + inv.getArgument(2));
+
+        // 필드 디스크립터 없음(이 테스트는 상속 로직 중심)
+        lenient().when(context.getCachedDescriptors(any())).thenReturn(List.of());
+    }
+
+    // === 유틸 ===
+
+    private static TypeElement mockTypeElement(String fqcn, String simple) {
+        TypeElement te = mock(TypeElement.class);
+        Name qn = mock(Name.class);
+        Name sn = mock(Name.class);
+        when(qn.toString()).thenReturn(fqcn);
+        when(sn.toString()).thenReturn(simple);
+        when(te.getQualifiedName()).thenReturn(qn);
+        when(te.getSimpleName()).thenReturn(sn);
+        return te;
+    }
+
+    private static DeclaredType declaredOf(TypeElement el) {
+        DeclaredType dt = mock(DeclaredType.class);
+        when(dt.getKind()).thenReturn(TypeKind.DECLARED);
+        when(dt.asElement()).thenReturn(el);
+        return dt;
+    }
+
+    private static TypeMirror noneSuper() {
+        TypeMirror t = mock(TypeMirror.class);
+        when(t.getKind()).thenReturn(TypeKind.NONE);
+        return t;
+    }
+
+    // === 테스트 시나리오 ===
+
+    @Test
+    @DisplayName("중간 부모가 @Inheritance 미지정이어도 상위에서 JOINED를 찾아 FK 생성")
+    void joinedParent_found_through_intermediate() {
+        // 체인: Child -> Mid(entity, @Inheritance 없음) -> Root(entity, @Inheritance JOINED) -> (없음)
+        TypeElement root = mockTypeElement("com.ex.Root", "Root");
+        when(root.getAnnotation(Entity.class)).thenReturn(AnnotationProxies.of(Entity.class, Map.of()));
+        Inheritance inhJoined = AnnotationProxies.of(Inheritance.class, Map.of("strategy", InheritanceType.JOINED));
+        when(root.getAnnotation(Inheritance.class)).thenReturn(inhJoined);
+        TypeMirror none = noneSuper();
+        when(root.getSuperclass()).thenReturn(none);
+
+        TypeElement mid = mockTypeElement("com.ex.Mid", "Mid");
+        when(mid.getAnnotation(Entity.class)).thenReturn(AnnotationProxies.of(Entity.class, Map.of()));
+        when(mid.getAnnotation(Inheritance.class)).thenReturn(null); // 명시 X
+        DeclaredType dtMid = declaredOf(root);
+        when(mid.getSuperclass()).thenReturn(dtMid);
+
+        TypeElement child = mockTypeElement("com.ex.Child", "child");
+        DeclaredType dtChild = declaredOf(mid);
+        when(child.getSuperclass()).thenReturn(dtChild);
+
+        // 스키마: Root 엔티티는 이미 존재하며 PK가 준비되어 있어야 함
+        EntityModel rootEntity = EntityModelMother.javaEntityWithPkIdLong("com.ex.Root", "root_tbl");
+        when(entitiesMap.get("com.ex.Root")).thenReturn(rootEntity);
+        when(entitiesMap.containsKey("com.ex.Child")).thenReturn(false);
+
+        // 부모 PK 메타 제공
+        when(context.findAllPrimaryKeyColumns(rootEntity))
+                .thenReturn(List.of(
+                        ColumnModel.builder().columnName("id").tableName("root_tbl").javaType("java.lang.Long").isPrimaryKey(true).build()
+                ));
+
+        // Act
+        handler.handle(child);
+
+        // Assert: Child 가등록
+        EntityModel childModel = SchemaCapture.capturePutIfAbsent(entitiesMap, "com.ex.Child");
+        assertEquals("child", childModel.getTableName());
+
+        // JOINED 상속 FK가 child 테이블에 생성되어 있어야 함
+        RelationshipModel rel = childModel.getRelationships().values().stream()
+                .filter(r -> r.getType() == RelationshipType.JOINED_INHERITANCE)
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals("child", rel.getTableName());         // FK가 걸리는 곳 = 자식 테이블
+        assertEquals("root_tbl", rel.getReferencedTable()); // 참조 = 루트(부모) 테이블
+        assertEquals(List.of("id"), rel.getColumns());     // 부모 PK 컬럼과 동일명 매핑
+
+        RelationshipAssertions.assertFkByStructure(
+                childModel,
+                "child",     List.of("id"),
+                "root_tbl",  List.of("id"),
+                RelationshipType.JOINED_INHERITANCE
+        );
+    }
+
+    @Test
+    @DisplayName("중간에 SINGLE_TABLE이 명시되면 JOINED 탐색 충돌로 에러 처리하고 관계 생성 중단")
+    void explicitSingleTable_conflict_reportsError() {
+        // 체인: Child -> Mid(entity, @Inheritance SINGLE_TABLE) -> Root(entity, @Inheritance JOINED)
+        TypeElement root = mockTypeElement("com.ex.Root", "Root");
+        when(root.getAnnotation(Entity.class)).thenReturn(AnnotationProxies.of(Entity.class, Map.of()));
+        Inheritance inhJoined = AnnotationProxies.of(Inheritance.class, Map.of("strategy", InheritanceType.JOINED));
+        when(root.getAnnotation(Inheritance.class)).thenReturn(inhJoined);
+        TypeMirror none = noneSuper();
+        when(root.getSuperclass()).thenReturn(none);
+
+        TypeElement mid = mockTypeElement("com.ex.Mid", "Mid");
+        when(mid.getAnnotation(Entity.class)).thenReturn(AnnotationProxies.of(Entity.class, Map.of()));
+        Inheritance inhSingle = AnnotationProxies.of(Inheritance.class, Map.of("strategy", InheritanceType.SINGLE_TABLE));
+        when(mid.getAnnotation(Inheritance.class)).thenReturn(inhSingle);
+        DeclaredType declaredOfRoot = declaredOf(root);
+        when(mid.getSuperclass()).thenReturn(declaredOfRoot);
+
+        TypeElement child = mockTypeElement("com.ex.Child", "child");
+        DeclaredType declaredOfMid = declaredOf(mid);
+        when(child.getSuperclass()).thenReturn(declaredOfMid);
+
+        // 루트 엔티티는 스키마에 존재(있어도 충돌 때문에 못 씀)
+        EntityModel rootEntity = EntityModelMother.javaEntityWithPkIdLong("com.ex.Root", "root_tbl");
+        when(entitiesMap.get("com.ex.Root")).thenReturn(rootEntity);
+        when(entitiesMap.containsKey("com.ex.Child")).thenReturn(false);
+
+        // 부모 PK 메타
+        when(context.findAllPrimaryKeyColumns(rootEntity))
+                .thenReturn(List.of(
+                        ColumnModel.builder().columnName("id").tableName("root_tbl").javaType("java.lang.Long").isPrimaryKey(true).build()
+                ));
+
+        // Act
+        handler.handle(child);
+
+        // Assert: Child 가등록은 됨
+        EntityModel childModel = SchemaCapture.capturePutIfAbsent(entitiesMap, "com.ex.Child");
+        assertEquals("child", childModel.getTableName());
+
+        // 관계는 생성되지 않아야 함(충돌로 중단)
+        assertTrue(
+                childModel.getRelationships().values().stream()
+                        .noneMatch(r -> r.getType() == RelationshipType.JOINED_INHERITANCE),
+                "JOINED_INHERITANCE 관계가 생성되면 안 됩니다"
+        );
+
+        // 에러 메시지 검증
+        MessagerAssertions.assertErrorContains(
+                messager,
+                "inheritance strategy 'SINGLE_TABLE'"
+        );
+    }
+
+    @Test
+    @DisplayName("바로 위 부모가 JOINED이면 즉시 매핑")
+    void immediate_joined_parent() {
+        // 체인: Child -> Parent(entity, @Inheritance JOINED)
+        TypeElement parent = mockTypeElement("com.ex.Parent", "parent_tbl");
+        when(parent.getAnnotation(Entity.class)).thenReturn(AnnotationProxies.of(Entity.class, Map.of()));
+        Inheritance inhJoined = AnnotationProxies.of(Inheritance.class, Map.of("strategy", InheritanceType.JOINED));
+        when(parent.getAnnotation(Inheritance.class)).thenReturn(inhJoined);
+        TypeMirror typeMirror = noneSuper();
+        lenient().when(parent.getSuperclass()).thenReturn(typeMirror);
+
+        TypeElement child = mockTypeElement("com.ex.Child2", "child2");
+        DeclaredType declaredOf = declaredOf(parent);
+        when(child.getSuperclass()).thenReturn(declaredOf);
+
+        // 스키마: 부모 엔티티 존재
+        EntityModel parentEntity = EntityModelMother.javaEntityWithPkIdLong("com.ex.Parent", "parent_tbl");
+        when(entitiesMap.get("com.ex.Parent")).thenReturn(parentEntity);
+        when(entitiesMap.containsKey("com.ex.Child2")).thenReturn(false);
+
+        // 부모 PK
+        when(context.findAllPrimaryKeyColumns(parentEntity))
+                .thenReturn(List.of(
+                        ColumnModel.builder().columnName("id").tableName("parent_tbl").javaType("java.lang.Long").isPrimaryKey(true).build()
+                ));
+
+        // Act
+        handler.handle(child);
+
+        // Assert
+        EntityModel childModel = SchemaCapture.capturePutIfAbsent(entitiesMap, "com.ex.Child2");
+        RelationshipModel rel = childModel.getRelationships().values().stream()
+                .filter(r -> r.getType() == RelationshipType.JOINED_INHERITANCE)
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals("child2", rel.getTableName());
+        assertEquals("parent_tbl", rel.getReferencedTable());
+        assertEquals(List.of("id"), rel.getColumns());
+    }
+}


### PR DESCRIPTION
## 요약
`findNearestJoinedParentEntity` 로직을 개선하여 **JOINED 상속 루트 탐색의 정확도**와 **진단 메시지**를 대폭 향상했습니다.  
기존 구현은 첫 번째로 만난 `@Entity`가 JOINED가 아니면 즉시 중단하여, 상위 체인에 있는 JOINED 루트를 놓칠 수 있었습니다.

## 주요 변경 사항
- 상위 체인 **연속 스캔**: 중간 `@Entity`에 `@Inheritance`가 없더라도 상위로 계속 올라가 **가장 가까운 JOINED 부모**를 탐색
- **사이클 방지**: `seen (Set<String>)`으로 상속 체인 순환을 안전하게 차단(경고 로그)
- **전략 충돌 감지**: 중간 엔티티에서 `SINGLE_TABLE`/`TABLE_PER_CLASS`가 **명시**된 경우, JOINED 탐색과 **충돌 에러**를 리포팅
- **메시지 개선**: 에러/경고에 자식/문제 지점의 FQCN을 포함해 디버깅 가독성 향상

## 배경/문제
- JPA 스펙상 `@Inheritance`는 **계층 루트**에 정의되는 것이 일반적입니다.
- 기존 로직은 "첫 부모 엔티티가 JOINED가 아니면 종료"하여 JOINED 루트를 놓칠 수 있었습니다.
- 또한 전략이 섞여 있어도 조용히 통과하는 케이스가 있었고, 이는 런타임/스키마 단계에서 더 큰 문제로 이어질 수 있습니다.

## 구현 상세
- `while (superclass is DECLARED)` 반복으로 상위 엔티티 스캔
- `@Entity`가 아니면 스킵, `@Entity`이면 `@Inheritance` 확인
  - `JOINED` → **즉시 반환**
  - `SINGLE_TABLE`/`TABLE_PER_CLASS` → **에러 리포팅 후 탐색 종료**
  - 미지정 → **탐색 계속**
- 방문한 타입은 `seen`에 기록하여 순환 시 경고 후 중단

## 테스트
신규 테스트 클래스: `EntityHandlerInheritanceTest`
- `joinedParent_found_through_intermediate`: 중간에 `@Inheritance` 미지정이어도 상위에서 JOINED를 찾아 FK 생성
- `explicitSingleTable_conflict_reportsError`: 중간에 `SINGLE_TABLE` 명시 시 충돌 에러 리포팅, 관계 생성 안 함
- `immediate_joined_parent`: 바로 위 부모가 JOINED인 정상 케이스 회귀 확인

> 추가로, Mockito `UnfinishedStubbingException` 방지를 위해 stubbing 인자를 *선 준비 후 thenReturn* 또는 `doReturn().when()` 패턴으로 정리했습니다.

## 호환성/영향
- **동작 개선**: JOINED 루트를 놓치지 않음
- **진단 강화**: 혼합 전략은 명시적 에러로 조기 탐지 → 더 안전
- API 시그니처 변경 없음, 스키마 결과는 기존 의도와 동일하거나 개선됨

## 리뷰 포인트
- 상속 체인 탐색 조건 및 종료 조건(충돌/사이클)의 적절성
- 에러/경고 메시지 문구(가독성, 맥락성)
- 테스트 케이스 커버리지(추가 시나리오 필요 여부)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 엔티티 필드 처리를 속성 디스크립터 기반으로 수행하는 공개 API를 추가했습니다.
- Bug Fixes
  - JOINED 상속 스캔에서 순환 탐지를 도입해 무한 루프를 방지하고, 문제 경로를 경고로 보고합니다.
  - 상속 계층 내 혼합 전략(SINGLE_TABLE/TABLE_PER_CLASS) 사용 시 오류를 출력해 잘못된 매핑을 차단합니다.
- Refactor
  - 상속 해석 경로에서 jakarta.persistence 주석 사용으로 일관성을 개선했습니다.
- Tests
  - 다양한 상속 시나리오(중간 클래스, 충돌 감지, 직접 부모)를 검증하는 단위 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->