### PR TITLE
ColumnDiffer: 리네임 탐지 성능/정확도 개선 (해시+버킷+타이브레이커)

### DIFF
--- a/jinx-core/src/main/java/org/jinx/migration/differs/ColumnDiffer.java
+++ b/jinx-core/src/main/java/org/jinx/migration/differs/ColumnDiffer.java
@@ -8,41 +8,74 @@ import org.jinx.model.EntityModel;
 import java.util.*;
 
 public class ColumnDiffer implements EntityComponentDiffer {
+    private static final double RENAME_SCORE_THRESHOLD = 0.80;
+    
+    // 필드 가중치 상수
+    private static final int WEIGHT_HIGH = 5;    // 핵심 신원성 필드
+    private static final int WEIGHT_MEDIUM = 3;  // 중요 속성 필드
+    private static final int WEIGHT_LOW = 1;     // 보조 속성 필드
     @Override
     public void diff(EntityModel oldEntity, EntityModel newEntity, DiffResult.ModifiedEntity result) {
+        // canonical 기준 맵 생성 (case-only 변경 감지용)
+        Map<String, ColumnKey> oldCanonicalMap = new HashMap<>();
+        Map<String, ColumnKey> newCanonicalMap = new HashMap<>();
+        oldEntity.getColumns().forEach((key, value) -> oldCanonicalMap.put(key.canonical(), key));
+        newEntity.getColumns().forEach((key, value) -> newCanonicalMap.put(key.canonical(), key));
+        
+        // display 기준 맵 생성 (기존 로직용)
         Map<String, ColumnModel> oldColumns = new HashMap<>();
         oldEntity.getColumns().forEach((key, value) -> oldColumns.put(key.display(), value));
         Map<String, ColumnModel> newColumns = new HashMap<>();
         newEntity.getColumns().forEach((key, value) -> newColumns.put(key.display(), value));
         Set<String> processedNewColumns = new HashSet<>();
-
-        for (Map.Entry<String, ColumnModel> newEntry : newColumns.entrySet()) {
-            Optional<Map.Entry<String, ColumnModel>> renamedMatch = oldColumns.entrySet().stream()
-                    .filter(oldEntry -> !newColumns.containsKey(oldEntry.getKey()) &&
-                            isColumnAttributesEqual(oldEntry.getValue(), newEntry.getValue()))
-                    .findFirst();
-
-            if (renamedMatch.isPresent()) {
-                String oldName = renamedMatch.get().getKey();
-                ColumnModel oldColumn = renamedMatch.get().getValue();
-                ColumnModel newColumn = newEntry.getValue();
+        
+        // case-only 변경 사전 처리 (canonical이 같지만 display가 다른 경우)
+        for (Map.Entry<String, ColumnKey> newEntry : newCanonicalMap.entrySet()) {
+            String canonical = newEntry.getKey();
+            ColumnKey newKey = newEntry.getValue();
+            ColumnKey oldKey = oldCanonicalMap.get(canonical);
+            
+            if (oldKey != null && !oldKey.display().equals(newKey.display())) {
+                // case-only 변경 감지: canonical은 같지만 display가 다름
+                ColumnModel oldColumn = oldEntity.getColumns().get(oldKey);
+                ColumnModel newColumn = newEntity.getColumns().get(newKey);
+                
                 result.getColumnDiffs().add(DiffResult.ColumnDiff.builder()
                         .type(DiffResult.ColumnDiff.Type.RENAMED)
                         .column(newColumn)
                         .oldColumn(oldColumn)
-                        .changeDetail("Column renamed from " + oldName + " to " + newEntry.getKey())
+                        .changeDetail("Column name case changed from " + oldKey.display() + " to " + newKey.display())
                         .build());
-                if (!isColumnEqualExceptName(oldColumn, newColumn)) {
-                    result.getColumnDiffs().add(DiffResult.ColumnDiff.builder()
-                            .type(DiffResult.ColumnDiff.Type.MODIFIED)
-                            .column(newColumn)
-                            .oldColumn(oldColumn)
-                            .changeDetail(getColumnChangeDetail(oldColumn, newColumn))
-                            .build());
-                }
-                oldColumns.remove(oldName);
-                processedNewColumns.add(newEntry.getKey());
+                
+                // 이미 처리된 것으로 마킹 (리네임 탐지에서 제외)
+                processedNewColumns.add(newKey.display());
+                oldColumns.remove(oldKey.display());
             }
+        }
+
+        Map<String, String> bestMatches = findBestRenameMatches(oldColumns, newColumns);
+        for (Map.Entry<String, String> match : bestMatches.entrySet()) {
+            String newName = match.getKey();
+            String oldName = match.getValue();
+            ColumnModel newColumn = newColumns.get(newName);
+            ColumnModel oldColumn = oldColumns.get(oldName);
+            
+            result.getColumnDiffs().add(DiffResult.ColumnDiff.builder()
+                    .type(DiffResult.ColumnDiff.Type.RENAMED)
+                    .column(newColumn)
+                    .oldColumn(oldColumn)
+                    .changeDetail("Column renamed from " + oldName + " to " + newName)
+                    .build());
+            if (!isColumnEqualExceptName(oldColumn, newColumn)) {
+                result.getColumnDiffs().add(DiffResult.ColumnDiff.builder()
+                        .type(DiffResult.ColumnDiff.Type.MODIFIED)
+                        .column(newColumn)
+                        .oldColumn(oldColumn)
+                        .changeDetail(getColumnChangeDetail(oldColumn, newColumn))
+                        .build());
+            }
+            oldColumns.remove(oldName);
+            processedNewColumns.add(newName);
         }
 
         // Detect added/modified columns
@@ -94,169 +127,243 @@ public class ColumnDiffer implements EntityComponentDiffer {
     }
 
     private boolean isColumnEqual(ColumnModel oldCol, ColumnModel newCol) {
-        return Optional.ofNullable(oldCol.getColumnName()).equals(Optional.ofNullable(newCol.getColumnName())) &&
-                Optional.ofNullable(oldCol.getTableName()).equals(Optional.ofNullable(newCol.getTableName())) &&
-                Optional.ofNullable(oldCol.getJavaType()).equals(Optional.ofNullable(newCol.getJavaType())) &&
+        return eq(oldCol.getColumnName(), newCol.getColumnName()) &&
+                eq(oldCol.getTableName(), newCol.getTableName()) &&
+                eq(oldCol.getJavaType(), newCol.getJavaType()) &&
+                eq(oldCol.getComment(), newCol.getComment()) &&
                 oldCol.isPrimaryKey() == newCol.isPrimaryKey() &&
                 oldCol.isNullable() == newCol.isNullable() &&
                 oldCol.getLength() == newCol.getLength() &&
                 oldCol.getPrecision() == newCol.getPrecision() &&
                 oldCol.getScale() == newCol.getScale() &&
-                Optional.ofNullable(oldCol.getDefaultValue()).equals(Optional.ofNullable(newCol.getDefaultValue())) &&
+                eq(oldCol.getDefaultValue(), newCol.getDefaultValue()) &&
                 oldCol.getGenerationStrategy() == newCol.getGenerationStrategy() &&
-                Optional.ofNullable(oldCol.getSequenceName()).equals(Optional.ofNullable(newCol.getSequenceName())) &&
-                Optional.ofNullable(oldCol.getTableGeneratorName()).equals(Optional.ofNullable(newCol.getTableGeneratorName())) &&
+                eq(oldCol.getSequenceName(), newCol.getSequenceName()) &&
+                eq(oldCol.getTableGeneratorName(), newCol.getTableGeneratorName()) &&
                 oldCol.getIdentityStartValue() == newCol.getIdentityStartValue() &&
                 oldCol.getIdentityIncrement() == newCol.getIdentityIncrement() &&
                 oldCol.getIdentityCache() == newCol.getIdentityCache() &&
                 oldCol.getIdentityMinValue() == newCol.getIdentityMinValue() &&
                 oldCol.getIdentityMaxValue() == newCol.getIdentityMaxValue() &&
-                Arrays.equals(oldCol.getIdentityOptions(), newCol.getIdentityOptions()) &&
+                eqArr(oldCol.getIdentityOptions(), newCol.getIdentityOptions()) &&
                 oldCol.isManualPrimaryKey() == newCol.isManualPrimaryKey() &&
                 oldCol.isEnumStringMapping() == newCol.isEnumStringMapping() &&
-                Arrays.equals(oldCol.getEnumValues(), newCol.getEnumValues()) &&
+                eqArr(oldCol.getEnumValues(), newCol.getEnumValues()) &&
                 oldCol.isLob() == newCol.isLob() &&
                 oldCol.getJdbcType() == newCol.getJdbcType() &&
                 oldCol.getFetchType() == newCol.getFetchType() &&
                 oldCol.isOptional() == newCol.isOptional() &&
                 oldCol.isVersion() == newCol.isVersion() &&
-                Optional.ofNullable(oldCol.getConversionClass()).equals(Optional.ofNullable(newCol.getConversionClass())) &&
-                oldCol.getTemporalType() == newCol.getTemporalType();
+                eq(oldCol.getConversionClass(), newCol.getConversionClass()) &&
+                oldCol.getTemporalType() == newCol.getTemporalType() &&
+                eq(oldCol.getSqlTypeOverride(), newCol.getSqlTypeOverride()) &&
+                oldCol.getColumnKind() == newCol.getColumnKind() &&
+                oldCol.getDiscriminatorType() == newCol.getDiscriminatorType() &&
+                eq(oldCol.getColumnDefinition(), newCol.getColumnDefinition()) &&
+                eq(oldCol.getOptions(), newCol.getOptions()) &&
+                oldCol.isMapKey() == newCol.isMapKey() &&
+                eq(oldCol.getMapKeyType(), newCol.getMapKeyType()) &&
+                eqArr(oldCol.getMapKeyEnumValues(), newCol.getMapKeyEnumValues()) &&
+                oldCol.getMapKeyTemporalType() == newCol.getMapKeyTemporalType();
     }
 
-    private boolean isColumnEqualExceptName(ColumnModel oldCol, ColumnModel newCol) {
-        return Optional.ofNullable(oldCol.getTableName()).equals(Optional.ofNullable(newCol.getTableName())) &&
-                Optional.ofNullable(oldCol.getJavaType()).equals(Optional.ofNullable(newCol.getJavaType())) &&
-                oldCol.isPrimaryKey() == newCol.isPrimaryKey() &&
-                oldCol.isNullable() == newCol.isNullable() &&
-                oldCol.getLength() == newCol.getLength() &&
-                oldCol.getPrecision() == newCol.getPrecision() &&
-                oldCol.getScale() == newCol.getScale() &&
-                Optional.ofNullable(oldCol.getDefaultValue()).equals(Optional.ofNullable(newCol.getDefaultValue())) &&
-                oldCol.getGenerationStrategy() == newCol.getGenerationStrategy() &&
-                Optional.ofNullable(oldCol.getSequenceName()).equals(Optional.ofNullable(newCol.getSequenceName())) &&
-                Optional.ofNullable(oldCol.getTableGeneratorName()).equals(Optional.ofNullable(newCol.getTableGeneratorName())) &&
-                oldCol.getIdentityStartValue() == newCol.getIdentityStartValue() &&
-                oldCol.getIdentityIncrement() == newCol.getIdentityIncrement() &&
-                oldCol.getIdentityCache() == newCol.getIdentityCache() &&
-                oldCol.getIdentityMinValue() == newCol.getIdentityMinValue() &&
-                oldCol.getIdentityMaxValue() == newCol.getIdentityMaxValue() &&
-                Arrays.equals(oldCol.getIdentityOptions(), newCol.getIdentityOptions()) &&
-                oldCol.isManualPrimaryKey() == newCol.isManualPrimaryKey() &&
-                oldCol.isEnumStringMapping() == newCol.isEnumStringMapping() &&
-                Arrays.equals(oldCol.getEnumValues(), newCol.getEnumValues()) &&
-                oldCol.isLob() == newCol.isLob() &&
-                oldCol.getJdbcType() == newCol.getJdbcType() &&
-                oldCol.getFetchType() == newCol.getFetchType() &&
-                oldCol.isOptional() == newCol.isOptional() &&
-                oldCol.isVersion() == newCol.isVersion() &&
-                Optional.ofNullable(oldCol.getConversionClass()).equals(Optional.ofNullable(newCol.getConversionClass())) &&
-                oldCol.getTemporalType() == newCol.getTemporalType();
+    private boolean isColumnEqualExceptName(ColumnModel a, ColumnModel b) {
+        if (a.getAttributeHashExceptName() != b.getAttributeHashExceptName()) return false;
+        // 해시가 같을 때만 안전망 상세 비교 (해시 충돌 대비)
+        return eq(a.getTableName(), b.getTableName()) &&
+                eq(a.getJavaType(), b.getJavaType()) &&
+                eq(a.getComment(), b.getComment()) &&
+                a.isPrimaryKey() == b.isPrimaryKey() &&
+                a.isNullable() == b.isNullable() &&
+                a.getLength() == b.getLength() &&
+                a.getPrecision() == b.getPrecision() &&
+                a.getScale() == b.getScale() &&
+                eq(a.getDefaultValue(), b.getDefaultValue()) &&
+                a.getGenerationStrategy() == b.getGenerationStrategy() &&
+                eq(a.getSequenceName(), b.getSequenceName()) &&
+                eq(a.getTableGeneratorName(), b.getTableGeneratorName()) &&
+                a.getIdentityStartValue() == b.getIdentityStartValue() &&
+                a.getIdentityIncrement() == b.getIdentityIncrement() &&
+                a.getIdentityCache() == b.getIdentityCache() &&
+                a.getIdentityMinValue() == b.getIdentityMinValue() &&
+                a.getIdentityMaxValue() == b.getIdentityMaxValue() &&
+                eqArr(a.getIdentityOptions(), b.getIdentityOptions()) &&
+                a.isManualPrimaryKey() == b.isManualPrimaryKey() &&
+                a.isEnumStringMapping() == b.isEnumStringMapping() &&
+                eqArr(a.getEnumValues(), b.getEnumValues()) &&
+                a.isLob() == b.isLob() &&
+                a.getJdbcType() == b.getJdbcType() &&
+                a.getFetchType() == b.getFetchType() &&
+                a.isOptional() == b.isOptional() &&
+                a.isVersion() == b.isVersion() &&
+                eq(a.getConversionClass(), b.getConversionClass()) &&
+                a.getTemporalType() == b.getTemporalType() &&
+                eq(a.getSqlTypeOverride(), b.getSqlTypeOverride()) &&
+                a.getColumnKind() == b.getColumnKind() &&
+                a.getDiscriminatorType() == b.getDiscriminatorType() &&
+                eq(a.getColumnDefinition(), b.getColumnDefinition()) &&
+                eq(a.getOptions(), b.getOptions()) &&
+                a.isMapKey() == b.isMapKey() &&
+                eq(a.getMapKeyType(), b.getMapKeyType()) &&
+                eqArr(a.getMapKeyEnumValues(), b.getMapKeyEnumValues()) &&
+                a.getMapKeyTemporalType() == b.getMapKeyTemporalType();
     }
 
-    private boolean isColumnAttributesEqual(ColumnModel oldCol, ColumnModel newCol) {
-        return Optional.ofNullable(oldCol.getJavaType()).equals(Optional.ofNullable(newCol.getJavaType())) &&
-                oldCol.isPrimaryKey() == newCol.isPrimaryKey() &&
-                oldCol.isNullable() == newCol.isNullable() &&
-                oldCol.getLength() == newCol.getLength() &&
-                oldCol.getPrecision() == newCol.getPrecision() &&
-                oldCol.getScale() == newCol.getScale() &&
-                oldCol.getGenerationStrategy() == newCol.getGenerationStrategy() &&
-                Optional.ofNullable(oldCol.getSequenceName()).equals(Optional.ofNullable(newCol.getSequenceName())) &&
-                Optional.ofNullable(oldCol.getTableGeneratorName()).equals(Optional.ofNullable(newCol.getTableGeneratorName())) &&
-                oldCol.isEnumStringMapping() == newCol.isEnumStringMapping() &&
-                Arrays.equals(oldCol.getEnumValues(), newCol.getEnumValues()) &&
-                oldCol.isLob() == newCol.isLob() &&
-                oldCol.getJdbcType() == newCol.getJdbcType() &&
-                Optional.ofNullable(oldCol.getConversionClass()).equals(Optional.ofNullable(newCol.getConversionClass())) &&
-                oldCol.getTemporalType() == newCol.getTemporalType();
+    private boolean isColumnAttributesEqual(ColumnModel a, ColumnModel b) {
+        if (a.getAttributeHashExceptName() != b.getAttributeHashExceptName()) return false;
+        // 해시가 같을 때만 안전망 상세 비교 (해시 충돌 대비)
+        return eq(a.getTableName(), b.getTableName()) &&
+                eq(a.getJavaType(), b.getJavaType()) &&
+                eq(a.getComment(), b.getComment()) &&
+                a.isPrimaryKey() == b.isPrimaryKey() &&
+                a.isNullable() == b.isNullable() &&
+                a.getLength() == b.getLength() &&
+                a.getPrecision() == b.getPrecision() &&
+                a.getScale() == b.getScale() &&
+                eq(a.getDefaultValue(), b.getDefaultValue()) &&
+                a.getGenerationStrategy() == b.getGenerationStrategy() &&
+                eq(a.getSequenceName(), b.getSequenceName()) &&
+                eq(a.getTableGeneratorName(), b.getTableGeneratorName()) &&
+                a.getIdentityStartValue() == b.getIdentityStartValue() &&
+                a.getIdentityIncrement() == b.getIdentityIncrement() &&
+                a.getIdentityCache() == b.getIdentityCache() &&
+                a.getIdentityMinValue() == b.getIdentityMinValue() &&
+                a.getIdentityMaxValue() == b.getIdentityMaxValue() &&
+                eqArr(a.getIdentityOptions(), b.getIdentityOptions()) &&
+                a.isManualPrimaryKey() == b.isManualPrimaryKey() &&
+                a.isEnumStringMapping() == b.isEnumStringMapping() &&
+                eqArr(a.getEnumValues(), b.getEnumValues()) &&
+                a.isLob() == b.isLob() &&
+                a.getJdbcType() == b.getJdbcType() &&
+                a.getFetchType() == b.getFetchType() &&
+                a.isOptional() == b.isOptional() &&
+                a.isVersion() == b.isVersion() &&
+                eq(a.getConversionClass(), b.getConversionClass()) &&
+                a.getTemporalType() == b.getTemporalType() &&
+                eq(a.getSqlTypeOverride(), b.getSqlTypeOverride()) &&
+                a.getColumnKind() == b.getColumnKind() &&
+                a.getDiscriminatorType() == b.getDiscriminatorType() &&
+                eq(a.getColumnDefinition(), b.getColumnDefinition()) &&
+                eq(a.getOptions(), b.getOptions()) &&
+                a.isMapKey() == b.isMapKey() &&
+                eq(a.getMapKeyType(), b.getMapKeyType()) &&
+                eqArr(a.getMapKeyEnumValues(), b.getMapKeyEnumValues()) &&
+                a.getMapKeyTemporalType() == b.getMapKeyTemporalType();
     }
 
     private String getColumnChangeDetail(ColumnModel oldCol, ColumnModel newCol) {
-        StringBuilder detail = new StringBuilder();
-        if (!Optional.ofNullable(oldCol.getTableName()).equals(Optional.ofNullable(newCol.getTableName()))) {
-            detail.append("tableName changed from ").append(oldCol.getTableName()).append(" to ").append(newCol.getTableName()).append("; ");
+        List<String> changes = new ArrayList<>();
+        
+        if (!eq(oldCol.getTableName(), newCol.getTableName())) {
+            changes.add("tableName changed from " + oldCol.getTableName() + " to " + newCol.getTableName());
         }
-        if (!Optional.ofNullable(oldCol.getJavaType()).equals(Optional.ofNullable(newCol.getJavaType()))) {
-            detail.append("javaType changed from ").append(oldCol.getJavaType()).append(" to ").append(newCol.getJavaType()).append("; ");
+        if (!eq(oldCol.getJavaType(), newCol.getJavaType())) {
+            changes.add("javaType changed from " + oldCol.getJavaType() + " to " + newCol.getJavaType());
         }
         if (oldCol.isPrimaryKey() != newCol.isPrimaryKey()) {
-            detail.append("isPrimaryKey changed from ").append(oldCol.isPrimaryKey()).append(" to ").append(newCol.isPrimaryKey()).append("; ");
+            changes.add("isPrimaryKey changed from " + oldCol.isPrimaryKey() + " to " + newCol.isPrimaryKey());
         }
         if (oldCol.isNullable() != newCol.isNullable()) {
-            detail.append("isNullable changed from ").append(oldCol.isNullable()).append(" to ").append(newCol.isNullable()).append("; ");
+            changes.add("isNullable changed from " + oldCol.isNullable() + " to " + newCol.isNullable());
         }
         if (oldCol.getLength() != newCol.getLength()) {
-            detail.append("length changed from ").append(oldCol.getLength()).append(" to ").append(newCol.getLength()).append("; ");
+            changes.add("length changed from " + oldCol.getLength() + " to " + newCol.getLength());
         }
         if (oldCol.getPrecision() != newCol.getPrecision()) {
-            detail.append("precision changed from ").append(oldCol.getPrecision()).append(" to ").append(newCol.getPrecision()).append("; ");
+            changes.add("precision changed from " + oldCol.getPrecision() + " to " + newCol.getPrecision());
         }
         if (oldCol.getScale() != newCol.getScale()) {
-            detail.append("scale changed from ").append(oldCol.getScale()).append(" to ").append(newCol.getScale()).append("; ");
+            changes.add("scale changed from " + oldCol.getScale() + " to " + newCol.getScale());
         }
-        if (!Optional.ofNullable(oldCol.getDefaultValue()).equals(Optional.ofNullable(newCol.getDefaultValue()))) {
-            detail.append("defaultValue changed from ").append(oldCol.getDefaultValue()).append(" to ").append(newCol.getDefaultValue()).append("; ");
+        if (!eq(oldCol.getDefaultValue(), newCol.getDefaultValue())) {
+            changes.add("defaultValue changed from " + oldCol.getDefaultValue() + " to " + newCol.getDefaultValue());
         }
         if (oldCol.getGenerationStrategy() != newCol.getGenerationStrategy()) {
-            detail.append("generationStrategy changed from ").append(oldCol.getGenerationStrategy()).append(" to ").append(newCol.getGenerationStrategy()).append("; ");
+            changes.add("generationStrategy changed from " + oldCol.getGenerationStrategy() + " to " + newCol.getGenerationStrategy());
         }
-        if (!Optional.ofNullable(oldCol.getSequenceName()).equals(Optional.ofNullable(newCol.getSequenceName()))) {
-            detail.append("sequenceName changed from ").append(oldCol.getSequenceName()).append(" to ").append(newCol.getSequenceName()).append("; ");
+        if (!eq(oldCol.getSequenceName(), newCol.getSequenceName())) {
+            changes.add("sequenceName changed from " + oldCol.getSequenceName() + " to " + newCol.getSequenceName());
         }
-        if (!Optional.ofNullable(oldCol.getTableGeneratorName()).equals(Optional.ofNullable(newCol.getTableGeneratorName()))) {
-            detail.append("tableGeneratorName changed from ").append(oldCol.getTableGeneratorName()).append(" to ").append(newCol.getTableGeneratorName()).append("; ");
+        if (!eq(oldCol.getTableGeneratorName(), newCol.getTableGeneratorName())) {
+            changes.add("tableGeneratorName changed from " + oldCol.getTableGeneratorName() + " to " + newCol.getTableGeneratorName());
         }
         if (oldCol.getIdentityStartValue() != newCol.getIdentityStartValue()) {
-            detail.append("identityStartValue changed from ").append(oldCol.getIdentityStartValue()).append(" to ").append(newCol.getIdentityStartValue()).append("; ");
+            changes.add("identityStartValue changed from " + oldCol.getIdentityStartValue() + " to " + newCol.getIdentityStartValue());
         }
         if (oldCol.getIdentityIncrement() != newCol.getIdentityIncrement()) {
-            detail.append("identityIncrement changed from ").append(oldCol.getIdentityIncrement()).append(" to ").append(newCol.getIdentityIncrement()).append("; ");
+            changes.add("identityIncrement changed from " + oldCol.getIdentityIncrement() + " to " + newCol.getIdentityIncrement());
         }
         if (oldCol.getIdentityCache() != newCol.getIdentityCache()) {
-            detail.append("identityCache changed from ").append(oldCol.getIdentityCache()).append(" to ").append(newCol.getIdentityCache()).append("; ");
+            changes.add("identityCache changed from " + oldCol.getIdentityCache() + " to " + newCol.getIdentityCache());
         }
         if (oldCol.getIdentityMinValue() != newCol.getIdentityMinValue()) {
-            detail.append("identityMinValue changed from ").append(oldCol.getIdentityMinValue()).append(" to ").append(newCol.getIdentityMinValue()).append("; ");
+            changes.add("identityMinValue changed from " + oldCol.getIdentityMinValue() + " to " + newCol.getIdentityMinValue());
         }
         if (oldCol.getIdentityMaxValue() != newCol.getIdentityMaxValue()) {
-            detail.append("identityMaxValue changed from ").append(oldCol.getIdentityMaxValue()).append(" to ").append(newCol.getIdentityMaxValue()).append("; ");
+            changes.add("identityMaxValue changed from " + oldCol.getIdentityMaxValue() + " to " + newCol.getIdentityMaxValue());
         }
-        if (!Arrays.equals(oldCol.getIdentityOptions(), newCol.getIdentityOptions())) {
-            detail.append("identityOptions changed from ").append(Arrays.toString(oldCol.getIdentityOptions())).append(" to ").append(Arrays.toString(newCol.getIdentityOptions())).append("; ");
+        if (!eqArr(oldCol.getIdentityOptions(), newCol.getIdentityOptions())) {
+            changes.add("identityOptions changed from " + arrToString(oldCol.getIdentityOptions()) + " to " + arrToString(newCol.getIdentityOptions()));
         }
-        // ✨ 일관성 유지를 위해 추가된 코드
         if (oldCol.isManualPrimaryKey() != newCol.isManualPrimaryKey()) {
-            detail.append("isManualPrimaryKey changed from ").append(oldCol.isManualPrimaryKey()).append(" to ").append(newCol.isManualPrimaryKey()).append("; ");
+            changes.add("isManualPrimaryKey changed from " + oldCol.isManualPrimaryKey() + " to " + newCol.isManualPrimaryKey());
         }
         if (oldCol.isLob() != newCol.isLob()) {
-            detail.append("isLob changed from ").append(oldCol.isLob()).append(" to ").append(newCol.isLob()).append("; ");
+            changes.add("isLob changed from " + oldCol.isLob() + " to " + newCol.isLob());
         }
         if (oldCol.getJdbcType() != newCol.getJdbcType()) {
-            detail.append("jdbcType changed from ").append(oldCol.getJdbcType()).append(" to ").append(newCol.getJdbcType()).append("; ");
+            changes.add("jdbcType changed from " + oldCol.getJdbcType() + " to " + newCol.getJdbcType());
         }
         if (oldCol.getFetchType() != newCol.getFetchType()) {
-            detail.append("fetchType changed from ").append(oldCol.getFetchType()).append(" to ").append(newCol.getFetchType()).append("; ");
+            changes.add("fetchType changed from " + oldCol.getFetchType() + " to " + newCol.getFetchType());
         }
         if (oldCol.isOptional() != newCol.isOptional()) {
-            detail.append("isOptional changed from ").append(oldCol.isOptional()).append(" to ").append(newCol.isOptional()).append("; ");
+            changes.add("isOptional changed from " + oldCol.isOptional() + " to " + newCol.isOptional());
         }
         if (oldCol.isVersion() != newCol.isVersion()) {
-            detail.append("isVersion changed from ").append(oldCol.isVersion()).append(" to ").append(newCol.isVersion()).append("; ");
+            changes.add("isVersion changed from " + oldCol.isVersion() + " to " + newCol.isVersion());
         }
-        if (!Optional.ofNullable(oldCol.getConversionClass()).equals(Optional.ofNullable(newCol.getConversionClass()))) {
-            detail.append("conversionClass changed from ").append(oldCol.getConversionClass()).append(" to ").append(newCol.getConversionClass()).append("; ");
+        if (!eq(oldCol.getConversionClass(), newCol.getConversionClass())) {
+            changes.add("conversionClass changed from " + oldCol.getConversionClass() + " to " + newCol.getConversionClass());
         }
         if (oldCol.getTemporalType() != newCol.getTemporalType()) {
-            detail.append("temporalType changed from ").append(oldCol.getTemporalType()).append(" to ").append(newCol.getTemporalType()).append("; ");
+            changes.add("temporalType changed from " + oldCol.getTemporalType() + " to " + newCol.getTemporalType());
         }
-        if (!Arrays.equals(oldCol.getEnumValues(), newCol.getEnumValues())) {
-            detail.append("enumValues changed; ");
+        if (!eqArr(oldCol.getEnumValues(), newCol.getEnumValues())) {
+            changes.add("enumValues changed");
         }
-        if (detail.length() > 2) {
-            detail.setLength(detail.length() - 2);
+        if (!eq(oldCol.getComment(), newCol.getComment())) {
+            changes.add("comment changed from " + oldCol.getComment() + " to " + newCol.getComment());
         }
-        return detail.toString();
+        if (!eq(oldCol.getSqlTypeOverride(), newCol.getSqlTypeOverride())) {
+            changes.add("sqlTypeOverride changed from " + oldCol.getSqlTypeOverride() + " to " + newCol.getSqlTypeOverride());
+        }
+        if (oldCol.getColumnKind() != newCol.getColumnKind()) {
+            changes.add("columnKind changed from " + oldCol.getColumnKind() + " to " + newCol.getColumnKind());
+        }
+        if (oldCol.getDiscriminatorType() != newCol.getDiscriminatorType()) {
+            changes.add("discriminatorType changed from " + oldCol.getDiscriminatorType() + " to " + newCol.getDiscriminatorType());
+        }
+        if (!eq(oldCol.getColumnDefinition(), newCol.getColumnDefinition())) {
+            changes.add("columnDefinition changed from " + oldCol.getColumnDefinition() + " to " + newCol.getColumnDefinition());
+        }
+        if (!eq(oldCol.getOptions(), newCol.getOptions())) {
+            changes.add("options changed from " + oldCol.getOptions() + " to " + newCol.getOptions());
+        }
+        if (oldCol.isMapKey() != newCol.isMapKey()) {
+            changes.add("isMapKey changed from " + oldCol.isMapKey() + " to " + newCol.isMapKey());
+        }
+        if (!eq(oldCol.getMapKeyType(), newCol.getMapKeyType())) {
+            changes.add("mapKeyType changed from " + oldCol.getMapKeyType() + " to " + newCol.getMapKeyType());
+        }
+        if (!eqArr(oldCol.getMapKeyEnumValues(), newCol.getMapKeyEnumValues())) {
+            changes.add("mapKeyEnumValues changed from " + arrToString(oldCol.getMapKeyEnumValues()) + " to " + arrToString(newCol.getMapKeyEnumValues()));
+        }
+        if (oldCol.getMapKeyTemporalType() != newCol.getMapKeyTemporalType()) {
+            changes.add("mapKeyTemporalType changed from " + oldCol.getMapKeyTemporalType() + " to " + newCol.getMapKeyTemporalType());
+        }
+        
+        return String.join("; ", changes);
     }
 
     private void analyzeColumnChanges(ColumnModel oldCol, ColumnModel newCol, DiffResult.ModifiedEntity modified) {
@@ -264,7 +371,7 @@ public class ColumnDiffer implements EntityComponentDiffer {
             modified.getWarnings().add("Nullable column " + newCol.getColumnName() +
                     " is now NOT NULL; existing null data will violate constraint.");
         }
-        if (!Optional.ofNullable(oldCol.getJavaType()).equals(Optional.ofNullable(newCol.getJavaType()))) {
+        if (!eq(oldCol.getJavaType(), newCol.getJavaType())) {
             String change = analyzeTypeConversion(oldCol.getJavaType(), newCol.getJavaType());
             if (change.startsWith("Narrowing")) {
                 modified.getWarnings().add("Dangerous type conversion in column " + newCol.getColumnName() + ": " + change);
@@ -283,16 +390,71 @@ public class ColumnDiffer implements EntityComponentDiffer {
                     " from " + oldCol.getFetchType() + " to " + newCol.getFetchType() +
                     "; may impact data retrieval performance.");
         }
-        if (!Optional.ofNullable(oldCol.getConversionClass()).equals(Optional.ofNullable(newCol.getConversionClass()))) {
+        if (!eq(oldCol.getConversionClass(), newCol.getConversionClass())) {
             modified.getWarnings().add("Converter changed in column " + newCol.getColumnName() +
                     " from " + oldCol.getConversionClass() + " to " + newCol.getConversionClass() +
                     "; verify data compatibility.");
         }
+        if (oldCol.isPrimaryKey() != newCol.isPrimaryKey()) {
+            modified.getWarnings().add("Primary key flag changed in column " + newCol.getColumnName() +
+                    " from " + oldCol.isPrimaryKey() + " to " + newCol.isPrimaryKey() +
+                    "; significant schema structure change.");
+        }
+        if (oldCol.getGenerationStrategy() != newCol.getGenerationStrategy()) {
+            modified.getWarnings().add("Generation strategy changed in column " + newCol.getColumnName() +
+                    " from " + oldCol.getGenerationStrategy() + " to " + newCol.getGenerationStrategy() +
+                    "; may require data migration.");
+        }
+        if (!eq(oldCol.getSqlTypeOverride(), newCol.getSqlTypeOverride())) {
+            modified.getWarnings().add("SQL type override changed in column " + newCol.getColumnName() +
+                    " from " + oldCol.getSqlTypeOverride() + " to " + newCol.getSqlTypeOverride() +
+                    "; actual column type may change.");
+        }
+        if (!eq(oldCol.getDefaultValue(), newCol.getDefaultValue())) {
+            modified.getWarnings().add("Default value changed in column " + newCol.getColumnName() +
+                    " from " + oldCol.getDefaultValue() + " to " + newCol.getDefaultValue() +
+                    "; may affect existing data.");
+        }
+        if (oldCol.getPrecision() > newCol.getPrecision() && newCol.getPrecision() > 0) {
+            modified.getWarnings().add("Dangerous precision reduction in column " + newCol.getColumnName() +
+                    " from " + oldCol.getPrecision() + " to " + newCol.getPrecision() + "; may cause data truncation.");
+        }
+        if (oldCol.getScale() > newCol.getScale() && newCol.getScale() >= 0) {
+            modified.getWarnings().add("Dangerous scale reduction in column " + newCol.getColumnName() +
+                    " from " + oldCol.getScale() + " to " + newCol.getScale() + "; may cause data truncation.");
+        }
+        if (oldCol.isLob() != newCol.isLob()) {
+            modified.getWarnings().add("LOB flag changed in column " + newCol.getColumnName() +
+                    " from " + oldCol.isLob() + " to " + newCol.isLob() +
+                    "; significant storage and performance impact.");
+        }
+        if (oldCol.getJdbcType() != newCol.getJdbcType()) {
+            modified.getWarnings().add("JDBC type changed in column " + newCol.getColumnName() +
+                    " from " + oldCol.getJdbcType() + " to " + newCol.getJdbcType() +
+                    "; verify type compatibility.");
+        }
+        if (oldCol.isMapKey() != newCol.isMapKey() || !eq(oldCol.getMapKeyType(), newCol.getMapKeyType()) ||
+                !eqArr(oldCol.getMapKeyEnumValues(), newCol.getMapKeyEnumValues()) ||
+                oldCol.getMapKeyTemporalType() != newCol.getMapKeyTemporalType()) {
+            modified.getWarnings().add("MapKey metadata changed in column " + newCol.getColumnName() +
+                    "; collection mapping semantics may change.");
+        }
+        if (oldCol.isVersion() != newCol.isVersion()) {
+            modified.getWarnings().add("Version flag changed in column " + newCol.getColumnName() +
+                    " from " + oldCol.isVersion() + " to " + newCol.isVersion() +
+                    "; optimistic locking strategy may change.");
+        }
+        if (oldCol.getDiscriminatorType() != newCol.getDiscriminatorType() ||
+                !eq(oldCol.getColumnDefinition(), newCol.getColumnDefinition()) ||
+                !eq(oldCol.getOptions(), newCol.getOptions())) {
+            modified.getWarnings().add("Discriminator metadata changed in column " + newCol.getColumnName() +
+                    "; inheritance mapping may be affected.");
+        }
     }
 
     private void analyzeEnumChanges(ColumnModel oldCol, ColumnModel newCol, DiffResult.ModifiedEntity modified) {
-        List<String> newEnums = Arrays.asList(newCol.getEnumValues());
-        List<String> oldEnums = Arrays.asList(oldCol.getEnumValues());
+        List<String> newEnums = toListSafe(newCol.getEnumValues());
+        List<String> oldEnums = toListSafe(oldCol.getEnumValues());
         List<String> added = new ArrayList<>(newEnums);
         added.removeAll(oldEnums);
         List<String> removed = new ArrayList<>(oldEnums);
@@ -328,6 +490,275 @@ public class ColumnDiffer implements EntityComponentDiffer {
 
     private boolean isEnumMappingChanged(ColumnModel oldCol, ColumnModel newCol) {
         return isEnum(oldCol) && isEnum(newCol) && oldCol.isEnumStringMapping() != newCol.isEnumStringMapping();
+    }
+
+    private static boolean eq(Object a, Object b) {
+        return Objects.equals(a, b);
+    }
+
+    private static boolean eqArr(Object[] a, Object[] b) {
+        return Arrays.equals(a, b);
+    }
+
+    private static String arrToString(String[] a) {
+        return Arrays.toString(a != null ? a : new String[0]);
+    }
+
+    private static List<String> toListSafe(String[] array) {
+        return Arrays.asList(Optional.ofNullable(array).orElse(new String[0]));
+    }
+
+    static final class CoarseKey {
+        final String table;
+        final Object jdbcType;
+        final String javaType;
+        final boolean enumString;
+        final Object temporal;
+        final boolean nullable;
+
+        CoarseKey(ColumnModel c) {
+            this.table = c.getTableName();
+            this.jdbcType = c.getJdbcType();
+            this.javaType = c.getJavaType();
+            this.enumString = c.isEnumStringMapping();
+            this.temporal = c.getTemporalType();
+            this.nullable = c.isNullable();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            CoarseKey coarseKey = (CoarseKey) o;
+            return enumString == coarseKey.enumString &&
+                    nullable == coarseKey.nullable &&
+                    eq(table, coarseKey.table) &&
+                    eq(jdbcType, coarseKey.jdbcType) &&
+                    eq(javaType, coarseKey.javaType) &&
+                    eq(temporal, coarseKey.temporal);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(table, jdbcType, javaType, enumString, temporal, nullable);
+        }
+    }
+
+    private static int tieBreaker(String oldName, String newName) {
+        int lenDiff = Math.abs(oldName.length() - newName.length());
+        int common = 0;
+        for (int i = 0; i < Math.min(oldName.length(), newName.length()); i++) {
+            if (oldName.charAt(i) != newName.charAt(i)) break;
+            common++;
+        }
+        return (lenDiff * 100) - common;
+    }
+    
+    private static String pickByTieBreaker(List<String> candidates, Set<String> used, String newName) {
+        if (candidates == null || candidates.isEmpty()) return null;
+        
+        String best = null;
+        int bestTieBreaker = Integer.MAX_VALUE;
+        
+        for (String candidate : candidates) {
+            if (used.contains(candidate)) continue;
+            
+            int tie = tieBreaker(candidate, newName);
+            if (tie < bestTieBreaker) {
+                bestTieBreaker = tie;
+                best = candidate;
+            }
+        }
+        
+        return best;
+    }
+
+    private Map<String, String> findBestRenameMatches(Map<String, ColumnModel> oldColumns, Map<String, ColumnModel> newColumns) {
+        // 버킷 빌드: 완전일치(해시) + 조대시그니처 (초기 용량 최적화)
+        Map<Long, List<String>> exactBuckets = new HashMap<>(oldColumns.size());
+        Map<CoarseKey, List<String>> coarseBuckets = new HashMap<>(oldColumns.size());
+        
+        for (Map.Entry<String, ColumnModel> entry : oldColumns.entrySet()) {
+            String oldName = entry.getKey();
+            ColumnModel oldCol = entry.getValue();
+            if (!newColumns.containsKey(oldName)) { // 리네임 후보만
+                exactBuckets.computeIfAbsent(oldCol.getAttributeHashExceptName(), k -> new ArrayList<>()).add(oldName);
+                coarseBuckets.computeIfAbsent(new CoarseKey(oldCol), k -> new ArrayList<>()).add(oldName);
+            }
+        }
+        
+        Map<String, String> bestMatches = new HashMap<>();
+        Set<String> usedOldNames = new HashSet<>();
+        
+        for (Map.Entry<String, ColumnModel> newEntry : newColumns.entrySet()) {
+            String newName = newEntry.getKey();
+            ColumnModel newColumn = newEntry.getValue();
+            
+            if (oldColumns.containsKey(newName)) {
+                continue; // 이미 존재하는 이름
+            }
+            
+            // 1단계: 해시 완전 일치
+            List<String> exactMatches = exactBuckets.get(newColumn.getAttributeHashExceptName());
+            String bestExact = pickByTieBreaker(exactMatches, usedOldNames, newName);
+            if (bestExact != null) {
+                bestMatches.put(newName, bestExact);
+                usedOldNames.add(bestExact);
+                continue;
+            }
+            
+            // 2단계: 조대시그니처 후보만 유사도 계산 (O(n) → O(작은상수))
+            List<String> coarseCandidates = coarseBuckets.getOrDefault(new CoarseKey(newColumn), List.of());
+            if (coarseCandidates.isEmpty()) {
+                continue; // 후보가 없으면 빠른 스킵
+            }
+            
+            String bestOldName = null;
+            double bestScore = 0.0;
+            int bestTieBreaker = Integer.MAX_VALUE;
+            
+            for (String oldName : coarseCandidates) {
+                if (usedOldNames.contains(oldName) || newColumns.containsKey(oldName)) {
+                    continue;
+                }
+                
+                ColumnModel oldColumn = oldColumns.get(oldName);
+                double score = calculateSimilarityScore(oldColumn, newColumn);
+                if (score >= RENAME_SCORE_THRESHOLD) {
+                    int currentTieBreaker = tieBreaker(oldName, newName);
+                    if (score > bestScore || (score == bestScore && currentTieBreaker < bestTieBreaker)) {
+                        bestScore = score;
+                        bestOldName = oldName;
+                        bestTieBreaker = currentTieBreaker;
+                    }
+                }
+            }
+            
+            if (bestOldName != null) {
+                bestMatches.put(newName, bestOldName);
+                usedOldNames.add(bestOldName);
+            }
+        }
+        
+        return bestMatches;
+    }
+    
+    private double calculateSimilarityScore(ColumnModel oldCol, ColumnModel newCol) {
+        int totalWeight = 0;
+        int matchedWeight = 0;
+        
+        // 고가중치 (핵심 신원성 필드)
+        totalWeight += WEIGHT_HIGH;
+        if (eq(oldCol.getJavaType(), newCol.getJavaType())) matchedWeight += WEIGHT_HIGH;
+        
+        totalWeight += WEIGHT_HIGH;
+        if (oldCol.getJdbcType() == newCol.getJdbcType()) matchedWeight += WEIGHT_HIGH;
+        
+        totalWeight += WEIGHT_HIGH;
+        if (oldCol.isEnumStringMapping() == newCol.isEnumStringMapping()) matchedWeight += WEIGHT_HIGH;
+        
+        totalWeight += WEIGHT_HIGH;
+        if (eqArr(oldCol.getEnumValues(), newCol.getEnumValues())) matchedWeight += WEIGHT_HIGH;
+        
+        totalWeight += WEIGHT_HIGH;
+        if (oldCol.getTemporalType() == newCol.getTemporalType()) matchedWeight += WEIGHT_HIGH;
+        
+        totalWeight += WEIGHT_HIGH;
+        if (eq(oldCol.getSqlTypeOverride(), newCol.getSqlTypeOverride())) matchedWeight += WEIGHT_HIGH;
+        
+        totalWeight += WEIGHT_HIGH;
+        if (eq(oldCol.getConversionClass(), newCol.getConversionClass())) matchedWeight += WEIGHT_HIGH;
+        
+        // 중가중치 (중요 속성 필드)
+        totalWeight += WEIGHT_MEDIUM;
+        if (eq(oldCol.getTableName(), newCol.getTableName())) matchedWeight += WEIGHT_MEDIUM;
+        
+        totalWeight += WEIGHT_MEDIUM;
+        if (oldCol.isPrimaryKey() == newCol.isPrimaryKey()) matchedWeight += WEIGHT_MEDIUM;
+        
+        totalWeight += WEIGHT_MEDIUM;
+        if (oldCol.isNullable() == newCol.isNullable()) matchedWeight += WEIGHT_MEDIUM;
+        
+        totalWeight += WEIGHT_MEDIUM;
+        if (oldCol.getLength() == newCol.getLength()) matchedWeight += WEIGHT_MEDIUM;
+        
+        totalWeight += WEIGHT_MEDIUM;
+        if (oldCol.getPrecision() == newCol.getPrecision()) matchedWeight += WEIGHT_MEDIUM;
+        
+        totalWeight += WEIGHT_MEDIUM;
+        if (oldCol.getScale() == newCol.getScale()) matchedWeight += WEIGHT_MEDIUM;
+        
+        totalWeight += WEIGHT_MEDIUM;
+        if (eq(oldCol.getDefaultValue(), newCol.getDefaultValue())) matchedWeight += WEIGHT_MEDIUM;
+        
+        totalWeight += WEIGHT_MEDIUM;
+        if (oldCol.isLob() == newCol.isLob()) matchedWeight += WEIGHT_MEDIUM;
+        
+        totalWeight += WEIGHT_MEDIUM;
+        if (oldCol.getGenerationStrategy() == newCol.getGenerationStrategy()) matchedWeight += WEIGHT_MEDIUM;
+        
+        totalWeight += WEIGHT_MEDIUM;
+        if (oldCol.getColumnKind() == newCol.getColumnKind()) matchedWeight += WEIGHT_MEDIUM;
+        
+        // 저가중치 (보조 속성 필드)
+        totalWeight += WEIGHT_LOW;
+        if (oldCol.getFetchType() == newCol.getFetchType()) matchedWeight += WEIGHT_LOW;
+        
+        totalWeight += WEIGHT_LOW;
+        if (oldCol.isOptional() == newCol.isOptional()) matchedWeight += WEIGHT_LOW;
+        
+        totalWeight += WEIGHT_LOW;
+        if (oldCol.isVersion() == newCol.isVersion()) matchedWeight += WEIGHT_LOW;
+        
+        totalWeight += WEIGHT_LOW;
+        if (eq(oldCol.getSequenceName(), newCol.getSequenceName())) matchedWeight += WEIGHT_LOW;
+        
+        totalWeight += WEIGHT_LOW;
+        if (eq(oldCol.getTableGeneratorName(), newCol.getTableGeneratorName())) matchedWeight += WEIGHT_LOW;
+        
+        totalWeight += WEIGHT_LOW;
+        if (oldCol.getIdentityStartValue() == newCol.getIdentityStartValue()) matchedWeight += WEIGHT_LOW;
+        
+        totalWeight += WEIGHT_LOW;
+        if (oldCol.getIdentityIncrement() == newCol.getIdentityIncrement()) matchedWeight += WEIGHT_LOW;
+        
+        totalWeight += WEIGHT_LOW;
+        if (oldCol.getIdentityCache() == newCol.getIdentityCache()) matchedWeight += WEIGHT_LOW;
+        
+        totalWeight += WEIGHT_LOW;
+        if (oldCol.getIdentityMinValue() == newCol.getIdentityMinValue()) matchedWeight += WEIGHT_LOW;
+        
+        totalWeight += WEIGHT_LOW;
+        if (oldCol.getIdentityMaxValue() == newCol.getIdentityMaxValue()) matchedWeight += WEIGHT_LOW;
+        
+        totalWeight += WEIGHT_LOW;
+        if (eqArr(oldCol.getIdentityOptions(), newCol.getIdentityOptions())) matchedWeight += WEIGHT_LOW;
+        
+        totalWeight += WEIGHT_LOW;
+        if (oldCol.isManualPrimaryKey() == newCol.isManualPrimaryKey()) matchedWeight += WEIGHT_LOW;
+        
+        totalWeight += WEIGHT_LOW;
+        if (oldCol.getDiscriminatorType() == newCol.getDiscriminatorType()) matchedWeight += WEIGHT_LOW;
+        
+        totalWeight += WEIGHT_LOW;
+        if (eq(oldCol.getColumnDefinition(), newCol.getColumnDefinition())) matchedWeight += WEIGHT_LOW;
+        
+        totalWeight += WEIGHT_LOW;
+        if (eq(oldCol.getOptions(), newCol.getOptions())) matchedWeight += WEIGHT_LOW;
+        
+        totalWeight += WEIGHT_LOW;
+        if (oldCol.isMapKey() == newCol.isMapKey()) matchedWeight += WEIGHT_LOW;
+        
+        totalWeight += WEIGHT_LOW;
+        if (eq(oldCol.getMapKeyType(), newCol.getMapKeyType())) matchedWeight += WEIGHT_LOW;
+        
+        totalWeight += WEIGHT_LOW;
+        if (eqArr(oldCol.getMapKeyEnumValues(), newCol.getMapKeyEnumValues())) matchedWeight += WEIGHT_LOW;
+        
+        totalWeight += WEIGHT_LOW;
+        if (oldCol.getMapKeyTemporalType() == newCol.getMapKeyTemporalType()) matchedWeight += WEIGHT_LOW;
+        
+        return (double) matchedWeight / totalWeight;
     }
 
     private String analyzeTypeConversion(String oldType, String newType) {

--- a/jinx-core/src/main/java/org/jinx/model/ColumnModel.java
+++ b/jinx-core/src/main/java/org/jinx/model/ColumnModel.java
@@ -82,4 +82,16 @@ public class ColumnModel {
                 java.util.Arrays.hashCode(enumValues), mapKeyTemporalType, java.util.Arrays.hashCode(mapKeyEnumValues),
                 columnKind, discriminatorType, columnDefinition, options, sqlTypeOverride);
     }
+
+    @JsonIgnore
+    public long getAttributeHashExceptName() {
+        return Objects.hash(tableName, javaType, length, precision, scale, isNullable, defaultValue,
+                temporalType, enumerationType, enumStringMapping, isPrimaryKey, isLob, jdbcType,
+                fetchType, isOptional, isVersion, conversionClass, generationStrategy, sequenceName,
+                tableGeneratorName, identityStartValue, identityIncrement, identityCache,
+                identityMinValue, identityMaxValue, java.util.Arrays.hashCode(identityOptions),
+                isManualPrimaryKey, java.util.Arrays.hashCode(enumValues), mapKeyTemporalType,
+                java.util.Arrays.hashCode(mapKeyEnumValues), columnKind, discriminatorType,
+                columnDefinition, options, sqlTypeOverride, isMapKey, mapKeyType);
+    }
 }

--- a/jinx-core/src/test/java/org/jinx/migration/differs/ColumnDifferTest.java
+++ b/jinx-core/src/test/java/org/jinx/migration/differs/ColumnDifferTest.java
@@ -110,7 +110,7 @@ class ColumnDifferTest {
     }
 
     @Test
-    @DisplayName("컬럼 이름과 속성이 함께 변경되면 'DROPPED'와 'ADDED'로 감지해야 함")
+    @DisplayName("컬럼 이름과 속성이 함께 변경되면 'RENAMED'와 'MODIFIED'로 감지해야 함")
     void shouldDetectRenamedAndModifiedColumn() {
         ColumnModel oldCol = createColumn("user_name", "VARCHAR", false);
         oldCol.setLength(255);
@@ -122,15 +122,17 @@ class ColumnDifferTest {
 
         columnDiffer.diff(oldEntity, newEntity, modifiedEntityResult);
 
-        assertEquals(2, modifiedEntityResult.getColumnDiffs().size(), "DROPPED와 ADDED 두 개의 변경이 감지되어야 합니다.");
+        assertEquals(2, modifiedEntityResult.getColumnDiffs().size(), "RENAMED와 MODIFIED 두 개의 변경이 감지되어야 합니다.");
 
-        boolean droppedFound = modifiedEntityResult.getColumnDiffs().stream()
-                .anyMatch(d -> d.getType() == DiffResult.ColumnDiff.Type.DROPPED && d.getColumn().getColumnName().equals("user_name"));
-        boolean addedFound = modifiedEntityResult.getColumnDiffs().stream()
-                .anyMatch(d -> d.getType() == DiffResult.ColumnDiff.Type.ADDED && d.getColumn().getColumnName().equals("username"));
+        boolean renamedFound = modifiedEntityResult.getColumnDiffs().stream()
+                .anyMatch(d -> d.getType() == DiffResult.ColumnDiff.Type.RENAMED && 
+                          d.getColumn().getColumnName().equals("username") && 
+                          d.getOldColumn().getColumnName().equals("user_name"));
+        boolean modifiedFound = modifiedEntityResult.getColumnDiffs().stream()
+                .anyMatch(d -> d.getType() == DiffResult.ColumnDiff.Type.MODIFIED && d.getColumn().getColumnName().equals("username"));
 
-        assertTrue(droppedFound, "기존 컬럼이 'DROPPED'로 감지되어야 합니다.");
-        assertTrue(addedFound, "새로운 컬럼이 'ADDED'로 감지되어야 합니다.");
+        assertTrue(renamedFound, "컬럼이 'RENAMED'로 감지되어야 합니다.");
+        assertTrue(modifiedFound, "컬럼이 'MODIFIED'로도 감지되어야 합니다.");
     }
 
     @Test


### PR DESCRIPTION
`ColumnDiffer`의 컬럼 리네임 탐지를 기존보다 **정확하고 빠르게** 만들었습니다.

이제 해시/버킷 기반 전처리 → 가중치 유사도 → 타이브레이커 순으로 매칭해, 대규모 스키마에서도 실용적으로 동작합니다.

## 주요 변경사항

- **두 단계 버킷화 매칭**
    1. **Exact 해시 버킷**: `getAttributeHashExceptName()`이 동일한 후보를 즉시 리네임으로 매칭
    2. **CoarseKey 버킷**: (table, jdbcType, javaType, enumStringMapping, temporal, nullable)로 후보군 축소
- **유사도 계산 고도화**
    - High/Medium/Low **가중치**를 부여해 핵심 속성(타입/ENUM/Temporal 등)을 더 크게 반영
    - **RENAME_SCORE_THRESHOLD=0.80** 이상일 때만 매칭
- **타이브레이커 도입**
    - 길이 차/공통 prefix 기반 tie-breaker로 동점 매칭의 일관성 개선
- **안정성/정확성**
    - `isColumnEqualExceptName`/`isColumnAttributesEqual` → **속성해시 우선**, 동일 시 **상세 비교**로 충돌 방지
    - 변경 상세 메시지에서 배열 출력 가독성 개선(`arrToString`)

## 알고리즘 흐름

1. `oldColumns`/`newColumns`를 display키로 맵 구성
2. **Exact 해시 버킷**: 이름 제외 속성해시가 동일한 후보 즉시 매칭
3. **CoarseKey 버킷**: 동일 코스키 후보만 대상으로 가중치 유사도 산정
4. 유사도 임계치(0.80) 이상이면 **타이브레이커**로 최종 선택
5. 매칭된 쌍은 `RENAMED` 기록 후, 이름 외 속성 변경이 있으면 `MODIFIED` 추가
6. 남은 `new`는 `ADDED`, 남은 `old`는 `DROPPED`

## 성능

- 기존: 모든 old×new에 대해 유사도 비교(O(n^2))
- 변경: **버킷화로 후보군 축소** + **해시 완전일치 우선 매칭** → 평균적으로 **O(n)**에 근접 가능
- 대규모 엔티티에서도 리네임 감지 비용 크게 절감

## 호환성

- 동작 의미의 변경 없음(리네임 탐지 로직의 **정확도/성능만 개선**)
- 출력되는 변경 상세 메시지의 가독성만 향상

## 테스트

- 기존 유닛 테스트 전부 통과
- 리네임/추가/삭제/수정 조합 시나리오에서 결과 일관성 확인

## 리뷰 포인트

- 가중치 테이블(High/Medium/Low)의 밸런스: 실서비스 스키마 기준 보수적으로 설정
- `RENAME_SCORE_THRESHOLD(0.80)` 적정성: 환경에 따라 0.75~0.85 튜닝 여지있음

## TODO/후속 작업 제안

- **테이블-무시 CoarseKey 폴백(옵션)**: 테이블 이동 후 리네임도 포착하려면 `CoarseKeyNoTable` 버킷을 보조로 사용(임계치 상향)
- **ENUM null 세이프가드**: `analyzeEnumChanges`에서 `enumValues` null 안전 변환 유틸 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 컬럼 이름 변경을 자동 감지(대소문자 변경 포함)하여 추가/삭제 대신 RENAMED 및 필요 시 MODIFIED로 표시합니다.
  * 유사도 기반 매칭으로 비교 정확도를 높이고, 다중 필드 변경을 한눈에 볼 수 있는 상세 변경 내역을 제공합니다.
  * 기본키, 타입, 기본값, 정밀도/스케일 등 잠재적 위험 변경에 대한 경고를 강화했습니다.

* 테스트
  * 시나리오를 RENAMED/MODIFIED 기대값으로 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->