### PR TITLE
feat(liquibase): LiquibaseVisitor 전면 개선 — 다이얼렉트 인지, 기본값 우선순위, PK/UK/C…

### DIFF
--- a/jinx-core/src/main/java/org/jinx/migration/dialect/mysql/MySqlDialect.java
+++ b/jinx-core/src/main/java/org/jinx/migration/dialect/mysql/MySqlDialect.java
@@ -490,6 +490,21 @@ public class MySqlDialect extends AbstractDialect
         return "UUID()";
     }
 
+    @Override
+    public String getTableGeneratorPkColumnType() {
+        return "VARCHAR(255)";
+    }
+    
+    @Override
+    public String getTableGeneratorValueColumnType() {
+        return "BIGINT";
+    }
+    
+    @Override
+    public int getMaxIdentifierLength() {
+        return 64; // MySQL identifier limit
+    }
+
     // Liquibase helper
     public String getLiquibaseTypeName(ColumnModel column) {
         // If sqlTypeOverride is specified, use it directly

--- a/jinx-core/src/main/java/org/jinx/migration/spi/dialect/LiquibaseDialect.java
+++ b/jinx-core/src/main/java/org/jinx/migration/spi/dialect/LiquibaseDialect.java
@@ -32,4 +32,32 @@ public interface LiquibaseDialect extends BaseDialect{
     default boolean supportsIdentity() {
         return true; // Most modern databases support IDENTITY
     }
+
+    default boolean supportsDropCheck() { return true; }              // MySQL 8.0.16+ true, 구버전 false
+    default boolean allowLobLiteralDefault() { return false; }        // TEXT/BLOB 기본값 리터럴 허용 여부
+    default boolean pkDropNeedsName() { return false; }               // PK drop 시 이름 필요 DB 여부
+    default boolean preferUniqueConstraintOverUniqueIndex() { return true; } // UNIQUE를 제약으로 갈지 인덱스로 갈지
+    default boolean supportsComputedUuidDefault() { return getUuidDefaultValue() != null; }
+
+    /**
+     * Gets the SQL type for table generator primary key column
+     */
+    default String getTableGeneratorPkColumnType() {
+        return "VARCHAR(255)";
+    }
+    
+    /**
+     * Gets the SQL type for table generator value column  
+     */
+    default String getTableGeneratorValueColumnType() {
+        return "BIGINT";
+    }
+    
+    /**
+     * Gets the maximum identifier length for this database
+     */
+    default int getMaxIdentifierLength() {
+        return 63; // Standard SQL default
+    }
+
 }

--- a/jinx-core/src/main/java/org/jinx/model/DiffResult.java
+++ b/jinx-core/src/main/java/org/jinx/model/DiffResult.java
@@ -1,7 +1,9 @@
 package org.jinx.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.jinx.migration.spi.visitor.SequenceVisitor;
 import org.jinx.migration.spi.visitor.TableContentVisitor;
 import org.jinx.migration.spi.visitor.TableGeneratorVisitor;
@@ -123,6 +125,8 @@ public class DiffResult {
 
     @Builder
     @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class RenamedTable {
         private EntityModel oldEntity;
         private EntityModel newEntity;

--- a/jinx-core/src/test/java/org/jinx/migration/liquibase/LiquibaseVisitorTest.java
+++ b/jinx-core/src/test/java/org/jinx/migration/liquibase/LiquibaseVisitorTest.java
@@ -1,186 +1,506 @@
 package org.jinx.migration.liquibase;
 
 import org.jinx.migration.liquibase.model.*;
-import org.jinx.migration.spi.dialect.LiquibaseDialect;
-import org.jinx.model.ColumnModel;
-import org.jinx.model.DialectBundle;
-import org.jinx.model.EntityModel;
-import org.jinx.model.GenerationStrategy;
+import org.jinx.model.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.function.Consumer;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
-class LiquibaseVisitorTest {
+class LiquibaseVisitorExtraTest {
 
-    @Mock
-    DialectBundle dialectBundle;
-    @Mock
-    LiquibaseDialect liquibaseDialect;
-    @Mock
-    ChangeSetIdGenerator idGen;
+    private DialectBundle bundle;           // mock
+    private ChangeSetIdGenerator idGen;     // simple stub
+    private LiquibaseVisitor visitor;
 
-    @InjectMocks
-    LiquibaseVisitor visitor;
+    @BeforeEach
+    void setUp() {
+        bundle = mock(DialectBundle.class);
+
+        // 기본은 liquibase() Optional.empty() — 개별 테스트에서 필요시 덮어씀
+        when(bundle.liquibase()).thenReturn(Optional.empty());
+
+        // withSequence / withTableGenerator 는 넘긴 Consumer 를 즉시 실행
+        doAnswer(inv -> {
+            @SuppressWarnings("unchecked")
+            Consumer<Object> c = (Consumer<Object>) inv.getArgument(0);
+            c.accept(null); // 내부에서 dialect를 사용하지 않으므로 null로 충분
+            return null;
+        }).when(bundle).withSequence(any());
+
+        doAnswer(inv -> {
+            @SuppressWarnings("unchecked")
+            Consumer<Object> c = (Consumer<Object>) inv.getArgument(0);
+            c.accept(null);
+            return null;
+        }).when(bundle).withTableGenerator(any());
+
+        idGen = new ChangeSetIdGenerator() {
+            private long n = 0;
+            @Override public String nextId() { return "cs-extra-" + (++n); }
+        };
+
+        visitor = new LiquibaseVisitor(bundle, idGen);
+    }
+
 
     @Test
-    void visitAddedTable_wrapsChangesUnderChangeSetWrapper() {
-        // given
-        DialectBundle dialect = mock(DialectBundle.class);
-        // liquibase() 경로를 사용하지 않도록 fallback을 막기 위해 type override를 쓸 예정 -> Optional.empty()
-        when(dialect.liquibase()).thenReturn(Optional.empty());
+    @DisplayName("visitAddedTable: PK 없음 분기 커버(Map<ColumnKey, ColumnModel>)")
+    void visitAddedTable_noPk_branch() {
+        visitor.setCurrentTableName(null);
 
-        ChangeSetIdGenerator ids = mock(ChangeSetIdGenerator.class);
-        when(ids.nextId()).thenReturn("001", "002");
+        ColumnModel id = mock(ColumnModel.class);
+        when(id.getColumnName()).thenReturn("id");
+        when(id.isPrimaryKey()).thenReturn(false);
+        when(id.getSqlTypeOverride()).thenReturn("BIGINT");
+        when(id.getGenerationStrategy()).thenReturn(GenerationStrategy.NONE);
 
-        LiquibaseVisitor v = new LiquibaseVisitor(dialect, ids);
+        ColumnModel name = mock(ColumnModel.class);
+        when(name.getColumnName()).thenReturn("name");
+        when(name.isPrimaryKey()).thenReturn(false);
+        when(name.getSqlTypeOverride()).thenReturn("VARCHAR(50)");
+        when(name.getGenerationStrategy()).thenReturn(GenerationStrategy.NONE);
 
-        EntityModel table = EntityModel.builder()
-                .entityName("users")
-                .tableName("users")
-                .isValid(true)
-                .build();
+        Map<ColumnKey, ColumnModel> cols = new LinkedHashMap<>();
+        cols.put(ColumnKey.of("id","id"), id);
+        cols.put(ColumnKey.of("name","name"), name);
 
-        // PK/일반 컬럼 2개 추가
-        table.putColumn(ColumnModel.builder()
-                .columnName("id")
-                .tableName("users")
-                .javaType("java.lang.Long")
-                .isPrimaryKey(true)
-                .isNullable(false)
-                .sqlTypeOverride("bigint")   // dialect 의존 제거
-                .build());
-        table.putColumn(ColumnModel.builder()
-                .columnName("name")
-                .tableName("users")
-                .javaType("java.lang.String")
-                .isNullable(false)
-                .sqlTypeOverride("varchar(255)")
-                .build());
+        EntityModel table = mock(EntityModel.class);
+        when(table.getTableName()).thenReturn("users");
+        when(table.getColumns()).thenReturn(cols);
+        when(table.getConstraints()).thenReturn(Collections.emptyMap());
+        when(table.getIndexes()).thenReturn(Collections.emptyMap());
+        when(table.getRelationships()).thenReturn(Collections.emptyMap());
 
-        // when
-        v.visitAddedTable(table);
+        int before = visitor.getChangeSets().size();
+        visitor.visitAddedTable(table);
+        int after = visitor.getChangeSets().size();
 
-        // then: 래퍼 → 체인지셋 → 체인지 확인
-        List<ChangeSetWrapper> all = v.getChangeSets();
-        assertThat(all.size()).isEqualTo(2);
-
-        // 1) createTable
-        ChangeSetWrapper cs1w = all.get(0);
-        assertThat(cs1w).isNotNull();
-        ChangeSet cs1 = cs1w.getChangeSet();
-        assertThat(cs1.getId()).isEqualTo("001");
-        assertThat(cs1.getChanges().size()).isEqualTo(1);
-        assertThat(cs1.getChanges().get(0)).isInstanceOf(CreateTableChange.class);
-
-        CreateTableChange ct = (CreateTableChange) cs1.getChanges().get(0);
-        assertThat(ct.getConfig().getTableName()).isEqualTo("users");
-        assertThat(ct.getConfig().getColumns().size()).isEqualTo(2);
-        // PK는 createTable 단계 constraints에서 제외하고, 별도 AddPrimaryKey로 추가됨
-
-        // 2) addPrimaryKey
-        ChangeSetWrapper cs2w = all.get(1);
-        ChangeSet cs2 = cs2w.getChangeSet();
-        assertThat(cs2.getId()).isEqualTo("002");
-        assertThat(cs2.getChanges().size()).isEqualTo(1);
-        assertThat(cs2.getChanges().get(0)).isInstanceOf(AddPrimaryKeyConstraintChange.class);
-
-        AddPrimaryKeyConstraintChange pk = (AddPrimaryKeyConstraintChange) cs2.getChanges().get(0);
-        assertThat(pk.getConfig().getTableName()).isEqualTo("users");
-        assertThat(pk.getConfig().getColumnNames()).isEqualTo("id");
+        // PK가 없으므로 CreateTable 만 생성
+        assertEquals(before + 1, after);
     }
 
     @Test
-    void visitAddedColumn_sets_defaultValueSequenceNext_whenSequenceStrategy() {
-        // given
-        DialectBundle dialect = mock(DialectBundle.class);
-        when(dialect.liquibase()).thenReturn(Optional.empty());
+    @DisplayName("visitDroppedTable: DropTable changeSet 생성")
+    void visitDroppedTable_addsChangeSet() {
+        EntityModel table = mock(EntityModel.class);
+        when(table.getTableName()).thenReturn("users");
 
-        ChangeSetIdGenerator ids = mock(ChangeSetIdGenerator.class);
-        when(ids.nextId()).thenReturn("100");
-
-        LiquibaseVisitor v = new LiquibaseVisitor(dialect, ids);
-        v.setCurrentTableName("orders");
-
-        // SEQUENCE 전략 + defaultValue에 시퀀스명 저장 → defaultValueSequenceNext로 나가야 함
-        ColumnModel seqCol = ColumnModel.builder()
-                .columnName("id")
-                .tableName("orders")
-                .javaType("java.lang.Long")
-                .generationStrategy(GenerationStrategy.SEQUENCE)
-                .defaultValue("order_id_seq")           // 시퀀스명
-                .sqlTypeOverride("bigint")
-                .isNullable(false)
-                .isPrimaryKey(true) // (참고) AddColumn에서 PK는 즉시 constraints로 갈 수 있으니 정책에 유의
-                .build();
-
-        // when
-        v.visitAddedColumn(seqCol);
-
-        // then
-        List<ChangeSetWrapper> all = v.getChangeSets();
-        assertThat(all.size()).isEqualTo(1);
-
-        ChangeSet cs = all.get(0).getChangeSet();
-        assertThat(cs.getId()).isEqualTo("100");
-        assertThat(cs.getChanges().size()).isEqualTo(1);
-        assertThat(cs.getChanges().get(0)).isInstanceOf(AddColumnChange.class);
-
-        AddColumnChange add = (AddColumnChange) cs.getChanges().get(0);
-        AddColumnConfig cfg = add.getConfig();
-
-        assertThat(cfg.getTableName()).isEqualTo("orders");
-        assertThat(cfg.getColumns().size()).isEqualTo(1);
-
-        ColumnConfig colCfg = cfg.getColumns().get(0).getConfig();
-        // 우선순위: computed > sequence > literal
-        assertThat(colCfg.getDefaultValueComputed()).isNull();
-        assertThat(colCfg.getDefaultValue()).isNull();
-        assertThat(colCfg.getDefaultValueSequenceNext()).isEqualTo("order_id_seq");
-        assertThat(colCfg.getType()).isEqualTo("bigint");
+        int before = visitor.getChangeSets().size();
+        visitor.visitDroppedTable(table);
+        assertEquals(before + 1, visitor.getChangeSets().size());
     }
 
     @Test
-    void visitAddedColumn_sets_literalDefault_ifNoComputedOrSequence() {
-        // given
-        DialectBundle dialect = mock(DialectBundle.class);
-        when(dialect.liquibase()).thenReturn(Optional.empty());
+    @DisplayName("visitRenamedTable: RenameTable changeSet 생성")
+    void visitRenamedTable_addsChangeSet() {
+        EntityModel oldE = mock(EntityModel.class);
+        when(oldE.getTableName()).thenReturn("old_t");
+        EntityModel newE = mock(EntityModel.class);
+        when(newE.getTableName()).thenReturn("new_t");
+        DiffResult.RenamedTable renamed = new DiffResult.RenamedTable(oldE, newE, "");
 
-        ChangeSetIdGenerator ids = mock(ChangeSetIdGenerator.class);
-        when(ids.nextId()).thenReturn("200");
-
-        LiquibaseVisitor v = new LiquibaseVisitor(dialect, ids);
-        v.setCurrentTableName("emails");
-
-        ColumnModel col = ColumnModel.builder()
-                .columnName("status")
-                .tableName("emails")
-                .javaType("java.lang.String")
-                .generationStrategy(GenerationStrategy.NONE)
-                .defaultValue("ACTIVE")                 // literal
-                .isNullable(false)
-                .sqlTypeOverride("varchar(50)")
-                .build();
-
-        // when
-        v.visitAddedColumn(col);
-
-        // then
-        ChangeSet cs = v.getChangeSets().get(0).getChangeSet();
-        AddColumnChange add = (AddColumnChange) cs.getChanges().get(0);
-        ColumnConfig cfg = add.getConfig().getColumns().get(0).getConfig();
-
-        assertThat(cfg.getDefaultValueComputed()).isNull();
-        assertThat(cfg.getDefaultValueSequenceNext()).isNull();
-        assertThat(cfg.getDefaultValue()).isEqualTo("ACTIVE");
-        assertThat(cfg.getType()).isEqualTo("varchar(50)");
+        int before = visitor.getChangeSets().size();
+        visitor.visitRenamedTable(renamed);
+        assertEquals(before + 1, visitor.getChangeSets().size());
     }
 
+    // ===== 시퀀스 =====
+
+    @Test
+    @DisplayName("visitAddedSequence: CreateSequence changeSet 생성")
+    void visitAddedSequence_addsChangeSet() {
+        SequenceModel seq = mock(SequenceModel.class);
+        when(seq.getName()).thenReturn("seq1");
+        when(seq.getInitialValue()).thenReturn(10L);
+        when(seq.getAllocationSize()).thenReturn(Integer.valueOf(100));
+
+        int before = visitor.getChangeSets().size();
+        visitor.visitAddedSequence(seq);
+        assertEquals(before + 1, visitor.getChangeSets().size());
+    }
+
+    @Test
+    @DisplayName("visitDroppedSequence: DropSequence changeSet 생성")
+    void visitDroppedSequence_addsChangeSet() {
+        SequenceModel seq = mock(SequenceModel.class);
+        when(seq.getName()).thenReturn("seq1");
+
+        int before = visitor.getChangeSets().size();
+        visitor.visitDroppedSequence(seq);
+        assertEquals(before + 1, visitor.getChangeSets().size());
+    }
+
+    @Test
+    @DisplayName("visitModifiedSequence: Drop → Create 두 개의 changeSet 생성")
+    void visitModifiedSequence_addsTwoChangeSets() {
+        SequenceModel oldS = mock(SequenceModel.class);
+        when(oldS.getName()).thenReturn("seq_old");
+
+        SequenceModel newS = mock(SequenceModel.class);
+        when(newS.getName()).thenReturn("seq_new");
+        when(newS.getInitialValue()).thenReturn(1L);
+        when(newS.getAllocationSize()).thenReturn(Integer.valueOf(50));
+
+        int before = visitor.getChangeSets().size();
+        visitor.visitModifiedSequence(newS, oldS);
+        assertEquals(before + 2, visitor.getChangeSets().size());
+    }
+
+    // ===== 테이블 제너레이터 =====
+
+    @Test
+    @DisplayName("visitAddedTableGenerator: CreateTable + Insert changeSet 생성 (Liquibase 타입 지정)")
+    void visitAddedTableGenerator_addsChangeSets() {
+        // LiquibaseDialect가 TableGenerator 컬럼 타입을 제공하도록 스텁
+        var lb = mock(org.jinx.migration.spi.dialect.LiquibaseDialect.class);
+        when(lb.getTableGeneratorPkColumnType()).thenReturn("VARCHAR(128)");
+        when(lb.getTableGeneratorValueColumnType()).thenReturn("BIGINT");
+        when(bundle.liquibase()).thenReturn(Optional.of(lb));
+
+        TableGeneratorModel tg = mock(TableGeneratorModel.class);
+        when(tg.getTable()).thenReturn("seq_table");
+        when(tg.getPkColumnName()).thenReturn("k");
+        when(tg.getValueColumnName()).thenReturn("v");
+        when(tg.getPkColumnValue()).thenReturn("SEQ_A");
+        when(tg.getInitialValue()).thenReturn(1L);
+
+        int before = visitor.getChangeSets().size();
+        visitor.visitAddedTableGenerator(tg);
+        // CreateTable + Insert
+        assertEquals(before + 2, visitor.getChangeSets().size());
+    }
+
+    @Test
+    @DisplayName("visitDroppedTableGenerator: Drop changeSet 생성")
+    void visitDroppedTableGenerator_addsChangeSet() {
+        TableGeneratorModel tg = mock(TableGeneratorModel.class);
+        when(tg.getTable()).thenReturn("seq_table");
+
+        int before = visitor.getChangeSets().size();
+        visitor.visitDroppedTableGenerator(tg);
+        assertEquals(before + 1, visitor.getChangeSets().size());
+    }
+
+    @Test
+    @DisplayName("visitModifiedTableGenerator: Drop → Create 두 개의 changeSet 생성")
+    void visitModifiedTableGenerator_addsTwoChangeSets() {
+        var lb = mock(org.jinx.migration.spi.dialect.LiquibaseDialect.class);
+        when(lb.getTableGeneratorPkColumnType()).thenReturn("VARCHAR(64)");
+        when(lb.getTableGeneratorValueColumnType()).thenReturn("BIGINT");
+        when(bundle.liquibase()).thenReturn(Optional.of(lb));
+
+        TableGeneratorModel oldTg = mock(TableGeneratorModel.class);
+        when(oldTg.getTable()).thenReturn("old_seq");
+        when(oldTg.getPkColumnName()).thenReturn("k");
+        when(oldTg.getValueColumnName()).thenReturn("v");
+
+        TableGeneratorModel newTg = mock(TableGeneratorModel.class);
+        when(newTg.getTable()).thenReturn("new_seq");
+        when(newTg.getPkColumnName()).thenReturn("k");
+        when(newTg.getValueColumnName()).thenReturn("v");
+
+        int before = visitor.getChangeSets().size();
+        visitor.visitModifiedTableGenerator(newTg, oldTg);
+        assertEquals(before + 2, visitor.getChangeSets().size());
+    }
+
+    // ===== 컬럼 컨텐츠 =====
+
+    @Test
+    @DisplayName("visitDroppedColumn: DropColumn changeSet 생성")
+    void visitDroppedColumn_addsChangeSet() {
+        visitor.setCurrentTableName("users");
+        ColumnModel c = mock(ColumnModel.class);
+        when(c.getColumnName()).thenReturn("name");
+
+        int before = visitor.getChangeSets().size();
+        visitor.visitDroppedColumn(c);
+        assertEquals(before + 1, visitor.getChangeSets().size());
+    }
+
+    @Test
+    @DisplayName("visitModifiedColumn: 타입 변경 분기")
+    void visitModifiedColumn_typeChange() {
+        visitor.setCurrentTableName("users");
+
+        ColumnModel oldC = mock(ColumnModel.class);
+        when(oldC.getColumnName()).thenReturn("age");
+        when(oldC.getSqlTypeOverride()).thenReturn("INT");
+        when(oldC.isNullable()).thenReturn(true);
+
+        ColumnModel newC = mock(ColumnModel.class);
+        when(newC.getColumnName()).thenReturn("age");
+        when(newC.getSqlTypeOverride()).thenReturn("BIGINT"); // 타입 변경
+        when(newC.isNullable()).thenReturn(true);
+
+        int before = visitor.getChangeSets().size();
+        visitor.visitModifiedColumn(newC, oldC);
+        assertEquals(before + 1, visitor.getChangeSets().size());
+    }
+
+    @Test
+    @DisplayName("visitModifiedColumn: NULLABLE true → false (AddNotNull)")
+    void visitModifiedColumn_addNotNull() {
+        visitor.setCurrentTableName("users");
+
+        ColumnModel oldC = mock(ColumnModel.class);
+        when(oldC.getColumnName()).thenReturn("title");
+        when(oldC.getSqlTypeOverride()).thenReturn("VARCHAR(100)");
+        when(oldC.isNullable()).thenReturn(true);
+
+        ColumnModel newC = mock(ColumnModel.class);
+        when(newC.getColumnName()).thenReturn("title");
+        when(newC.getSqlTypeOverride()).thenReturn("VARCHAR(100)");
+        when(newC.isNullable()).thenReturn(false);
+
+        int before = visitor.getChangeSets().size();
+        visitor.visitModifiedColumn(newC, oldC);
+        assertEquals(before + 1, visitor.getChangeSets().size());
+    }
+
+    @Test
+    @DisplayName("visitModifiedColumn: NULLABLE false → true (DropNotNull)")
+    void visitModifiedColumn_dropNotNull() {
+        visitor.setCurrentTableName("users");
+
+        ColumnModel oldC = mock(ColumnModel.class);
+        when(oldC.getColumnName()).thenReturn("note");
+        when(oldC.getSqlTypeOverride()).thenReturn("VARCHAR(200)");
+        when(oldC.isNullable()).thenReturn(false);
+
+        ColumnModel newC = mock(ColumnModel.class);
+        when(newC.getColumnName()).thenReturn("note");
+        when(newC.getSqlTypeOverride()).thenReturn("VARCHAR(200)");
+        when(newC.isNullable()).thenReturn(true);
+
+        int before = visitor.getChangeSets().size();
+        visitor.visitModifiedColumn(newC, oldC);
+        assertEquals(before + 1, visitor.getChangeSets().size());
+    }
+
+    @Test
+    @DisplayName("visitRenamedColumn: RenameColumn changeSet 생성")
+    void visitRenamedColumn_addsChangeSet() {
+        visitor.setCurrentTableName("users");
+
+        ColumnModel oldC = mock(ColumnModel.class);
+        when(oldC.getColumnName()).thenReturn("old");
+        ColumnModel newC = mock(ColumnModel.class);
+        when(newC.getColumnName()).thenReturn("new");
+
+        int before = visitor.getChangeSets().size();
+        visitor.visitRenamedColumn(newC, oldC);
+        assertEquals(before + 1, visitor.getChangeSets().size());
+    }
+
+    // ===== 인덱스 =====
+
+    @Test
+    @DisplayName("visitModifiedIndex: DropIndex → CreateIndex 두 개 changeSet 생성")
+    void visitModifiedIndex_addsTwoChangeSets() {
+        // old
+        IndexModel oldIdx = mock(IndexModel.class);
+        when(oldIdx.getIndexName()).thenReturn("ix_old");
+        when(oldIdx.getTableName()).thenReturn("users");
+
+        // new
+        IndexModel newIdx = mock(IndexModel.class);
+        when(newIdx.getIndexName()).thenReturn("ix_new");
+        when(newIdx.getTableName()).thenReturn("users");
+        when(newIdx.getColumnNames()).thenReturn(List.of("email"));
+
+        int before = visitor.getChangeSets().size();
+        visitor.visitModifiedIndex(newIdx, oldIdx);
+        assertEquals(before + 2, visitor.getChangeSets().size());
+    }
+
+    // ===== 제약 =====
+
+    @Test
+    @DisplayName("visitDroppedConstraint: UNIQUE 이름 명시 분기")
+    void visitDroppedConstraint_unique_named() {
+        visitor.setCurrentTableName("users");
+        ConstraintModel uq = mock(ConstraintModel.class);
+        when(uq.getType()).thenReturn(ConstraintType.UNIQUE);
+        when(uq.getName()).thenReturn("uq_users_email");
+        when(uq.getColumns()).thenReturn(List.of("email"));
+
+        int before = visitor.getChangeSets().size();
+        visitor.visitDroppedConstraint(uq);
+        assertEquals(before + 1, visitor.getChangeSets().size());
+    }
+
+    @Test
+    @DisplayName("visitDroppedConstraint: CHECK 이름 명시 분기")
+    void visitDroppedConstraint_check_named() {
+        visitor.setCurrentTableName("orders");
+        ConstraintModel ck = mock(ConstraintModel.class);
+        when(ck.getType()).thenReturn(ConstraintType.CHECK);
+        when(ck.getName()).thenReturn("ck_orders_total");
+        when(ck.getColumns()).thenReturn(List.of("total"));
+        when(ck.getCheckClause()).thenReturn(Optional.of("total >= 0"));
+
+        int before = visitor.getChangeSets().size();
+        visitor.visitDroppedConstraint(ck);
+        assertEquals(before + 1, visitor.getChangeSets().size());
+    }
+
+    @Test
+    @DisplayName("visitModifiedConstraint: drop → add 흐름")
+    void visitModifiedConstraint_flow() {
+        visitor.setCurrentTableName("users");
+
+        ConstraintModel oldC = mock(ConstraintModel.class);
+        when(oldC.getType()).thenReturn(ConstraintType.UNIQUE);
+        when(oldC.getName()).thenReturn("uq_users_email");
+        when(oldC.getColumns()).thenReturn(List.of("email"));
+
+        ConstraintModel newC = mock(ConstraintModel.class);
+        when(newC.getType()).thenReturn(ConstraintType.UNIQUE);
+        when(newC.getName()).thenReturn("uq_users_email_new");
+        when(newC.getColumns()).thenReturn(List.of("email"));
+
+        int before = visitor.getChangeSets().size();
+        visitor.visitModifiedConstraint(newC, oldC);
+        assertEquals(before + 2, visitor.getChangeSets().size());
+    }
+
+    // ===== FK =====
+
+    @Test
+    @DisplayName("visitAddedRelationship: constraintName 명시 + onDelete/onUpdate null 분기")
+    void visitAddedRelationship_named_withoutActions() {
+        visitor.setCurrentTableName("orders");
+
+        RelationshipModel rel = mock(RelationshipModel.class);
+        when(rel.isNoConstraint()).thenReturn(false);
+        when(rel.getTableName()).thenReturn("orders");
+        when(rel.getConstraintName()).thenReturn("fk_orders_user_id_users");
+        when(rel.getColumns()).thenReturn(List.of("user_id"));
+        when(rel.getReferencedTable()).thenReturn("users");
+        when(rel.getReferencedColumns()).thenReturn(List.of("id"));
+        when(rel.getOnDelete()).thenReturn(null);
+        when(rel.getOnUpdate()).thenReturn(null);
+
+        int before = visitor.getChangeSets().size();
+        visitor.visitAddedRelationship(rel);
+        assertEquals(before + 1, visitor.getChangeSets().size());
+    }
+
+    @Test
+    @DisplayName("visitDroppedRelationship: NO_CONSTRAINT=true는 skip")
+    void visitDroppedRelationship_skipWhenNoConstraint() {
+        visitor.setCurrentTableName("orders");
+        RelationshipModel rel = mock(RelationshipModel.class);
+        when(rel.isNoConstraint()).thenReturn(true);
+
+        int before = visitor.getChangeSets().size();
+        visitor.visitDroppedRelationship(rel);
+        assertEquals(before, visitor.getChangeSets().size());
+    }
+
+    // ===== 보조/분기 메서드 커버 =====
+
+    @Test
+    @DisplayName("getTableNameSafely: currentTableName이 공백이면 예외")
+    void getTableNameSafely_blank_throws() {
+        visitor.setCurrentTableName("  "); // 공백만
+        IndexModel idx = mock(IndexModel.class);
+        when(idx.getTableName()).thenReturn(null);
+
+        assertThrows(IllegalStateException.class, () -> visitor.visitAddedIndex(idx));
+    }
+
+    @Test
+    @DisplayName("getLiquibaseTypeName: liquibase가 타입을 제공하는 분기")
+    void liquibase_typeName_branch() {
+        var lb = mock(org.jinx.migration.spi.dialect.LiquibaseDialect.class);
+        when(lb.getLiquibaseTypeName(any())).thenReturn("NUMERIC(10)");
+        when(lb.shouldUseAutoIncrement(GenerationStrategy.AUTO)).thenReturn(true);
+        when(lb.getUuidDefaultValue()).thenReturn("UUID()");
+        when(bundle.liquibase()).thenReturn(Optional.of(lb));
+
+        visitor.setCurrentTableName("users");
+
+        ColumnModel c = mock(ColumnModel.class);
+        when(c.getColumnName()).thenReturn("code");
+        when(c.getSqlTypeOverride()).thenReturn(null); // liquibase 분기로 유도
+        when(c.getGenerationStrategy()).thenReturn(GenerationStrategy.AUTO); // shouldUseAutoIncrement 분기도 커버
+        when(c.isNullable()).thenReturn(true);
+        when(c.getDefaultValue()).thenReturn("42");
+
+        int before = visitor.getChangeSets().size();
+        visitor.visitAddedColumn(c);
+        assertEquals(before + 1, visitor.getChangeSets().size());
+    }
+
+    @Test
+    @DisplayName("setDefaultValueWithPriority: UUID → computed default 분기")
+    void defaultPriority_uuidComputed_branch() {
+        var lb = mock(org.jinx.migration.spi.dialect.LiquibaseDialect.class);
+        when(lb.getLiquibaseTypeName(any())).thenReturn("CHAR(36)");
+        when(lb.getUuidDefaultValue()).thenReturn("UUID()");
+        when(bundle.liquibase()).thenReturn(Optional.of(lb));
+
+        visitor.setCurrentTableName("users");
+
+        ColumnModel c = mock(ColumnModel.class);
+        when(c.getColumnName()).thenReturn("uuid");
+        when(c.getSqlTypeOverride()).thenReturn(null);
+        when(c.getGenerationStrategy()).thenReturn(GenerationStrategy.UUID);
+        when(c.isNullable()).thenReturn(true);
+        when(c.getDefaultValue()).thenReturn(null);
+
+        int before = visitor.getChangeSets().size();
+        visitor.visitAddedColumn(c);
+        assertEquals(before + 1, visitor.getChangeSets().size());
+    }
+
+    @Test
+    @DisplayName("setDefaultValueWithPriority: SEQUENCE → sequence next 분기")
+    void defaultPriority_sequence_branch() {
+        var lb = mock(org.jinx.migration.spi.dialect.LiquibaseDialect.class);
+        when(lb.getLiquibaseTypeName(any())).thenReturn("BIGINT");
+        when(bundle.liquibase()).thenReturn(Optional.of(lb));
+
+        visitor.setCurrentTableName("users");
+
+        ColumnModel c = mock(ColumnModel.class);
+        when(c.getColumnName()).thenReturn("seq_col");
+        when(c.getSqlTypeOverride()).thenReturn(null);
+        when(c.getGenerationStrategy()).thenReturn(GenerationStrategy.SEQUENCE);
+        when(c.getDefaultValue()).thenReturn("order_seq"); // 시퀀스 이름
+        when(c.isNullable()).thenReturn(true);
+
+        int before = visitor.getChangeSets().size();
+        visitor.visitAddedColumn(c);
+        assertEquals(before + 1, visitor.getChangeSets().size());
+    }
+
+    @Test
+    @DisplayName("setDefaultValueWithPriority: literal default 분기")
+    void defaultPriority_literal_branch() {
+        var lb = mock(org.jinx.migration.spi.dialect.LiquibaseDialect.class);
+        when(lb.getLiquibaseTypeName(any())).thenReturn("INT");
+        when(bundle.liquibase()).thenReturn(Optional.of(lb));
+
+        visitor.setCurrentTableName("users");
+
+        ColumnModel c = mock(ColumnModel.class);
+        when(c.getColumnName()).thenReturn("flag");
+        when(c.getSqlTypeOverride()).thenReturn(null);
+        when(c.getGenerationStrategy()).thenReturn(GenerationStrategy.NONE);
+        when(c.getDefaultValue()).thenReturn("0");
+        when(c.isNullable()).thenReturn(true);
+
+        int before = visitor.getChangeSets().size();
+        visitor.visitAddedColumn(c);
+        assertEquals(before + 1, visitor.getChangeSets().size());
+    }
 }


### PR DESCRIPTION
`LiquibaseVisitor`를 전면적으로 리팩터링해 **다이얼렉트 인지 동작**, **안정적인 제약/인덱스 생성**, **세분화된 기본값 우선순위**, **테이블/컬럼 변경의 ChangeSet 분리**를 구현했습니다. 이로써 멀티 DB 확장 시에도 Liquibase DSL이 일관되고 안전하게 생성됩니다.

## 배경/문제

- 컬럼에 `primaryKey`를 인라인으로 집어넣을 때 복합 PK에서 엣지 케이스가 발생.
- 기본값 처리(특히 UUID/SEQUENCE)가 DB/다이얼렉트에 따라 달라지는 부분을 고려하지 못함.
- sqlTypeOverride, LiquibaseDialect 타입명, JavaTypeMapper 간 우선순위가 불명확.
- 인덱스/제약/FK add/drop/modify 경로가 부분적이거나 이름 정책 일관성이 부족.

## 핵심 변경사항

1. **PK 분리 전략**
    - 컬럼 constraints에서는 PK 제외 → 테이블 생성 직후 `AddPrimaryKeyChange`로 별도 ChangeSet.
2. **기본값 우선순위**
    - `computed > sequence > literal` 적용.
    - `UUID` 전략은 `defaultValueComputed` 사용.
    - `SEQUENCE` 전략은 `defaultValueSequenceNext` 사용(시퀀스명은 column.defaultValue에서 취득).
3. **autoIncrement 위임**
    - `LiquibaseDialect.shouldUseAutoIncrement`로 위임(AUTO→IDENTITY 매핑 가능).
4. **타입 결정 우선순위**
    - `sqlTypeOverride` > `LiquibaseDialect.getLiquibaseTypeName` > `DdlDialect.JavaTypeMapper`.
5. **제약/인덱스/FK 경로 보강**
    - UNIQUE/CHECK/INDEX/FK의 add/drop/modify 전 경로 구현 및 이름 정책 정리.
    - 이름은 모델 명시 우선, 미지정 시 내부 `NamingUtil`에서 생성.
6. **Table Generator/Sequence**
    - dialect 제공 타입 사용(없으면 안전한 기본값).
    - TableGenerator 초기 데이터 insert 포함.
7. **안전성/진단성**
    - `getTableNameSafely`로 테이블명 누락 시 명확한 예외.
    - `getGeneratedSql()`는 빈 문자열(역할 명확화).

## 호환성/영향도

- **예외 타입 변화**: 테이블명 누락 시 NPE → `IllegalStateException`.
- **파생 이름 정책**: 미지정 이름에 대해 `NamingUtil` 규칙이 적용되므로, 기존 자동명과 달라질 수 있음(실제 DB에는 보통 영향 미미. Liquibase가 엔진별로 적절히 매핑/무시).
- Liquibase DSL 기반이므로 런타임 SQL 차원 영향은 제한적.

## 테스트 플랜

- LiquibaseVisitor 단위 테스트 보강
    - CREATE TABLE(+PK 분리), 컬럼 추가/수정/삭제, UNIQUE/CHECK/INDEX/FK add/drop/modify 각 경로 검증
    - 기본값 우선순위: (UUID/SEQUENCE/LITERAL) 별로 `defaultValueComputed/defaultValueSequenceNext/defaultValue` 확인
    - `sqlTypeOverride` 우선 적용 및 LiquibaseDialect/JavaTypeMapper 폴백 케이스
    - `shouldUseAutoIncrement` 위임 동작(Mock LiquibaseDialect)
    - `getTableNameSafely` 예외 검증
- JaCoCo 기준 라인/분기 커버리지 상승 확인(목표 ~80%)

## 마이그레이션 노트

- 커스텀 네이밍을 쓰는 경우(예: 외부 Naming 구현)에는 모델에 명시적 이름을 주는 것을 권장합니다. 미지정 시 본 PR의 파생 규칙이 적용됩니다.
- 프로세서/다른 Visitor에서 `currentTableName` 세팅 순서를 지켜 주세요(없으면 IllegalStateException).

## 관련 모듈

- `org.jinx.migration.liquibase.*`
- `org.jinx.model.*`
- `org.jinx.migration.spi.dialect.LiquibaseDialect` (위임 포인트)

## 체크리스트

- [x]  기존 테스트 통과
- [x]  신규/수정 테스트 추가 (UUID/SEQUENCE/LITERAL, add/drop/modify 전 경로)
- [x]  다이얼렉트 폴백 경로 수기 검증
- [x]  JaCoCo 커버리지 목표 상향