### PR TITLE
test(processor/relationship): ToOne/OneToMany/ManyToMany 전용 프로세서 단위 테스트 추가

### DIFF
--- a/jinx-processor/src/main/java/org/jinx/handler/relationship/OneToManyOwningJoinTableProcessor.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/relationship/OneToManyOwningJoinTableProcessor.java
@@ -218,7 +218,7 @@ public final class OneToManyOwningJoinTableProcessor implements RelationshipProc
         }
 
         Optional<EntityModel> joinTableEntityOp = joinSupport.createJoinTableEntity(details, ownerPks, targetPks);
-        if (joinTableEntityOp == null) return;
+        if (joinTableEntityOp.isEmpty()) return;
         EntityModel joinTableEntity = joinTableEntityOp.get();
         joinSupport.ensureJoinTableColumns(joinTableEntity, ownerPks, targetPks, ownerFkToPkMap, targetFkToPkMap, attr);
         joinSupport.ensureJoinTableRelationships(joinTableEntity, details);

--- a/jinx-processor/src/main/java/org/jinx/handler/relationship/RelationshipSupport.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/relationship/RelationshipSupport.java
@@ -11,9 +11,6 @@ import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
 import java.util.*;
 
-/**
- * Utility class providing common validation and support functions for relationship processing
- */
 public final class RelationshipSupport {
     
     private final ProcessingContext context;

--- a/jinx-processor/src/test/java/org/jinx/handler/relationship/ManyToManyOwningProcessorTest.java
+++ b/jinx-processor/src/test/java/org/jinx/handler/relationship/ManyToManyOwningProcessorTest.java
@@ -1,0 +1,500 @@
+package org.jinx.handler.relationship;
+
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import org.jinx.context.ProcessingContext;
+import org.jinx.descriptor.AttributeDescriptor;
+import org.jinx.model.ColumnModel;
+import org.jinx.model.ConstraintModel;
+import org.jinx.model.ConstraintType;
+import org.jinx.model.EntityModel;
+import org.jinx.model.SchemaModel;
+import org.jinx.naming.DefaultNaming;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.tools.Diagnostic;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class ManyToManyOwningProcessorTest {
+
+    ProcessingContext context;
+    RelationshipSupport support;
+    RelationshipJoinSupport joinSupport;
+    ManyToManyOwningProcessor processor;
+
+    SchemaModel schema;
+    Map<String, EntityModel> entities;
+    javax.annotation.processing.Messager messager;
+
+    AttributeDescriptor attr;
+    ManyToMany manyToMany;
+    Element diagnosticElement;
+
+    EntityModel owner;
+    EntityModel target;
+
+    @BeforeEach
+    void setUp() {
+        context = mock(ProcessingContext.class);
+        support = mock(RelationshipSupport.class);
+        joinSupport = mock(RelationshipJoinSupport.class);
+        processor = new ManyToManyOwningProcessor(context, support, joinSupport);
+
+        messager = mock(javax.annotation.processing.Messager.class);
+        schema = mock(SchemaModel.class);
+        entities = new HashMap<>();
+
+        when(context.getMessager()).thenReturn(messager);
+        when(context.getSchemaModel()).thenReturn(schema);
+        when(schema.getEntities()).thenReturn(entities);
+        when(context.getNaming()).thenReturn(new DefaultNaming(63));
+
+        attr = mock(AttributeDescriptor.class);
+        manyToMany = mock(ManyToMany.class);
+        when(attr.getAnnotation(ManyToMany.class)).thenReturn(manyToMany);
+        when(manyToMany.mappedBy()).thenReturn(""); // owning side
+
+        diagnosticElement = mock(Element.class);
+        when(attr.elementForDiagnostics()).thenReturn(diagnosticElement);
+        when(attr.name()).thenReturn("mmField");
+
+        // 기본 엔티티
+        owner = EntityModel.builder()
+                .entityName("com.example.Owner")
+                .tableName("owner_tbl")
+                .build();
+        target = EntityModel.builder()
+                .entityName("com.example.Target")
+                .tableName("target_tbl")
+                .build();
+
+        // 기본 PK (단일)
+        when(context.findAllPrimaryKeyColumns(owner))
+                .thenReturn(List.of(ColumnModel.builder().tableName("owner_tbl").columnName("owner_id").javaType("Long").isPrimaryKey(true).build()));
+        when(context.findAllPrimaryKeyColumns(target))
+                .thenReturn(List.of(ColumnModel.builder().tableName("target_tbl").columnName("target_id").javaType("Long").isPrimaryKey(true).build()));
+
+        // 컬렉션 + 제네릭 존재
+        when(attr.isCollection()).thenReturn(true);
+        when(attr.genericArg(0)).thenReturn(Optional.of(mock(DeclaredType.class)));
+
+        // resolveTargetEntity → TypeElement(mock) → FQN(String)
+        TypeElement te = mock(TypeElement.class);
+        Name qn = mock(Name.class);
+        when(qn.toString()).thenReturn("com.example.Target");
+        when(te.getQualifiedName()).thenReturn(qn);
+        when(support.resolveTargetEntity(eq(attr), isNull(), isNull(), isNull(), eq(manyToMany)))
+                .thenReturn(Optional.of(te));
+
+        // ConstraintMode 체크는 기본 true로
+        when(support.allSameConstraintMode(anyList())).thenReturn(true);
+
+        // 스키마에 타겟 등록
+        entities.put("com.example.Target", target);
+    }
+
+    // ---------- supports() ----------
+
+    @Test
+    void supports_true_when_mappedBy_empty() {
+        when(manyToMany.mappedBy()).thenReturn("");
+        assertThat(processor.supports(attr)).isTrue();
+    }
+
+    @Test
+    void supports_false_when_mappedBy_present() {
+        when(manyToMany.mappedBy()).thenReturn("otherSide");
+        assertThat(processor.supports(attr)).isFalse();
+    }
+
+    // ---------- process(): 행복 경로 (JoinTable 미지정, 기본 네이밍) ----------
+
+    @Test
+    void process_happyPath_default_join_table_and_defaults() {
+        // JoinTable 없음
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(null);
+
+        // 이름 충돌 검증: 예외 없이 통과
+        doReturn(true).when(joinSupport).validateJoinTableNameConflict(anyString(), eq(owner), eq(target), eq(attr));
+
+        // createJoinTableEntity → Optional.of(...)
+        ArgumentCaptor<JoinTableDetails> detailsCap = ArgumentCaptor.forClass(JoinTableDetails.class);
+        EntityModel created = EntityModel.builder()
+                .entityName("jt_owner_tbl__target_tbl")
+                .tableName("jt_owner_tbl__target_tbl")
+                .tableType(EntityModel.TableType.JOIN_TABLE)
+                .build();
+        when(joinSupport.createJoinTableEntity(detailsCap.capture(), anyList(), anyList()))
+                .thenReturn(Optional.of(created));
+
+        processor.process(attr, owner);
+
+        // JoinTableDetails 검증
+        JoinTableDetails d = detailsCap.getValue();
+        assertThat(d.joinTableName()).isEqualTo("jt_owner_tbl__target_tbl");
+        assertThat(d.ownerEntity()).isEqualTo(owner);
+        assertThat(d.referencedEntity()).isEqualTo(target);
+        assertThat(d.ownerFkToPkMap()).containsEntry("owner_tbl_owner_id", "owner_id");
+        assertThat(d.inverseFkToPkMap()).containsEntry("target_tbl_target_id", "target_id");
+
+        // ensure 호출
+        verify(joinSupport).ensureJoinTableColumns(eq(created), anyList(), anyList(), anyMap(), anyMap(), eq(attr));
+        verify(joinSupport).ensureJoinTableRelationships(eq(created), any(JoinTableDetails.class));
+
+        // N:N PK 제약 추가 확인 (owner_fk + target_fk)
+        assertThat(created.getConstraints().values())
+                .anySatisfy(c -> {
+                    assertThat(c.getType()).isEqualTo(ConstraintType.PRIMARY_KEY);
+                    assertThat(c.getColumns()).containsExactly("owner_tbl_owner_id", "target_tbl_target_id");
+                });
+
+        // 스키마에 등록
+        assertThat(entities).containsKey("jt_owner_tbl__target_tbl");
+        assertThat(entities.get("jt_owner_tbl__target_tbl")).isSameAs(created);
+
+        // 에러 없음
+        verify(messager, never()).printMessage(eq(Diagnostic.Kind.ERROR), anyString(), any());
+    }
+
+    // ---------- process(): 행복 경로 (JoinTable 명시 + 명시적 JoinColumns) ----------
+
+    @Test
+    void process_happyPath_with_explicit_JoinTable_and_JoinColumns_and_UniqueConstraints() {
+        JoinTable jt = mock(JoinTable.class);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+
+        // jt.name() 모킹 반드시
+        when(jt.name()).thenReturn("mm_posts_tags");
+
+        // owner side joinColumns (1:1)
+        JoinColumn o = mock(JoinColumn.class);
+        when(o.referencedColumnName()).thenReturn(""); // 단일PK: 빈 문자열이면 순서로 매핑
+        when(o.name()).thenReturn("owner_fk");
+        ForeignKey ofk = mock(ForeignKey.class);
+        when(ofk.name()).thenReturn(""); // 이름 미지정 → 내부 네이밍
+        when(ofk.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(o.foreignKey()).thenReturn(ofk);
+        when(jt.joinColumns()).thenReturn(new JoinColumn[]{o});
+
+        // inverse side joinColumns (1:1)
+        JoinColumn t = mock(JoinColumn.class);
+        when(t.referencedColumnName()).thenReturn(""); // 단일PK
+        when(t.name()).thenReturn("target_fk");
+        ForeignKey tfk = mock(ForeignKey.class);
+        when(tfk.name()).thenReturn("");
+        when(tfk.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(t.foreignKey()).thenReturn(tfk);
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[]{t});
+
+        // uniqueConstraints 존재
+        jakarta.persistence.UniqueConstraint uc = mock(jakarta.persistence.UniqueConstraint.class);
+        when(uc.columnNames()).thenReturn(new String[]{"owner_fk"});
+        when(jt.uniqueConstraints()).thenReturn(new jakarta.persistence.UniqueConstraint[]{uc});
+
+        // 이름 충돌 검증: 통과
+        doReturn(true).when(joinSupport).validateJoinTableNameConflict(eq("mm_posts_tags"), eq(owner), eq(target), eq(attr));
+
+        ArgumentCaptor<JoinTableDetails> cap = ArgumentCaptor.forClass(JoinTableDetails.class);
+        EntityModel created = EntityModel.builder()
+                .entityName("mm_posts_tags")
+                .tableName("mm_posts_tags")
+                .tableType(EntityModel.TableType.JOIN_TABLE)
+                .build();
+        when(joinSupport.createJoinTableEntity(cap.capture(), anyList(), anyList()))
+                .thenReturn(Optional.of(created));
+
+        processor.process(attr, owner);
+
+        JoinTableDetails d = cap.getValue();
+        assertThat(d.joinTableName()).isEqualTo("mm_posts_tags");
+        assertThat(d.ownerFkToPkMap()).containsEntry("owner_fk", "owner_id");
+        assertThat(d.inverseFkToPkMap()).containsEntry("target_fk", "target_id");
+
+        // ensure & uniqueConstraints 처리 호출 확인
+        verify(joinSupport).ensureJoinTableColumns(eq(created), anyList(), anyList(), anyMap(), anyMap(), eq(attr));
+        verify(joinSupport).ensureJoinTableRelationships(eq(created), any(JoinTableDetails.class));
+        verify(joinSupport).addJoinTableUniqueConstraints(eq(created), any(jakarta.persistence.UniqueConstraint[].class), eq(attr));
+
+        // PK 제약 추가 확인
+        assertThat(created.getConstraints().values())
+                .anySatisfy(c -> assertThat(c.getType()).isEqualTo(ConstraintType.PRIMARY_KEY));
+    }
+
+    // ---------- 에러 경로들 ----------
+
+    @Test
+    void process_error_when_not_a_collection() {
+        when(attr.isCollection()).thenReturn(false);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(null);
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("@ManyToMany field must be a collection type"), eq(diagnosticElement));
+        verifyNoMoreInteractions(joinSupport);
+    }
+
+    @Test
+    void process_error_when_generic_type_missing() {
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(null);
+        when(attr.genericArg(0)).thenReturn(Optional.empty());
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("Cannot resolve generic type parameter"), eq(diagnosticElement));
+        verifyNoMoreInteractions(joinSupport);
+    }
+
+    @Test
+    void process_error_when_any_side_pks_empty() {
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(null);
+        when(context.findAllPrimaryKeyColumns(owner)).thenReturn(List.of()); // owner pk 없음
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("must have a primary key"), eq(diagnosticElement));
+        verifyNoMoreInteractions(joinSupport);
+    }
+
+    @Test
+    void process_error_when_joinColumns_count_mismatch_owner_side() {
+        JoinTable jt = mock(JoinTable.class);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+        when(jt.name()).thenReturn("mm_bad");
+        // composite owner PK 2개
+        when(context.findAllPrimaryKeyColumns(owner)).thenReturn(List.of(
+                ColumnModel.builder().tableName("owner_tbl").columnName("a").javaType("Long").isPrimaryKey(true).build(),
+                ColumnModel.builder().tableName("owner_tbl").columnName("b").javaType("Long").isPrimaryKey(true).build()
+        ));
+        // joinColumns 1개 → 카운트 불일치
+        JoinColumn c = mock(JoinColumn.class);
+        when(jt.joinColumns()).thenReturn(new JoinColumn[]{c});
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[0]);
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("must match its primary key columns"), eq(diagnosticElement));
+        verifyNoMoreInteractions(joinSupport);
+    }
+
+    @Test
+    void process_error_when_inverseJoinColumns_count_mismatch_target_side() {
+        JoinTable jt = mock(JoinTable.class);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+        when(jt.name()).thenReturn("mm_bad2");
+        // target composite PK 2개
+        when(context.findAllPrimaryKeyColumns(target)).thenReturn(List.of(
+                ColumnModel.builder().tableName("target_tbl").columnName("x").javaType("Long").isPrimaryKey(true).build(),
+                ColumnModel.builder().tableName("target_tbl").columnName("y").javaType("Long").isPrimaryKey(true).build()
+        ));
+        // inverseJoinColumns 1개 → 카운트 불일치
+        JoinColumn c = mock(JoinColumn.class);
+        when(jt.joinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[]{c});
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("must match its primary key columns"), eq(diagnosticElement));
+        verifyNoMoreInteractions(joinSupport);
+    }
+
+    @Test
+    void process_error_when_constraintMode_not_same_on_owner_side() {
+        JoinTable jt = mock(JoinTable.class);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+        when(jt.name()).thenReturn("mm_owner_mode");
+        // owner composite PK 2개
+        when(context.findAllPrimaryKeyColumns(owner)).thenReturn(List.of(
+                ColumnModel.builder().tableName("owner_tbl").columnName("a").javaType("Long").isPrimaryKey(true).build(),
+                ColumnModel.builder().tableName("owner_tbl").columnName("b").javaType("Long").isPrimaryKey(true).build()
+        ));
+
+        JoinColumn jc1 = mock(JoinColumn.class);
+        JoinColumn jc2 = mock(JoinColumn.class);
+        when(jt.joinColumns()).thenReturn(new JoinColumn[]{jc1, jc2});
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[0]);
+
+        ForeignKey fk1 = mock(ForeignKey.class);
+        when(fk1.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(fk1.name()).thenReturn("");
+        when(jc1.foreignKey()).thenReturn(fk1);
+        when(jc1.referencedColumnName()).thenReturn("a");
+        when(jc1.name()).thenReturn("a_fk");
+
+        ForeignKey fk2 = mock(ForeignKey.class);
+        when(fk2.value()).thenReturn(ConstraintMode.NO_CONSTRAINT);
+        when(fk2.name()).thenReturn("");
+        when(jc2.foreignKey()).thenReturn(fk2);
+        when(jc2.referencedColumnName()).thenReturn("b");
+        when(jc2.name()).thenReturn("b_fk");
+
+        // 이 케이스만 false 반환
+        when(support.allSameConstraintMode(eq(Arrays.asList(jc1, jc2)))).thenReturn(false);
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("All owner-side @JoinColumn.foreignKey.value must be identical"), eq(diagnosticElement));
+        verifyNoMoreInteractions(joinSupport);
+    }
+
+    @Test
+    void process_error_when_fk_name_collision_between_owner_and_target_sides() {
+        JoinTable jt = mock(JoinTable.class);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+        when(jt.name()).thenReturn("mm_collision");
+
+        // 단일 PK 양쪽, 같은 FK 이름 강제 → 충돌
+        JoinColumn o = mock(JoinColumn.class);
+        when(o.name()).thenReturn("dup_fk");
+        when(o.referencedColumnName()).thenReturn("");
+        ForeignKey ofk = mock(ForeignKey.class);
+        when(ofk.name()).thenReturn("");
+        when(ofk.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(o.foreignKey()).thenReturn(ofk);
+
+        JoinColumn t = mock(JoinColumn.class);
+        when(t.name()).thenReturn("dup_fk");
+        when(t.referencedColumnName()).thenReturn("");
+        ForeignKey tfk = mock(ForeignKey.class);
+        when(tfk.name()).thenReturn("");
+        when(tfk.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(t.foreignKey()).thenReturn(tfk);
+
+        when(jt.joinColumns()).thenReturn(new JoinColumn[]{o});
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[]{t});
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("foreign key name collision across sides"), eq(diagnosticElement));
+        verifyNoMoreInteractions(joinSupport);
+    }
+
+    @Test
+    void process_error_when_owner_referencedColumn_is_not_pk() {
+        JoinTable jt = mock(JoinTable.class);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+        when(jt.name()).thenReturn("mm_bad_ref");
+
+        // owner 실제 PK는 a
+        when(context.findAllPrimaryKeyColumns(owner)).thenReturn(List.of(
+                ColumnModel.builder().tableName("owner_tbl").columnName("a").javaType("Long").isPrimaryKey(true).build()
+        ));
+
+        JoinColumn jc = mock(JoinColumn.class);
+        when(jc.referencedColumnName()).thenReturn("not_pk");
+        when(jc.name()).thenReturn("fk_bad");
+        ForeignKey fk = mock(ForeignKey.class);
+        when(fk.name()).thenReturn("");
+        when(fk.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(jc.foreignKey()).thenReturn(fk);
+        when(jt.joinColumns()).thenReturn(new JoinColumn[]{jc});
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[0]);
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("is not a primary key column"), eq(diagnosticElement));
+        verifyNoMoreInteractions(joinSupport);
+    }
+
+    @Test
+    void process_returns_when_resolveTargetEntity_empty() {
+        when(support.resolveTargetEntity(eq(attr), isNull(), isNull(), isNull(), eq(manyToMany)))
+                .thenReturn(Optional.empty());
+
+        processor.process(attr, owner);
+
+        verifyNoInteractions(joinSupport);
+    }
+
+    @Test
+    void process_returns_when_target_entity_not_in_schema() {
+        entities.clear(); // target 제거
+        processor.process(attr, owner);
+        verifyNoInteractions(joinSupport);
+    }
+
+    @Test
+    void process_existing_join_table_with_non_join_table_type_reports_error() {
+        JoinTable jt = mock(JoinTable.class);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+        when(jt.name()).thenReturn("existing_tbl");
+        when(jt.joinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[0]);
+
+        EntityModel existing = EntityModel.builder()
+                .entityName("existing_tbl")
+                .tableName("existing_tbl")
+                .tableType(EntityModel.TableType.ENTITY) // 충돌
+                .build();
+        entities.put("existing_tbl", existing);
+
+        doReturn(true).when(joinSupport).validateJoinTableNameConflict(eq("existing_tbl"), eq(owner), eq(target), eq(attr));
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("conflicts with a non-join entity/table"), eq(diagnosticElement));
+        verify(joinSupport, never()).ensureJoinTableColumns(any(), anyList(), anyList(), anyMap(), anyMap(), any());
+    }
+
+    @Test
+    void process_returns_when_join_table_name_validator_throws() {
+        JoinTable jt = mock(JoinTable.class);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+        when(jt.joinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.name()).thenReturn("mm_throw");
+
+        doThrow(new IllegalStateException("stop"))
+                .when(joinSupport).validateJoinTableNameConflict(eq("mm_throw"), eq(owner), eq(target), eq(attr));
+
+        processor.process(attr, owner);
+
+        // 이후 동작 없음
+        verify(joinSupport, never()).createJoinTableEntity(any(), anyList(), anyList());
+    }
+
+    @Test
+    void process_existing_join_table_with_fk_set_mismatch_aborts() {
+        JoinTable jt = mock(JoinTable.class);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+        when(jt.name()).thenReturn("existing_jt");
+        when(jt.joinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[0]);
+
+        EntityModel existing = EntityModel.builder()
+                .entityName("existing_jt")
+                .tableName("existing_jt")
+                .tableType(EntityModel.TableType.JOIN_TABLE)
+                .build();
+        entities.put("existing_jt", existing);
+
+        doReturn(true).when(joinSupport).validateJoinTableNameConflict(eq("existing_jt"), eq(owner), eq(target), eq(attr));
+        doThrow(new IllegalStateException("fk mismatch"))
+                .when(joinSupport).validateJoinTableFkConsistency(eq(existing), any(JoinTableDetails.class), eq(attr));
+
+        processor.process(attr, owner);
+
+        verify(joinSupport, never()).ensureJoinTableColumns(any(), anyList(), anyList(), anyMap(), anyMap(), any());
+    }
+}

--- a/jinx-processor/src/test/java/org/jinx/handler/relationship/OneToManyOwningFkProcessor_AdditionalTest.java
+++ b/jinx-processor/src/test/java/org/jinx/handler/relationship/OneToManyOwningFkProcessor_AdditionalTest.java
@@ -1,0 +1,174 @@
+package org.jinx.handler.relationship;
+
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinColumns;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.OneToMany;
+import org.jinx.context.ProcessingContext;
+import org.jinx.descriptor.AttributeDescriptor;
+import org.jinx.model.ColumnModel;
+import org.jinx.model.EntityModel;
+import org.jinx.model.SchemaModel;
+import org.jinx.naming.DefaultNaming;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.tools.Diagnostic;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class OneToManyOwningFkProcessor_AdditionalTest {
+
+    ProcessingContext context;
+    RelationshipSupport support;
+    OneToManyOwningFkProcessor processor;
+
+    SchemaModel schema;
+    Map<String, EntityModel> entities;
+    javax.annotation.processing.Messager messager;
+
+    AttributeDescriptor attr;
+    OneToMany oneToMany;
+    Element diagEl;
+
+    EntityModel owner;
+    EntityModel target;
+
+    @BeforeEach
+    void setUp() {
+        context = mock(ProcessingContext.class);
+        support = mock(RelationshipSupport.class);
+        processor = new OneToManyOwningFkProcessor(context, support);
+
+        messager = mock(javax.annotation.processing.Messager.class);
+        schema = mock(SchemaModel.class);
+        entities = new HashMap<>();
+
+        when(context.getMessager()).thenReturn(messager);
+        when(context.getSchemaModel()).thenReturn(schema);
+        when(schema.getEntities()).thenReturn(entities);
+        when(context.getNaming()).thenReturn(new DefaultNaming(63));
+
+        attr = mock(AttributeDescriptor.class);
+        oneToMany = mock(OneToMany.class);
+        when(attr.getAnnotation(OneToMany.class)).thenReturn(oneToMany);
+        when(oneToMany.mappedBy()).thenReturn(""); // owning
+
+        diagEl = mock(Element.class);
+        when(attr.elementForDiagnostics()).thenReturn(diagEl);
+        when(attr.name()).thenReturn("orders");   // FK 기본 네이밍에 사용됨
+
+        // 기본: 컬렉션 + 제네릭 존재
+        when(attr.isCollection()).thenReturn(true);
+        when(attr.genericArg(0)).thenReturn(Optional.of(mock(DeclaredType.class)));
+
+        // 기본 엔티티
+        owner = EntityModel.builder().entityName("com.example.Owner").tableName("owner_tbl").build();
+        target = EntityModel.builder().entityName("com.example.Target").tableName("target_tbl").build();
+
+        // PK (단일)
+        when(context.findAllPrimaryKeyColumns(owner))
+                .thenReturn(List.of(ColumnModel.builder()
+                        .tableName("owner_tbl").columnName("owner_id").javaType("Long").isPrimaryKey(true).build()));
+
+        // resolveTargetEntity -> TypeElement("com.example.Target")
+        TypeElement te = mock(TypeElement.class);
+        Name qn = mock(Name.class);
+        when(qn.toString()).thenReturn("com.example.Target");
+        when(te.getQualifiedName()).thenReturn(qn);
+
+        when(support.resolveTargetEntity(eq(attr), isNull(), isNull(), any(), isNull()))
+                .thenReturn(Optional.of(te));
+
+        // 스키마에 타겟 존재 (테스트마다 필요에 따라 비우기도 함)
+        entities.put("com.example.Target", target);
+
+        // 기본: JoinColumn 하나(mock)
+        JoinColumn jc = mock(JoinColumn.class);
+        when(jc.name()).thenReturn("owner_fk");
+        when(jc.referencedColumnName()).thenReturn(""); // 인덱스 기반 fallback 사용 가능
+        when(jc.nullable()).thenReturn(true);
+
+        when(attr.getAnnotation(JoinColumns.class)).thenReturn(null);
+        when(attr.getAnnotation(JoinColumn.class)).thenReturn(jc);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(null);
+
+        // FK가 걸릴 테이블 resolve
+        when(support.resolveJoinColumnTable(any(), eq(target))).thenReturn(target.getTableName());
+    }
+
+    // --- supports() 보강: JoinTable이 존재하면 false ---
+
+    @Test
+    void supports_false_when_joinTable_present_even_if_joinColumn_exists() {
+        // given: JoinColumn + JoinTable 동시 존재
+        JoinTable jt = mock(JoinTable.class);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+
+        boolean ok = processor.supports(attr);
+        assertThat(ok).isFalse(); // FK 전략은 JoinTable 있으면 안 됨
+    }
+
+    // --- process(): resolveTargetEntity empty → return ---
+
+    @Test
+    void process_returns_when_resolveTargetEntity_empty() {
+        when(support.resolveTargetEntity(eq(attr), isNull(), isNull(), any(), isNull()))
+                .thenReturn(Optional.empty());
+
+        processor.process(attr, owner);
+
+        verify(support, times(1))
+                .resolveTargetEntity(eq(attr), isNull(), isNull(), any(OneToMany.class), isNull());
+
+        verifyNoMoreInteractions(support);
+
+        verify(support, never()).putColumn(any(), any());
+    }
+
+    // --- process(): 타겟 엔티티 스키마에 없음 → return ---
+
+    @Test
+    void process_returns_when_target_entity_not_in_schema() {
+        entities.clear(); // 타겟 제거
+
+        processor.process(attr, owner);
+
+        // 새 컬럼 추가나 관계 생성이 없어야 함
+        verify(support, never()).putColumn(any(), any());
+    }
+
+    // --- process(): 기존 FK 컬럼 타입 불일치 → ERROR 후 abort ---
+
+    @Test
+    void process_error_when_existing_fk_column_type_mismatch() {
+        // target에 동일 이름의 FK 컬럼이 이미 있는데 타입이 다름(String vs Long)
+        String fkColName = "owner_fk";
+        ColumnModel existing = ColumnModel.builder()
+                .columnName(fkColName)
+                .tableName(target.getTableName())
+                .javaType("String") // 기대: Long
+                .build();
+
+        when(support.findColumn(eq(target), eq(target.getTableName()), eq(fkColName)))
+                .thenReturn(existing);
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("Type mismatch for implicit foreign key column 'owner_fk'"),
+                eq(diagEl));
+        // abort 되었으므로 putColumn/관계 추가 없음
+        verify(support, never()).putColumn(any(), any());
+    }
+}

--- a/jinx-processor/src/test/java/org/jinx/handler/relationship/OneToManyOwningJoinTableProcessorTest.java
+++ b/jinx-processor/src/test/java/org/jinx/handler/relationship/OneToManyOwningJoinTableProcessorTest.java
@@ -1,0 +1,729 @@
+package org.jinx.handler.relationship;
+
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.OneToMany;
+import org.jinx.context.ProcessingContext;
+import org.jinx.descriptor.AttributeDescriptor;
+import org.jinx.model.ColumnModel;
+import org.jinx.model.EntityModel;
+import org.jinx.model.SchemaModel;
+import org.jinx.naming.DefaultNaming;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.tools.Diagnostic;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class OneToManyOwningJoinTableProcessorTest {
+
+    ProcessingContext context;
+    RelationshipSupport support;
+    RelationshipJoinSupport joinSupport;
+    OneToManyOwningJoinTableProcessor processor;
+
+    SchemaModel schema;
+    Map<String, EntityModel> entities;
+    javax.annotation.processing.Messager messager;
+
+    AttributeDescriptor attr;
+    OneToMany oneToMany;
+    Element diagnosticElement;
+
+    EntityModel owner;
+    EntityModel target;
+
+    @BeforeEach
+    void setUp() {
+        context = mock(ProcessingContext.class);
+        support = mock(RelationshipSupport.class);
+        joinSupport = mock(RelationshipJoinSupport.class);
+        processor = new OneToManyOwningJoinTableProcessor(context, support, joinSupport);
+
+        messager = mock(javax.annotation.processing.Messager.class);
+        schema = mock(SchemaModel.class);
+        entities = new HashMap<>();
+
+        when(context.getMessager()).thenReturn(messager);
+        when(context.getSchemaModel()).thenReturn(schema);
+        when(schema.getEntities()).thenReturn(entities);
+        when(context.getNaming()).thenReturn(new DefaultNaming(63));
+
+        attr = mock(AttributeDescriptor.class);
+        oneToMany = mock(OneToMany.class);
+        when(attr.getAnnotation(OneToMany.class)).thenReturn(oneToMany);
+        when(oneToMany.mappedBy()).thenReturn(""); // owning side
+        
+        // Mock elementForDiagnostics() to return Element
+        diagnosticElement = mock(Element.class);
+        when(attr.elementForDiagnostics()).thenReturn(diagnosticElement);
+        when(attr.name()).thenReturn("testAttribute");
+
+        // 공통 엔티티
+        owner = EntityModel.builder()
+                .entityName("com.example.Owner")
+                .tableName("owner_tbl")
+                .build();
+        target = EntityModel.builder()
+                .entityName("com.example.Target")
+                .tableName("target_tbl")
+                .build();
+
+        // PK 리스트 (단일 PK 기본)
+        when(context.findAllPrimaryKeyColumns(owner))
+                .thenReturn(List.of(ColumnModel.builder().tableName("owner_tbl").columnName("owner_id").javaType("Long").isPrimaryKey(true).build()));
+        when(context.findAllPrimaryKeyColumns(target))
+                .thenReturn(List.of(ColumnModel.builder().tableName("target_tbl").columnName("target_id").javaType("Long").isPrimaryKey(true).build()));
+
+        // 컬렉션 + 제네릭 존재
+        when(attr.isCollection()).thenReturn(true);
+        when(attr.genericArg(0)).thenReturn(Optional.of(mock(DeclaredType.class)));
+
+        // resolveTargetEntity → TypeElement(mock) → FQN(String)
+        TypeElement te = mock(TypeElement.class);
+        Name qn = mock(Name.class);
+        when(qn.toString()).thenReturn("com.example.Target");
+        when(te.getQualifiedName()).thenReturn(qn);
+        when(support.resolveTargetEntity(eq(attr), isNull(), isNull(), eq(oneToMany), isNull()))
+                .thenReturn(Optional.of(te));
+        
+        // Mock allSameConstraintMode method
+        when(support.allSameConstraintMode(anyList())).thenReturn(true);
+
+        // 스키마에 타겟 등록
+        entities.put("com.example.Target", target);
+    }
+
+    // ---------- supports() ----------
+
+    @Test
+    void supports_true_when_Owning_without_JoinColumn_and_no_JoinTable() {
+        // given
+        when(attr.getAnnotation(jakarta.persistence.JoinColumns.class)).thenReturn(null);
+        when(attr.getAnnotation(jakarta.persistence.JoinColumn.class)).thenReturn(null);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(null);
+
+        // when
+        boolean ok = processor.supports(attr);
+
+        // then
+        assertThat(ok).isTrue();
+    }
+
+    @Test
+    void supports_false_when_mappedBy_present() {
+        when(oneToMany.mappedBy()).thenReturn("owner");
+        boolean ok = processor.supports(attr);
+        assertThat(ok).isFalse();
+    }
+
+    @Test
+    void supports_true_when_JoinTable_present_even_if_JoinColumn_exists() {
+        JoinTable jt = mock(JoinTable.class);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+
+        JoinColumn jc = mock(JoinColumn.class);
+        when(attr.getAnnotation(jakarta.persistence.JoinColumn.class)).thenReturn(jc);
+
+        boolean ok = processor.supports(attr);
+        assertThat(ok).isTrue(); // JoinTable 있으면 true
+    }
+
+    @Test
+    void supports_false_when_has_JoinColumn_and_no_JoinTable() {
+        JoinColumn jc = mock(JoinColumn.class);
+        when(attr.getAnnotation(jakarta.persistence.JoinColumn.class)).thenReturn(jc);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(null);
+
+        boolean ok = processor.supports(attr);
+        assertThat(ok).isFalse();
+    }
+
+    // ---------- process(): 행복 경로 (JoinTable 미지정, 기본 네이밍) ----------
+
+    @Test
+    void process_happyPath_default_join_table_and_defaults() {
+        // given: JoinTable 없음 → 기본 이름 jt_owner_tbl__target_tbl
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(null);
+        when(attr.getAnnotation(jakarta.persistence.JoinColumns.class)).thenReturn(null);
+        when(attr.getAnnotation(jakarta.persistence.JoinColumn.class)).thenReturn(null);
+
+        // joinSupport 동작 설정
+        when(joinSupport.validateJoinTableNameConflict(anyString(), eq(owner), eq(target), eq(attr)))
+                .thenReturn(true);
+
+        // createJoinTableEntity → Optional.of(...)
+        ArgumentCaptor<JoinTableDetails> detailsCap = ArgumentCaptor.forClass(JoinTableDetails.class);
+        EntityModel created = EntityModel.builder()
+                .entityName("jt_owner_tbl__target_tbl")
+                .tableName("jt_owner_tbl__target_tbl")
+                .tableType(EntityModel.TableType.JOIN_TABLE)
+                .build();
+        when(joinSupport.createJoinTableEntity(detailsCap.capture(), anyList(), anyList()))
+                .thenReturn(Optional.of(created));
+
+        // when
+        processor.process(attr, owner);
+
+        // then: JoinTableDetails 검증
+        JoinTableDetails d = detailsCap.getValue();
+        assertThat(d.joinTableName()).isEqualTo("jt_owner_tbl__target_tbl");
+        assertThat(d.ownerEntity()).isEqualTo(owner);
+        assertThat(d.referencedEntity()).isEqualTo(target);
+        assertThat(d.ownerFkToPkMap()).containsEntry("owner_tbl_owner_id", "owner_id");
+        assertThat(d.inverseFkToPkMap()).containsEntry("target_tbl_target_id", "target_id");
+
+        // ensure 호출
+        verify(joinSupport).ensureJoinTableColumns(eq(created), anyList(), anyList(), anyMap(), anyMap(), eq(attr));
+        verify(joinSupport).ensureJoinTableRelationships(eq(created), any(JoinTableDetails.class));
+        verify(joinSupport).addOneToManyJoinTableUnique(eq(created), anyMap());
+
+        // 스키마에 등록
+        assertThat(entities).containsKey("jt_owner_tbl__target_tbl");
+        assertThat(entities.get("jt_owner_tbl__target_tbl")).isSameAs(created);
+
+        // 에러 없음
+        verify(messager, never()).printMessage(eq(Diagnostic.Kind.ERROR), anyString(), any());
+    }
+
+    // ---------- process(): 행복 경로 (JoinTable 명시 + 명시적 JoinColumns) ----------
+
+    @Test
+    void process_happyPath_with_explicit_JoinTable_and_JoinColumns() {
+        // JoinTable
+        JoinTable jt = mock(JoinTable.class);
+        when(jt.name()).thenReturn("post__comments");
+        when(jt.uniqueConstraints()).thenReturn(new jakarta.persistence.UniqueConstraint[0]);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+
+        // owner side joinColumns (1:1)
+        JoinColumn o = mock(JoinColumn.class);
+        when(o.referencedColumnName()).thenReturn(""); // 단일PK: 비워두면 순서로 매핑
+        when(o.name()).thenReturn("owner_fk");
+        ForeignKey ofk = mock(ForeignKey.class);
+        when(ofk.name()).thenReturn(""); // 이름 미지정 → 내부 네이밍
+        when(ofk.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(o.foreignKey()).thenReturn(ofk);
+        when(jt.joinColumns()).thenReturn(new JoinColumn[]{o});
+
+        // inverse side joinColumns (1:1)
+        JoinColumn t = mock(JoinColumn.class);
+        when(t.referencedColumnName()).thenReturn(""); // 단일PK
+        when(t.name()).thenReturn("target_fk");
+        ForeignKey tfk = mock(ForeignKey.class);
+        when(tfk.name()).thenReturn("");
+        when(tfk.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(t.foreignKey()).thenReturn(tfk);
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[]{t});
+
+        when(attr.getAnnotation(jakarta.persistence.JoinColumns.class)).thenReturn(null);
+        when(attr.getAnnotation(jakarta.persistence.JoinColumn.class)).thenReturn(null);
+
+        when(joinSupport.validateJoinTableNameConflict(eq("post__comments"), eq(owner), eq(target), eq(attr)))
+                .thenReturn(true);
+
+        ArgumentCaptor<JoinTableDetails> cap = ArgumentCaptor.forClass(JoinTableDetails.class);
+        EntityModel created = EntityModel.builder()
+                .entityName("post__comments")
+                .tableName("post__comments")
+                .tableType(EntityModel.TableType.JOIN_TABLE)
+                .build();
+        when(joinSupport.createJoinTableEntity(cap.capture(), anyList(), anyList()))
+                .thenReturn(Optional.of(created));
+
+        processor.process(attr, owner);
+
+        JoinTableDetails d = cap.getValue();
+        assertThat(d.joinTableName()).isEqualTo("post__comments");
+        assertThat(d.ownerFkToPkMap()).containsEntry("owner_fk", "owner_id");
+        assertThat(d.inverseFkToPkMap()).containsEntry("target_fk", "target_id");
+
+        // 정상 흐름 호출 보장
+        verify(joinSupport).ensureJoinTableColumns(eq(created), anyList(), anyList(), anyMap(), anyMap(), eq(attr));
+        verify(joinSupport).ensureJoinTableRelationships(eq(created), any(JoinTableDetails.class));
+        verify(joinSupport).addOneToManyJoinTableUnique(eq(created), anyMap());
+        assertThat(entities).containsKey("post__comments");
+    }
+
+    // ---------- 에러 경로들 ----------
+
+    @Test
+    void process_error_when_not_a_collection() {
+        when(attr.isCollection()).thenReturn(false);
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("@OneToMany field must be a collection type"), eq(diagnosticElement));
+        verifyNoMoreInteractions(joinSupport);
+    }
+
+    @Test
+    void process_error_when_generic_type_missing() {
+        when(attr.genericArg(0)).thenReturn(Optional.empty());
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("Cannot resolve generic type parameter"), eq(diagnosticElement));
+        verifyNoMoreInteractions(joinSupport);
+    }
+
+    @Test
+    void process_error_when_owner_pks_empty() {
+        when(context.findAllPrimaryKeyColumns(owner)).thenReturn(List.of());
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("Owner entity requires a primary key"), eq(diagnosticElement));
+        verifyNoMoreInteractions(joinSupport);
+    }
+
+    @Test
+    void process_error_when_target_pks_empty() {
+        when(context.findAllPrimaryKeyColumns(target)).thenReturn(List.of());
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("Target entity requires a primary key"), eq(diagnosticElement));
+        verifyNoMoreInteractions(joinSupport);
+    }
+
+    @Test
+    void process_error_when_joinColumns_count_mismatch_owner_side() {
+        JoinTable jt = mock(JoinTable.class);
+        when(jt.name()).thenReturn(""); // Empty string to use default naming
+        when(jt.joinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.uniqueConstraints()).thenReturn(new jakarta.persistence.UniqueConstraint[0]);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+
+        // composite owner PK 2개
+        when(context.findAllPrimaryKeyColumns(owner)).thenReturn(List.of(
+                ColumnModel.builder().tableName("owner_tbl").columnName("a").javaType("Long").isPrimaryKey(true).build(),
+                ColumnModel.builder().tableName("owner_tbl").columnName("b").javaType("Long").isPrimaryKey(true).build()
+        ));
+
+        // joinColumns 1개 → 카운트 불일치
+        JoinColumn c = mock(JoinColumn.class);
+        when(c.name()).thenReturn("a");
+        when(jt.joinColumns()).thenReturn(new JoinColumn[]{c});
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[0]);
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("JoinTable.joinColumns count must match owner primary key count"), eq(diagnosticElement));
+        verifyNoMoreInteractions(joinSupport);
+    }
+
+    @Test
+    void process_error_when_inverseJoinColumns_count_mismatch_target_side() {
+        JoinTable jt = mock(JoinTable.class);
+        when(jt.name()).thenReturn(""); // Empty string to use default naming
+        when(jt.joinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.uniqueConstraints()).thenReturn(new jakarta.persistence.UniqueConstraint[0]);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+
+        when(context.findAllPrimaryKeyColumns(target)).thenReturn(List.of(
+                ColumnModel.builder().tableName("target_tbl").columnName("x").javaType("Long").isPrimaryKey(true).build(),
+                ColumnModel.builder().tableName("target_tbl").columnName("y").javaType("Long").isPrimaryKey(true).build()
+        ));
+
+        JoinColumn c = mock(JoinColumn.class);
+        when(c.name()).thenReturn("a");
+        when(jt.joinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[]{c});
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("JoinTable.inverseJoinColumns count must match target primary key count"), eq(diagnosticElement));
+        verifyNoMoreInteractions(joinSupport);
+    }
+
+    @Test
+    void process_error_when_composite_pk_requires_referencedColumnName_but_missing() {
+        JoinTable jt = mock(JoinTable.class);
+        when(jt.name()).thenReturn(""); // Empty string to use default naming
+        when(jt.joinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.uniqueConstraints()).thenReturn(new jakarta.persistence.UniqueConstraint[0]);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+
+        // composite owner PK 2개
+        when(context.findAllPrimaryKeyColumns(owner)).thenReturn(List.of(
+                ColumnModel.builder().tableName("owner_tbl").columnName("a").javaType("Long").isPrimaryKey(true).build(),
+                ColumnModel.builder().tableName("owner_tbl").columnName("b").javaType("Long").isPrimaryKey(true).build()
+        ));
+
+        // joinColumns 두 개인데 referencedColumnName 비워서 에러
+        JoinColumn jc1 = mock(JoinColumn.class);
+        when(jc1.name()).thenReturn("a");
+        JoinColumn jc2 = mock(JoinColumn.class);
+        when(jc2.name()).thenReturn("b");
+        when(jc1.referencedColumnName()).thenReturn("");
+        when(jc2.referencedColumnName()).thenReturn("");
+        ForeignKey fk = mock(ForeignKey.class);
+        when(fk.name()).thenReturn("");
+        when(fk.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(jc1.foreignKey()).thenReturn(fk);
+        when(jc2.foreignKey()).thenReturn(fk);
+
+        when(jt.joinColumns()).thenReturn(new JoinColumn[]{jc1, jc2});
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[0]);
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("Composite primary key requires explicit referencedColumnName"), eq(diagnosticElement));
+        verifyNoMoreInteractions(joinSupport);
+    }
+
+    @Test
+    void process_error_when_constraintMode_not_same_on_owner_side() {
+        JoinTable jt = mock(JoinTable.class);
+        when(jt.name()).thenReturn(""); // Empty string to use default naming
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.uniqueConstraints()).thenReturn(new jakarta.persistence.UniqueConstraint[0]);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+        
+        // Set up composite PK for owner to match 2 join columns
+        when(context.findAllPrimaryKeyColumns(owner)).thenReturn(List.of(
+                ColumnModel.builder().tableName("owner_tbl").columnName("a").javaType("Long").isPrimaryKey(true).build(),
+                ColumnModel.builder().tableName("owner_tbl").columnName("b").javaType("Long").isPrimaryKey(true).build()
+        ));
+
+        JoinColumn jc1 = mock(JoinColumn.class);
+        when(jc1.name()).thenReturn("a");
+        JoinColumn jc2 = mock(JoinColumn.class);
+        when(jc2.name()).thenReturn("b");
+
+        ForeignKey fk1 = mock(ForeignKey.class);
+        when(fk1.name()).thenReturn("");
+        when(fk1.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(jc1.foreignKey()).thenReturn(fk1);
+        when(jc1.referencedColumnName()).thenReturn("a"); // Composite PK needs explicit reference
+
+        ForeignKey fk2 = mock(ForeignKey.class);
+        when(fk2.name()).thenReturn("");
+        when(fk2.value()).thenReturn(ConstraintMode.NO_CONSTRAINT);
+        when(jc2.foreignKey()).thenReturn(fk2);
+        when(jc2.referencedColumnName()).thenReturn("b"); // Composite PK needs explicit reference
+
+        when(jt.joinColumns()).thenReturn(new JoinColumn[]{jc1, jc2});
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[0]);
+        
+        // Mock support.allSameConstraintMode to return false for this specific case
+        when(support.allSameConstraintMode(eq(Arrays.asList(jc1, jc2)))).thenReturn(false);
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("All owner-side @JoinColumn.foreignKey.value must be identical"), eq(diagnosticElement));
+        verifyNoMoreInteractions(joinSupport);
+    }
+
+    @Test
+    void process_error_when_fk_name_collision_between_owner_and_target_sides() {
+        JoinTable jt = mock(JoinTable.class);
+        when(jt.name()).thenReturn(""); // Empty string to use default naming
+        when(jt.joinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.uniqueConstraints()).thenReturn(new jakarta.persistence.UniqueConstraint[0]);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+
+        // 오너/타깃 각각 단일 PK, 둘 다 같은 FK 이름으로 지정 → 충돌
+        JoinColumn o = mock(JoinColumn.class);
+        when(o.name()).thenReturn("dup_fk");
+        when(o.referencedColumnName()).thenReturn("");
+        ForeignKey ofk = mock(ForeignKey.class);
+        when(ofk.name()).thenReturn("");
+        when(ofk.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(o.foreignKey()).thenReturn(ofk);
+
+        JoinColumn t = mock(JoinColumn.class);
+        when(t.name()).thenReturn("dup_fk");
+        when(t.referencedColumnName()).thenReturn("");
+        ForeignKey tfk = mock(ForeignKey.class);
+        when(tfk.name()).thenReturn("");
+        when(tfk.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(t.foreignKey()).thenReturn(tfk);
+
+        when(jt.joinColumns()).thenReturn(new JoinColumn[]{o});
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[]{t});
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("JoinTable foreign key name collision across sides"), eq(diagnosticElement));
+        verifyNoMoreInteractions(joinSupport);
+    }
+
+    @Test
+    void process_returns_when_join_table_name_conflict_validator_fails() {
+        // 기본 경로에서 validator=false
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(null);
+        when(attr.getAnnotation(jakarta.persistence.JoinColumns.class)).thenReturn(null);
+        when(attr.getAnnotation(jakarta.persistence.JoinColumn.class)).thenReturn(null);
+
+        when(joinSupport.validateJoinTableNameConflict(anyString(), eq(owner), eq(target), eq(attr)))
+                .thenReturn(false);
+
+        processor.process(attr, owner);
+
+        // 이후 동작 없음
+        verify(joinSupport, never()).createJoinTableEntity(any(), anyList(), anyList());
+    }
+
+    @Test
+    void process_existing_join_table_with_non_join_table_type_reports_error() {
+        // JoinTable 명시
+        JoinTable jt = mock(JoinTable.class);
+        when(jt.name()).thenReturn("existing_tbl");
+        when(jt.joinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.uniqueConstraints()).thenReturn(new jakarta.persistence.UniqueConstraint[0]);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+
+        // 스키마에 동일 이름의 엔티티 있으나 JOIN_TABLE 아님
+        EntityModel existing = EntityModel.builder()
+                .entityName("existing_tbl")
+                .tableName("existing_tbl")
+                .tableType(EntityModel.TableType.ENTITY) // 충돌
+                .build();
+        entities.put("existing_tbl", existing);
+        
+        // Mock joinSupport.validateJoinTableNameConflict to return true so we proceed to the type check
+        when(joinSupport.validateJoinTableNameConflict(eq("existing_tbl"), eq(owner), eq(target), eq(attr)))
+                .thenReturn(true);
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("conflicts with a non-join entity/table"), eq(diagnosticElement));
+        verify(joinSupport, never()).ensureJoinTableColumns(any(), anyList(), anyList(), anyMap(), anyMap(), any());
+    }
+
+    @Test
+    void process_existing_join_table_with_fk_set_mismatch_aborts() {
+        JoinTable jt = mock(JoinTable.class);
+        when(jt.name()).thenReturn("existing_jt");
+        when(jt.joinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.uniqueConstraints()).thenReturn(new jakarta.persistence.UniqueConstraint[0]);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+
+        EntityModel existing = EntityModel.builder()
+                .entityName("existing_jt")
+                .tableName("existing_jt")
+                .tableType(EntityModel.TableType.JOIN_TABLE)
+                .build();
+        entities.put("existing_jt", existing);
+
+        when(joinSupport.validateJoinTableFkConsistency(eq(existing), any(JoinTableDetails.class), eq(attr)))
+                .thenReturn(false);
+        when(jt.joinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.uniqueConstraints()).thenReturn(new jakarta.persistence.UniqueConstraint[0]);
+
+        processor.process(attr, owner);
+
+        verify(joinSupport, never()).ensureJoinTableColumns(any(), anyList(), anyList(), anyMap(), anyMap(), any());
+    }
+
+    @Test
+    void process_returns_when_resolveTargetEntity_empty() {
+        when(support.resolveTargetEntity(eq(attr), isNull(), isNull(), eq(oneToMany), isNull()))
+                .thenReturn(Optional.empty());
+
+        processor.process(attr, owner);
+
+        // 이후 joinSupport 호출 없음
+        verifyNoInteractions(joinSupport);
+    }
+
+    @Test
+    void process_returns_when_target_entity_not_in_schema() {
+        // resolveTargetEntity OK지만 스키마에 미등록
+        entities.clear(); // target 제거
+        processor.process(attr, owner);
+        verifyNoInteractions(joinSupport);
+    }
+
+    @Test
+    void process_error_when_owner_fk_names_not_identical() {
+        JoinTable jt = mock(JoinTable.class);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+        when(jt.name()).thenReturn("jt");
+
+        JoinColumn jc1 = mock(JoinColumn.class);
+        JoinColumn jc2 = mock(JoinColumn.class);
+        when(jt.joinColumns()).thenReturn(new JoinColumn[]{jc1, jc2});
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[0]);
+        // composite PK 2개로 맞춰줌
+        when(context.findAllPrimaryKeyColumns(owner)).thenReturn(List.of(
+                ColumnModel.builder().tableName("owner_tbl").columnName("a").javaType("Long").isPrimaryKey(true).build(),
+                ColumnModel.builder().tableName("owner_tbl").columnName("b").javaType("Long").isPrimaryKey(true).build()
+        ));
+
+        ForeignKey fk1 = mock(ForeignKey.class);
+        when(fk1.name()).thenReturn("FK_A");
+        when(fk1.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(jc1.foreignKey()).thenReturn(fk1);
+        when(jc1.referencedColumnName()).thenReturn("a");
+        when(jc1.name()).thenReturn("a_fk");
+
+        ForeignKey fk2 = mock(ForeignKey.class);
+        when(fk2.name()).thenReturn("FK_B");
+        when(fk2.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(jc2.foreignKey()).thenReturn(fk2);
+        when(jc2.referencedColumnName()).thenReturn("b");
+        when(jc2.name()).thenReturn("b_fk");
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("All owner-side @JoinColumn.foreignKey names must be identical"), eq(diagnosticElement));
+        verifyNoMoreInteractions(joinSupport);
+    }
+
+    @Test
+    void process_error_when_inverse_fk_names_not_identical() {
+        JoinTable jt = mock(JoinTable.class);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+        when(jt.name()).thenReturn("jt");
+
+        JoinColumn t1 = mock(JoinColumn.class);
+        JoinColumn t2 = mock(JoinColumn.class);
+        when(jt.joinColumns()).thenReturn(new JoinColumn[0]);
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[]{t1, t2});
+
+        // target composite PK 2개
+        when(context.findAllPrimaryKeyColumns(target)).thenReturn(List.of(
+                ColumnModel.builder().tableName("target_tbl").columnName("x").javaType("Long").isPrimaryKey(true).build(),
+                ColumnModel.builder().tableName("target_tbl").columnName("y").javaType("Long").isPrimaryKey(true).build()
+        ));
+
+        ForeignKey fk1 = mock(ForeignKey.class);
+        when(fk1.name()).thenReturn("FK_X");
+        when(fk1.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(t1.foreignKey()).thenReturn(fk1);
+        when(t1.referencedColumnName()).thenReturn("x");
+        when(t1.name()).thenReturn("x_fk");
+
+        ForeignKey fk2 = mock(ForeignKey.class);
+        when(fk2.name()).thenReturn("FK_Y_DIFFERENT");
+        when(fk2.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(t2.foreignKey()).thenReturn(fk2);
+        when(t2.referencedColumnName()).thenReturn("y");
+        when(t2.name()).thenReturn("y_fk");
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("All inverse-side @JoinColumn.foreignKey names must be identical"), eq(diagnosticElement));
+        verifyNoMoreInteractions(joinSupport);
+    }
+
+    @Test
+    void process_error_when_owner_referencedColumn_is_not_pk() {
+        JoinTable jt = mock(JoinTable.class);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+        when(jt.name()).thenReturn("jt");
+
+        // owner PK는 a 하나
+        when(context.findAllPrimaryKeyColumns(owner)).thenReturn(List.of(
+                ColumnModel.builder().tableName("owner_tbl").columnName("a").javaType("Long").isPrimaryKey(true).build()
+        ));
+
+        JoinColumn jc = mock(JoinColumn.class);
+        when(jc.referencedColumnName()).thenReturn("not_pk");
+        when(jc.name()).thenReturn("fk_bad");
+        ForeignKey fk = mock(ForeignKey.class);
+        when(fk.name()).thenReturn("");
+        when(fk.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(jc.foreignKey()).thenReturn(fk);
+        when(jt.joinColumns()).thenReturn(new JoinColumn[]{jc});
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[0]);
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("is not a primary key column"), eq(diagnosticElement));
+        verifyNoMoreInteractions(joinSupport);
+    }
+
+    @Test
+    void process_returns_when_createJoinTableEntity_empty() {
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(null);
+        when(joinSupport.validateJoinTableNameConflict(anyString(), eq(owner), eq(target), eq(attr)))
+                .thenReturn(true);
+
+        when(joinSupport.createJoinTableEntity(any(), anyList(), anyList()))
+                .thenReturn(Optional.empty());
+
+        processor.process(attr, owner);
+
+        verify(joinSupport, never()).ensureJoinTableColumns(any(), anyList(), anyList(), anyMap(), anyMap(), any());
+        verify(joinSupport, never()).ensureJoinTableRelationships(any(), any());
+    }
+
+    @Test
+    void process_sets_noConstraint_flags_from_joinColumns() {
+        JoinTable jt = mock(JoinTable.class);
+        when(attr.getAnnotation(JoinTable.class)).thenReturn(jt);
+        when(jt.name()).thenReturn("jt");
+        when(jt.uniqueConstraints()).thenReturn(new jakarta.persistence.UniqueConstraint[0]);
+
+        JoinColumn o = mock(JoinColumn.class);
+        ForeignKey ofk = mock(ForeignKey.class);
+        when(ofk.name()).thenReturn("");
+        when(ofk.value()).thenReturn(ConstraintMode.NO_CONSTRAINT); // owner no constraint
+        when(o.foreignKey()).thenReturn(ofk);
+        when(o.referencedColumnName()).thenReturn(""); // 단일 PK이면 빈 문자열 허용
+        when(o.name()).thenReturn("owner_fk");
+        when(jt.joinColumns()).thenReturn(new JoinColumn[]{o});
+
+        JoinColumn t = mock(JoinColumn.class);
+        ForeignKey tfk = mock(ForeignKey.class);
+        when(tfk.name()).thenReturn("");
+        when(tfk.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(t.foreignKey()).thenReturn(tfk);
+        when(t.referencedColumnName()).thenReturn("");
+        when(t.name()).thenReturn("target_fk");
+        when(jt.inverseJoinColumns()).thenReturn(new JoinColumn[]{t});
+
+        when(joinSupport.validateJoinTableNameConflict(anyString(), eq(owner), eq(target), eq(attr)))
+                .thenReturn(true);
+
+        ArgumentCaptor<JoinTableDetails> cap = ArgumentCaptor.forClass(JoinTableDetails.class);
+        when(joinSupport.createJoinTableEntity(cap.capture(), anyList(), anyList()))
+                .thenReturn(Optional.of(EntityModel.builder()
+                        .entityName("owner__target")
+                        .tableName("owner__target")
+                        .tableType(EntityModel.TableType.JOIN_TABLE)
+                        .build()));
+
+        processor.process(attr, owner);
+
+        JoinTableDetails d = cap.getValue();
+        assertThat(d.ownerNoConstraint()).isTrue();
+        assertThat(d.inverseNoConstraint()).isFalse();
+    }
+
+}

--- a/jinx-processor/src/test/java/org/jinx/handler/relationship/RelationshipJoinSupportTest.java
+++ b/jinx-processor/src/test/java/org/jinx/handler/relationship/RelationshipJoinSupportTest.java
@@ -1,0 +1,419 @@
+package org.jinx.handler.relationship;
+
+import jakarta.persistence.UniqueConstraint;
+import org.jinx.context.ProcessingContext;
+import org.jinx.descriptor.AttributeDescriptor;
+import org.jinx.model.ColumnModel;
+import org.jinx.model.ConstraintModel;
+import org.jinx.model.ConstraintType;
+import org.jinx.model.EntityModel;
+import org.jinx.model.RelationshipModel;
+import org.jinx.model.RelationshipType;
+import org.jinx.naming.DefaultNaming;
+import org.jinx.naming.Naming;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import javax.annotation.processing.Messager;
+import javax.tools.Diagnostic;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class RelationshipJoinSupportTest {
+
+    ProcessingContext context;
+    RelationshipSupport support;
+    Messager messager;
+    Naming naming;
+
+    RelationshipJoinSupport joinSupport;
+
+    AttributeDescriptor attr;
+
+    @BeforeEach
+    void setUp() {
+        context = mock(ProcessingContext.class, RETURNS_DEEP_STUBS);
+        support = mock(RelationshipSupport.class);
+        messager = mock(Messager.class);
+        naming = new DefaultNaming(64);
+        attr = mock(AttributeDescriptor.class);
+
+        when(context.getNaming()).thenReturn(naming);
+        when(context.getMessager()).thenReturn(messager);
+        when(attr.elementForDiagnostics()).thenReturn(null);
+
+        joinSupport = new RelationshipJoinSupport(context, support);
+    }
+
+    private EntityModel newEntity(String name, String table) {
+        return EntityModel.builder()
+                .entityName(name)
+                .tableName(table)
+                .build();
+    }
+
+    private EntityModel newJoinTableEntity(String jt) {
+        return EntityModel.builder()
+                .entityName(jt)
+                .tableName(jt)
+                .tableType(EntityModel.TableType.JOIN_TABLE)
+                .build();
+    }
+
+    @Test
+    void ensureJoinTableRelationships_adds_owner_and_target_FKs_and_indexes() {
+        // given
+        String jtName = "member_role";
+        String ownerTable = "member";
+        String targetTable = "role";
+
+        var joinTable = newJoinTableEntity(jtName);
+        var ownerEntity = newEntity("Member", ownerTable);
+        var targetEntity = newEntity("Role", targetTable);
+
+        // FK 매핑(입력 순서 보존)
+        Map<String, String> ownerFkToPk = new LinkedHashMap<>();
+        ownerFkToPk.put("member_id", "id");
+
+        Map<String, String> targetFkToPk = new LinkedHashMap<>();
+        targetFkToPk.put("role_id", "id");
+
+        var details = mock(JoinTableDetails.class);
+        when(details.joinTableName()).thenReturn(jtName);
+        when(details.ownerEntity()).thenReturn(ownerEntity);
+        when(details.referencedEntity()).thenReturn(targetEntity);
+        when(details.ownerFkToPkMap()).thenReturn(ownerFkToPk);
+        when(details.inverseFkToPkMap()).thenReturn(targetFkToPk);
+        when(details.ownerNoConstraint()).thenReturn(false);
+        when(details.inverseNoConstraint()).thenReturn(false);
+        when(details.ownerFkConstraintName()).thenReturn(null);
+        when(details.inverseFkConstraintName()).thenReturn(null);
+
+        // when
+        joinSupport.ensureJoinTableRelationships(joinTable, details);
+
+        // then
+        // 관계 두 개 생성
+        assertThat(joinTable.getRelationships()).hasSize(2);
+
+        String expectedOwnerFkName = naming.fkName(
+                jtName, List.of("member_id"), ownerTable, List.of("id"));
+        String expectedTargetFkName = naming.fkName(
+                jtName, List.of("role_id"), targetTable, List.of("id"));
+
+        RelationshipModel ownerRel = joinTable.getRelationships().get(expectedOwnerFkName);
+        RelationshipModel targetRel = joinTable.getRelationships().get(expectedTargetFkName);
+
+        assertThat(ownerRel).isNotNull();
+        assertThat(ownerRel.getTableName()).isEqualTo(jtName);
+        assertThat(ownerRel.getType()).isEqualTo(RelationshipType.MANY_TO_ONE);
+        assertThat(ownerRel.getColumns()).containsExactly("member_id");
+        assertThat(ownerRel.getReferencedTable()).isEqualTo(ownerTable);
+        assertThat(ownerRel.getReferencedColumns()).containsExactly("id");
+
+        assertThat(targetRel).isNotNull();
+        assertThat(targetRel.getColumns()).containsExactly("role_id");
+        assertThat(targetRel.getReferencedTable()).isEqualTo(targetTable);
+        assertThat(targetRel.getReferencedColumns()).containsExactly("id");
+
+        // 인덱스 자동 생성 호출 확인
+        verify(support).addForeignKeyIndex(eq(joinTable), eq(List.of("member_id")), eq(jtName));
+        verify(support).addForeignKeyIndex(eq(joinTable), eq(List.of("role_id")), eq(jtName));
+    }
+
+    @Test
+    void addOneToManyJoinTableUnique_adds_unique_on_target_fks_with_order_preserved() {
+        // given
+        String jtName = "a_b";
+        EntityModel jt = newJoinTableEntity(jtName);
+
+        Map<String, String> targetFkToPk = new LinkedHashMap<>();
+        targetFkToPk.put("b_id", "id");
+        targetFkToPk.put("b_code", "code"); // 순서 보존
+
+        // when
+        joinSupport.addOneToManyJoinTableUnique(jt, targetFkToPk);
+
+        // then
+        assertThat(jt.getConstraints()).hasSize(1);
+        ConstraintModel uc = jt.getConstraints().values().iterator().next();
+        assertThat(uc.getType()).isEqualTo(ConstraintType.UNIQUE);
+        assertThat(uc.getTableName()).isEqualTo(jtName);
+        assertThat(uc.getColumns()).containsExactly("b_id", "b_code"); // 입력 순서 유지
+        assertThat(uc.getName()).isEqualTo(naming.uqName(jtName, uc.getColumns()));
+    }
+
+    @Test
+    void addJoinTableUniqueConstraints_valid_and_named_and_generated() {
+        // given
+        String jtName = "post_tag";
+        EntityModel jt = newJoinTableEntity(jtName);
+        jt.putColumn(ColumnModel.builder().tableName(jtName).columnName("post_id").javaType("Long").isNullable(false).build());
+        jt.putColumn(ColumnModel.builder().tableName(jtName).columnName("tag_id").javaType("Long").isNullable(false).build());
+        jt.putColumn(ColumnModel.builder().tableName(jtName).columnName("tenant_id").javaType("Long").isNullable(false).build());
+
+        UniqueConstraint ucNamed = mock(UniqueConstraint.class);
+        when(ucNamed.name()).thenReturn("uc_post_tag_named");
+        when(ucNamed.columnNames()).thenReturn(new String[]{"post_id", "tag_id"});
+
+        UniqueConstraint ucGenerated = mock(UniqueConstraint.class);
+        when(ucGenerated.name()).thenReturn(""); // 이름 비워서 네이밍 전략 사용
+        when(ucGenerated.columnNames()).thenReturn(new String[]{"tenant_id"});
+
+        UniqueConstraint[] arr = new UniqueConstraint[]{ucNamed, ucGenerated};
+
+        // when
+        joinSupport.addJoinTableUniqueConstraints(jt, arr, attr);
+
+        // then: 제약 생성 검증
+        assertThat(jt.getConstraints()).hasSize(2);
+        assertThat(jt.getConstraints()).containsKey("uc_post_tag_named");
+        String generated = naming.uqName(jtName, List.of("tenant_id"));
+        assertThat(jt.getConstraints()).containsKey(generated);
+
+        // messager NOTE 로그 2건 발생 검증
+        @SuppressWarnings("unchecked")
+        var noteCaptor = org.mockito.ArgumentCaptor.forClass(CharSequence.class);
+        verify(messager, times(2)).printMessage(eq(Diagnostic.Kind.NOTE), noteCaptor.capture());
+        var notes = noteCaptor.getAllValues();
+        assertThat(notes.get(0).toString()).contains("Added unique constraint");
+        assertThat(notes.get(1).toString()).contains("Added unique constraint");
+
+        // WARNING/ERROR 는 없어야 함
+        verify(messager, never()).printMessage(eq(Diagnostic.Kind.WARNING), anyString(), any());
+        verify(messager, never()).printMessage(eq(Diagnostic.Kind.ERROR), anyString(), any());
+    }
+
+
+    @Test
+    void addJoinTableUniqueConstraints_warn_on_empty_columns_and_error_on_missing_column() {
+        // given
+        String jtName = "order_item";
+        EntityModel jt = newJoinTableEntity(jtName);
+        // 실제 존재하는 컬럼은 하나만
+        jt.putColumn(ColumnModel.builder().tableName(jtName).columnName("order_id").javaType("Long").isNullable(false).build());
+
+        UniqueConstraint emptyCols = mock(UniqueConstraint.class);
+        when(emptyCols.name()).thenReturn("");
+        when(emptyCols.columnNames()).thenReturn(new String[]{}); // 경고
+
+        UniqueConstraint missingCol = mock(UniqueConstraint.class);
+        when(missingCol.name()).thenReturn("");
+        when(missingCol.columnNames()).thenReturn(new String[]{"order_id", "missing"}); // 에러
+
+        // when
+        joinSupport.addJoinTableUniqueConstraints(jt, new UniqueConstraint[]{emptyCols, missingCol}, attr);
+
+        // then
+        // 첫 번째는 경고, 두 번째는 에러 후 return (추가 없음)
+        verify(messager).printMessage(eq(Diagnostic.Kind.WARNING), contains("UniqueConstraint with empty columnNames"), any());
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR), contains("non-existent column 'missing'"), any());
+
+        assertThat(jt.getConstraints()).isEmpty();
+    }
+
+    @Test
+    void createJoinTableEntity_success_creates_columns_with_not_null_and_types() {
+        // given
+        String jtName = "user_role";
+        var ownerEntity = newEntity("User", "users");
+        var refEntity = newEntity("Role", "roles");
+
+        // owner/ref PK 스키마
+        List<ColumnModel> ownerPks = List.of(
+                ColumnModel.builder().tableName("users").columnName("id").javaType("Long").isPrimaryKey(true).build());
+        List<ColumnModel> refPks = List.of(
+                ColumnModel.builder().tableName("roles").columnName("id").javaType("Long").isPrimaryKey(true).build());
+
+        Map<String, String> ownerFkToPk = new LinkedHashMap<>();
+        ownerFkToPk.put("user_id", "id");
+        Map<String, String> targetFkToPk = new LinkedHashMap<>();
+        targetFkToPk.put("role_id", "id");
+
+        var details = mock(JoinTableDetails.class);
+        when(details.joinTableName()).thenReturn(jtName);
+        when(details.ownerEntity()).thenReturn(ownerEntity);
+        when(details.referencedEntity()).thenReturn(refEntity);
+        when(details.ownerFkToPkMap()).thenReturn(ownerFkToPk);
+        when(details.inverseFkToPkMap()).thenReturn(targetFkToPk);
+
+        // when
+        var result = joinSupport.createJoinTableEntity(details, ownerPks, refPks);
+
+        // then
+        assertThat(result).isPresent();
+        EntityModel jt = result.get();
+        assertThat(jt.getTableName()).isEqualTo(jtName);
+        assertThat(jt.findColumn(jtName, "user_id")).isNotNull();
+        assertThat(jt.findColumn(jtName, "role_id")).isNotNull();
+        assertThat(jt.findColumn(jtName, "user_id").isNullable()).isFalse();
+        assertThat(jt.findColumn(jtName, "user_id").getJavaType()).isEqualTo("Long");
+        verifyNoInteractions(messager);
+    }
+
+    @Test
+    void createJoinTableEntity_error_if_pk_missing() {
+        // given
+        String jtName = "user_role";
+        var ownerEntity = newEntity("User", "users");
+        var refEntity = newEntity("Role", "roles");
+
+        // owner/ref PK 스키마 — owner의 id는 없음(에러 유도)
+        List<ColumnModel> ownerPks = List.of(
+                ColumnModel.builder().tableName("users").columnName("other").javaType("Long").isPrimaryKey(true).build());
+        List<ColumnModel> refPks = List.of(
+                ColumnModel.builder().tableName("roles").columnName("id").javaType("Long").isPrimaryKey(true).build());
+
+        Map<String, String> ownerFkToPk = new LinkedHashMap<>();
+        ownerFkToPk.put("user_id", "id"); // 존재하지 않는 PK
+        Map<String, String> targetFkToPk = new LinkedHashMap<>();
+        targetFkToPk.put("role_id", "id");
+
+        var details = mock(JoinTableDetails.class);
+        when(details.joinTableName()).thenReturn(jtName);
+        when(details.ownerEntity()).thenReturn(ownerEntity);
+        when(details.referencedEntity()).thenReturn(refEntity);
+        when(details.ownerFkToPkMap()).thenReturn(ownerFkToPk);
+        when(details.inverseFkToPkMap()).thenReturn(targetFkToPk);
+
+        // when
+        var result = joinSupport.createJoinTableEntity(details, ownerPks, refPks);
+
+        // then
+        assertThat(result).isEmpty();
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR), contains("Owner primary key 'id' not found"));
+    }
+
+    @Test
+    void addRelationshipsToJoinTable_adds_two_relationships_and_indexes() {
+        // given
+        String jtName = "author_book";
+        var ownerEntity = newEntity("Author", "author");
+        var targetEntity = newEntity("Book", "book");
+
+        Map<String, String> ownerFkToPk = new LinkedHashMap<>();
+        ownerFkToPk.put("author_id", "id");
+        Map<String, String> targetFkToPk = new LinkedHashMap<>();
+        targetFkToPk.put("book_id", "id");
+
+        var jt = newJoinTableEntity(jtName);
+
+        var details = mock(JoinTableDetails.class);
+        when(details.joinTableName()).thenReturn(jtName);
+        when(details.ownerEntity()).thenReturn(ownerEntity);
+        when(details.referencedEntity()).thenReturn(targetEntity);
+        when(details.ownerFkToPkMap()).thenReturn(ownerFkToPk);
+        when(details.inverseFkToPkMap()).thenReturn(targetFkToPk);
+        when(details.ownerNoConstraint()).thenReturn(false);
+        when(details.inverseNoConstraint()).thenReturn(false);
+        when(details.ownerFkConstraintName()).thenReturn(null);
+        when(details.inverseFkConstraintName()).thenReturn(null);
+
+        // when
+        joinSupport.addRelationshipsToJoinTable(jt, details);
+
+        // then
+        assertThat(jt.getRelationships()).hasSize(2);
+        String ownerFkName = naming.fkName(jtName, List.of("author_id"), "author", List.of("id"));
+        String targetFkName = naming.fkName(jtName, List.of("book_id"), "book", List.of("id"));
+        assertThat(jt.getRelationships()).containsKeys(ownerFkName, targetFkName);
+
+        verify(support).addForeignKeyIndex(eq(jt), eq(List.of("author_id")), eq(jtName));
+        verify(support).addForeignKeyIndex(eq(jt), eq(List.of("book_id")), eq(jtName));
+    }
+
+    @Test
+    void ensureJoinTableColumns_creates_missing_and_fixes_nullable_and_reports_type_mismatch() {
+        // given
+        String jtName = "team_user";
+        var jt = newJoinTableEntity(jtName);
+
+        // PK 정의
+        var ownerPk = ColumnModel.builder().tableName("team").columnName("id").javaType("Long").isPrimaryKey(true).build();
+        var targetPk = ColumnModel.builder().tableName("users").columnName("uid").javaType("UUID").isPrimaryKey(true).build();
+
+        List<ColumnModel> ownerPks = List.of(ownerPk);
+        List<ColumnModel> targetPks = List.of(targetPk);
+
+        // FK 매핑
+        Map<String, String> ownerFkToPk = new LinkedHashMap<>();
+        ownerFkToPk.put("team_id", "id"); // 새로 생성될 컬럼
+
+        Map<String, String> targetFkToPk = new LinkedHashMap<>();
+        targetFkToPk.put("user_uid", "uid"); // 이미 존재하지만 nullable=true & 타입 불일치로 에러 유도
+
+        // 기존에 잘못된 정의: 타입 불일치 + nullable
+        jt.putColumn(ColumnModel.builder()
+                .tableName(jtName).columnName("user_uid").javaType("String").isNullable(true).build());
+
+        // when
+        joinSupport.ensureJoinTableColumns(jt, ownerPks, targetPks, ownerFkToPk, targetFkToPk, attr);
+
+        // then
+        // team_id 생성됨
+        var teamId = jt.findColumn(jtName, "team_id");
+        assertThat(teamId).isNotNull();
+        assertThat(teamId.getJavaType()).isEqualTo("Long");
+        assertThat(teamId.isNullable()).isFalse();
+
+        // user_uid 는 nullable 이 false로 고쳐짐
+        var userUid = jt.findColumn(jtName, "user_uid");
+        assertThat(userUid).isNotNull();
+        assertThat(userUid.isNullable()).isFalse();
+
+        // 타입 불일치 에러 메시지 출력
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR), contains("Join table column type mismatch for 'user_uid'"), any());
+    }
+
+    @Test
+    void validateJoinTableNameConflict_detects_conflicts() {
+        // given
+        var owner = newEntity("Owner", "owner");
+        var target = newEntity("Target", "target");
+
+        // when / then
+        assertThat(joinSupport.validateJoinTableNameConflict("owner", owner, target, attr)).isFalse();
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR), contains("conflicts with owner entity table name"), any());
+
+        assertThat(joinSupport.validateJoinTableNameConflict("target", owner, target, attr)).isFalse();
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR), contains("conflicts with referenced entity table name"), any());
+
+        assertThat(joinSupport.validateJoinTableNameConflict("owner_target", owner, target, attr)).isTrue();
+    }
+
+    @Test
+    void validateJoinTableFkConsistency_checks_exact_column_set() {
+        // given
+        String jtName = "student_course";
+        var jt = newJoinTableEntity(jtName);
+
+        // 실제 존재 컬럼
+        jt.putColumn(ColumnModel.builder().tableName(jtName).columnName("student_id").javaType("Long").isNullable(false).build());
+        jt.putColumn(ColumnModel.builder().tableName(jtName).columnName("course_id").javaType("Long").isNullable(false).build());
+
+        Map<String, String> ownerFkToPk = new LinkedHashMap<>();
+        ownerFkToPk.put("student_id", "id");
+        Map<String, String> inverseFkToPk = new LinkedHashMap<>();
+        inverseFkToPk.put("course_id", "id");
+
+        var detailsOk = mock(JoinTableDetails.class);
+        when(detailsOk.joinTableName()).thenReturn(jtName);
+        when(detailsOk.ownerFkToPkMap()).thenReturn(ownerFkToPk);
+        when(detailsOk.inverseFkToPkMap()).thenReturn(inverseFkToPk);
+
+        // OK 케이스
+        assertThat(joinSupport.validateJoinTableFkConsistency(jt, detailsOk, attr)).isTrue();
+
+        // 누락/초과 유도 케이스
+        var detailsBad = mock(JoinTableDetails.class);
+        when(detailsBad.joinTableName()).thenReturn(jtName);
+        when(detailsBad.ownerFkToPkMap()).thenReturn(Map.of("student_id", "id"));
+        when(detailsBad.inverseFkToPkMap()).thenReturn(Map.of("extra_col", "id")); // 존재하지 않는 FK 요구
+
+        assertThat(joinSupport.validateJoinTableFkConsistency(jt, detailsBad, attr)).isFalse();
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR), contains("FK column set mismatch"), any());
+    }
+}

--- a/jinx-processor/src/test/java/org/jinx/handler/relationship/RelationshipSupportTest.java
+++ b/jinx-processor/src/test/java/org/jinx/handler/relationship/RelationshipSupportTest.java
@@ -1,0 +1,328 @@
+package org.jinx.handler.relationship;
+
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.CascadeType;
+
+import org.jinx.context.ProcessingContext;
+import org.jinx.descriptor.AttributeDescriptor;
+import org.jinx.model.*;
+import org.jinx.naming.Naming;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.processing.Messager;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.tools.Diagnostic;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class RelationshipSupportTest {
+
+    private ProcessingContext ctx;
+    private Messager messager;
+    private Naming naming;
+    private RelationshipSupport support;
+
+    @BeforeEach
+    void setUp() {
+        ctx = mock(ProcessingContext.class);
+        messager = mock(Messager.class);
+        naming = mock(Naming.class);
+
+        when(ctx.getMessager()).thenReturn(messager);
+        when(ctx.getNaming()).thenReturn(naming);
+
+        support = new RelationshipSupport(ctx);
+    }
+
+    // ---------- resolveJoinColumnTable ----------
+
+    @Test
+    @DisplayName("resolveJoinColumnTable: null JoinColumn 또는 빈 table → 기본 테이블")
+    void resolveJoinColumnTable_nullOrEmpty() {
+        EntityModel owner = mock(EntityModel.class);
+        when(owner.getTableName()).thenReturn("users");
+
+        assertEquals("users", support.resolveJoinColumnTable(null, owner));
+
+        JoinColumn jc = mock(JoinColumn.class);
+        when(jc.table()).thenReturn("");
+        assertEquals("users", support.resolveJoinColumnTable(jc, owner));
+        verifyNoInteractions(messager);
+    }
+
+    @Test
+    @DisplayName("resolveJoinColumnTable: secondary table로 유효하게 지정된 경우 그대로 사용")
+    void resolveJoinColumnTable_secondaryOk() {
+        EntityModel owner = mock(EntityModel.class);
+        when(owner.getTableName()).thenReturn("users");
+        when(owner.getEntityName()).thenReturn("User");
+
+        SecondaryTableModel st = mock(SecondaryTableModel.class);
+        when(st.getName()).thenReturn("user_ext");
+        when(owner.getSecondaryTables()).thenReturn(List.of(st));
+
+        JoinColumn jc = mock(JoinColumn.class);
+        when(jc.table()).thenReturn("user_ext");
+
+        assertEquals("user_ext", support.resolveJoinColumnTable(jc, owner));
+        verifyNoInteractions(messager);
+    }
+
+    @Test
+    @DisplayName("resolveJoinColumnTable: 존재하지 않는 테이블 지정 → 경고 후 기본 테이블 fallback")
+    void resolveJoinColumnTable_invalidWarns() {
+        EntityModel owner = mock(EntityModel.class);
+        when(owner.getTableName()).thenReturn("users");
+        when(owner.getEntityName()).thenReturn("User");
+        when(owner.getSecondaryTables()).thenReturn(List.of());
+
+        JoinColumn jc = mock(JoinColumn.class);
+        when(jc.table()).thenReturn("bad_table");
+
+        String resolved = support.resolveJoinColumnTable(jc, owner);
+        assertEquals("users", resolved);
+        verify(messager).printMessage(eq(Diagnostic.Kind.WARNING), contains("bad_table"));
+    }
+
+    // ---------- resolveTargetEntity ----------
+
+    @Test
+    @DisplayName("resolveTargetEntity: 명시적 targetEntity 우선")
+    void resolveTargetEntity_explicitAnnotation() {
+        Elements elements = mock(Elements.class);
+        when(ctx.getElementUtils()).thenReturn(elements);
+
+        TypeElement te = mock(TypeElement.class);
+        when(elements.getTypeElement("java.lang.String")).thenReturn(te);
+
+        ManyToOne m2o = mock(ManyToOne.class);
+        doReturn(String.class).when(m2o).targetEntity();
+
+        AttributeDescriptor attr = mock(AttributeDescriptor.class);
+        when(attr.genericArg(anyInt())).thenReturn(Optional.empty());
+        when(attr.type()).thenReturn(mock(TypeMirror.class));
+
+        Optional<TypeElement> found = support.resolveTargetEntity(attr, m2o, null, null, null);
+        assertTrue(found.isPresent());
+        assertSame(te, found.get());
+    }
+
+    @Test
+    @DisplayName("resolveTargetEntity: 컬렉션이면 genericArg(0) 사용")
+    void resolveTargetEntity_collectionGeneric() {
+        AttributeDescriptor attr = mock(AttributeDescriptor.class);
+
+        TypeElement te = mock(TypeElement.class);
+        DeclaredType dt = mock(DeclaredType.class);
+        when(dt.asElement()).thenReturn(te);
+        when(attr.genericArg(0)).thenReturn(Optional.of(dt));
+
+        Optional<TypeElement> found = support.resolveTargetEntity(attr, null, null, mock(OneToMany.class), null);
+        assertTrue(found.isPresent());
+        assertSame(te, found.get());
+    }
+
+    @Test
+    @DisplayName("resolveTargetEntity: fallback으로 속성 타입 사용")
+    void resolveTargetEntity_fallbackPropertyType() {
+        AttributeDescriptor attr = mock(AttributeDescriptor.class);
+        TypeElement te = mock(TypeElement.class);
+        DeclaredType dt = mock(DeclaredType.class);
+        when(dt.asElement()).thenReturn(te);
+        when(attr.genericArg(0)).thenReturn(Optional.empty());
+        when(attr.type()).thenReturn(dt);
+
+        Optional<TypeElement> found = support.resolveTargetEntity(attr, null, null, null, null);
+        assertTrue(found.isPresent());
+        assertSame(te, found.get());
+    }
+
+    // ---------- findColumn / putColumn delegate ----------
+
+    @Test
+    @DisplayName("findColumn/putColumn: EntityModel 위임 확인")
+    void delegate_find_put_column() {
+        EntityModel entity = mock(EntityModel.class);
+        ColumnModel col = mock(ColumnModel.class);
+
+        when(entity.findColumn("t", "c")).thenReturn(col);
+
+        assertSame(col, support.findColumn(entity, "t", "c"));
+        support.putColumn(entity, col);
+        verify(entity).putColumn(col);
+    }
+
+    // ---------- allSameConstraintMode ----------
+
+    @Test
+    @DisplayName("allSameConstraintMode: 모두 동일하면 true, 아니면 false")
+    void allSameConstraintMode_cases() {
+        assertTrue(support.allSameConstraintMode(List.of()));
+
+        JoinColumn a = joinColumnWithMode(ConstraintMode.CONSTRAINT);
+        JoinColumn b = joinColumnWithMode(ConstraintMode.CONSTRAINT);
+        JoinColumn c = joinColumnWithMode(ConstraintMode.NO_CONSTRAINT);
+
+        assertTrue(support.allSameConstraintMode(List.of(a, b)));
+        assertFalse(support.allSameConstraintMode(List.of(a, c)));
+    }
+
+    // ---------- toCascadeList ----------
+
+    @Test
+    @DisplayName("toCascadeList: null은 빈 리스트, 배열은 List로 변환")
+    void toCascadeList_cases() {
+        assertTrue(support.toCascadeList(null).isEmpty());
+
+        var list = support.toCascadeList(new CascadeType[]{CascadeType.PERSIST, CascadeType.MERGE});
+        assertEquals(2, list.size());
+        assertEquals(CascadeType.PERSIST, list.get(0));
+        assertEquals(CascadeType.MERGE, list.get(1));
+    }
+
+    // ---------- coveredByPkOrUnique / hasSameIndex / addForeignKeyIndex ----------
+
+    @Test
+    @DisplayName("coveredByPkOrUnique: 동일 집합이면 true, 아니면 false")
+    void coveredByPkOrUnique_cases() {
+        EntityModel e = mock(EntityModel.class);
+        Map<String, ConstraintModel> cons = new HashMap<>();
+        when(e.getConstraints()).thenReturn(cons);
+
+        cons.put("pk_users_id",
+                ConstraintModel.builder()
+                        .name("pk_users_id")
+                        .type(ConstraintType.PRIMARY_KEY)
+                        .tableName("users")
+                        .columns(List.of("id"))
+                        .build());
+
+        assertTrue(support.coveredByPkOrUnique(e, "users", List.of("id")));
+        assertFalse(support.coveredByPkOrUnique(e, "users", List.of("org_id", "id")));
+        assertFalse(support.coveredByPkOrUnique(e, "orders", List.of("id")));
+    }
+
+    @Test
+    @DisplayName("hasSameIndex: 동일 테이블+컬럼 순서 완전일치만 true")
+    void hasSameIndex_cases() {
+        EntityModel e = mock(EntityModel.class);
+        Map<String, IndexModel> idx = new HashMap<>();
+        when(e.getIndexes()).thenReturn(idx);
+
+        idx.put("ix_users_org_id_id",
+                IndexModel.builder()
+                        .indexName("ix_users_org_id_id")
+                        .tableName("users")
+                        .columnNames(List.of("org_id", "id"))
+                        .build());
+
+        assertTrue(support.hasSameIndex(e, "users", List.of("org_id", "id")));
+        assertFalse(support.hasSameIndex(e, "users", List.of("id", "org_id"))); // 순서 다르면 false
+        assertFalse(support.hasSameIndex(e, "orders", List.of("org_id", "id")));
+    }
+
+    @Test
+    @DisplayName("addForeignKeyIndex: PK/UNIQUE로 커버되면 생략, 동일 인덱스 있으면 생략, 아니면 생성")
+    void addForeignKeyIndex_flow() {
+        EntityModel e = mock(EntityModel.class);
+        Map<String, ConstraintModel> cons = new HashMap<>();
+        Map<String, IndexModel> idx = new HashMap<>();
+        when(e.getConstraints()).thenReturn(cons);
+        when(e.getIndexes()).thenReturn(idx);
+
+        // PK(id) 존재 → (id) 인덱스는 생략
+        cons.put("pk_users_id",
+                ConstraintModel.builder()
+                        .name("pk_users_id")
+                        .type(ConstraintType.PRIMARY_KEY)
+                        .tableName("users")
+                        .columns(List.of("id"))
+                        .build());
+
+        support.addForeignKeyIndex(e, List.of("id"), "users");
+        assertTrue(idx.isEmpty());
+
+        // 동일 인덱스가 이미 있으면 생략
+        when(naming.ixName("users", List.of("org_id", "id"))).thenReturn("ix_users_org_id_id");
+        idx.put("ix_users_org_id_id",
+                IndexModel.builder().indexName("ix_users_org_id_id").tableName("users")
+                        .columnNames(List.of("org_id", "id")).build());
+
+        support.addForeignKeyIndex(e, List.of("org_id", "id"), "users");
+        assertEquals(1, idx.size());
+
+        // 새 인덱스 생성
+        idx.clear();
+        when(naming.ixName("users", List.of("org_id", "id"))).thenReturn("ix_new");
+        support.addForeignKeyIndex(e, List.of("org_id", "id"), "users");
+
+        assertEquals(1, idx.size());
+        IndexModel created = idx.get("ix_new");
+        assertNotNull(created);
+        assertEquals(List.of("org_id", "id"), created.getColumnNames());
+        assertEquals("users", created.getTableName());
+    }
+
+    // ---------- promoteColumnsToPrimaryKey ----------
+
+    @Test
+    @DisplayName("promoteColumnsToPrimaryKey: 누락 컬럼이면 ERROR 로그 및 entity.setValid(false)")
+    void promoteColumnsToPrimaryKey_missingColumn() {
+        EntityModel e = mock(EntityModel.class);
+        when(e.findColumn("users", "missing")).thenReturn(null);
+
+        support.promoteColumnsToPrimaryKey(e, "users", List.of("missing"));
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR), contains("Missing FK column"));
+        verify(e).setValid(false);
+        verify(e, never()).getConstraints();
+    }
+
+    @Test
+    @DisplayName("promoteColumnsToPrimaryKey: 컬럼 PK/NN 설정 및 PK 제약 추가")
+    void promoteColumnsToPrimaryKey_success() {
+        EntityModel e = mock(EntityModel.class);
+        Map<String, ConstraintModel> cons = new HashMap<>();
+        when(e.getConstraints()).thenReturn(cons);
+
+        ColumnModel col = mock(ColumnModel.class);
+        when(col.getTableName()).thenReturn(null); // 테이블명도 세팅해보자
+        when(e.findColumn("users", "order_id")).thenReturn(col);
+
+        when(naming.pkName("users", List.of("order_id"))).thenReturn("pk_users_order_id");
+
+        support.promoteColumnsToPrimaryKey(e, "users", List.of("order_id"));
+
+        // 컬럼 속성 변경 호출되었는지
+        verify(col).setPrimaryKey(true);
+        verify(col).setNullable(false);
+        verify(col).setTableName("users");
+
+        // 제약 추가 확인
+        ConstraintModel pk = cons.get("pk_users_order_id");
+        assertNotNull(pk);
+        assertEquals(ConstraintType.PRIMARY_KEY, pk.getType());
+        assertEquals(List.of("order_id"), pk.getColumns());
+        assertEquals("users", pk.getTableName());
+    }
+
+    private JoinColumn joinColumnWithMode(ConstraintMode mode) {
+        JoinColumn jc = mock(JoinColumn.class);
+        ForeignKey fk = mock(ForeignKey.class);
+        when(fk.value()).thenReturn(mode);
+        when(jc.foreignKey()).thenReturn(fk);
+        return jc;
+    }
+}

--- a/jinx-processor/src/test/java/org/jinx/handler/relationship/ToOneRelationshipProcessorTest.java
+++ b/jinx-processor/src/test/java/org/jinx/handler/relationship/ToOneRelationshipProcessorTest.java
@@ -1,0 +1,434 @@
+package org.jinx.handler.relationship;
+
+import jakarta.persistence.*;
+import org.jinx.context.ProcessingContext;
+import org.jinx.descriptor.AttributeDescriptor;
+import org.jinx.model.*;
+import org.jinx.naming.DefaultNaming;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.tools.Diagnostic;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for ToOneRelationshipProcessor
+ */
+class ToOneRelationshipProcessorTest {
+
+    ProcessingContext context;
+    javax.annotation.processing.Messager messager;
+    SchemaModel schema;
+    Map<String, EntityModel> entities;
+
+    AttributeDescriptor attr;
+    Element diagEl;
+
+    EntityModel owner;
+    EntityModel referenced;
+
+    ToOneRelationshipProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        context = mock(ProcessingContext.class);
+        messager = mock(javax.annotation.processing.Messager.class);
+        when(context.getMessager()).thenReturn(messager);
+        when(context.getNaming()).thenReturn(new DefaultNaming(63));
+
+        schema = mock(SchemaModel.class);
+        entities = new HashMap<>();
+        when(context.getSchemaModel()).thenReturn(schema);
+        when(schema.getEntities()).thenReturn(entities);
+
+        // attribute descriptor
+        attr = mock(AttributeDescriptor.class);
+        when(attr.name()).thenReturn("partner");
+        diagEl = mock(Element.class);
+        when(attr.elementForDiagnostics()).thenReturn(diagEl);
+
+        // owner/referenced entities
+        owner = EntityModel.builder()
+                .entityName("com.example.Owner")
+                .tableName("owner_tbl")
+                .build();
+
+        referenced = EntityModel.builder()
+                .entityName("com.example.Partner")
+                .tableName("partner_tbl")
+                .build();
+
+        // referenced PK (단일 PK)
+        when(context.findAllPrimaryKeyColumns(referenced)).thenReturn(List.of(
+                ColumnModel.builder()
+                        .tableName("partner_tbl").columnName("id")
+                        .javaType("Long").isPrimaryKey(true).build()
+        ));
+
+        // resolveTargetEntity 경로: attr.type() -> DeclaredType -> TypeElement(FQN)
+        DeclaredType dt = mock(DeclaredType.class);
+        TypeElement te = mock(TypeElement.class);
+        Name qn = mock(Name.class);
+        when(qn.toString()).thenReturn("com.example.Partner");
+        when(te.getQualifiedName()).thenReturn(qn);
+        when(dt.asElement()).thenReturn(te);
+        when(attr.type()).thenReturn(dt);
+
+        // 스키마에 target 등록
+        entities.put("com.example.Partner", referenced);
+
+        processor = new ToOneRelationshipProcessor(context);
+    }
+
+    // ---------- supports() ----------
+
+    @Test
+    void supports_true_for_ManyToOne() {
+        ManyToOne m2o = mock(ManyToOne.class);
+        when(attr.getAnnotation(ManyToOne.class)).thenReturn(m2o);
+        assertThat(processor.supports(attr)).isTrue();
+    }
+
+    @Test
+    void supports_true_for_OneToOne_owning() {
+        OneToOne o2o = mock(OneToOne.class);
+        when(o2o.mappedBy()).thenReturn("");
+        when(attr.getAnnotation(OneToOne.class)).thenReturn(o2o);
+        assertThat(processor.supports(attr)).isTrue();
+    }
+
+    @Test
+    void supports_false_for_OneToOne_inverse() {
+        OneToOne o2o = mock(OneToOne.class);
+        when(o2o.mappedBy()).thenReturn("owner");
+        when(attr.getAnnotation(OneToOne.class)).thenReturn(o2o);
+        assertThat(processor.supports(attr)).isFalse();
+    }
+
+    @Test
+    void supports_false_when_no_annotations() {
+        assertThat(processor.supports(attr)).isFalse();
+    }
+
+    // ---------- process(): ManyToOne happy path (no JoinColumn, single PK) ----------
+
+    @Test
+    void process_manyToOne_happyPath_default_fk_and_index_added() {
+        ManyToOne m2o = mock(ManyToOne.class);
+        when(m2o.optional()).thenReturn(true);
+        when(m2o.cascade()).thenReturn(new CascadeType[0]);
+        when(m2o.fetch()).thenReturn(FetchType.EAGER);
+        when(attr.getAnnotation(ManyToOne.class)).thenReturn(m2o);
+
+        // no explicit JoinColumn(s)
+        when(attr.getAnnotation(JoinColumns.class)).thenReturn(null);
+        when(attr.getAnnotation(JoinColumn.class)).thenReturn(null);
+
+        processor.process(attr, owner);
+
+        // FK column created on owner
+        ColumnModel fk = owner.findColumn("owner_tbl", "partner_id");
+        assertThat(fk).isNotNull();
+        assertThat(fk.getJavaType()).isEqualTo("Long");
+        assertThat(fk.isNullable()).isTrue(); // optional=true & no JoinColumn override
+
+        // Relationship added
+        assertThat(owner.getRelationships()).hasSize(1);
+        RelationshipModel rel = owner.getRelationships().values().iterator().next();
+        assertThat(rel.getType()).isEqualTo(RelationshipType.MANY_TO_ONE);
+        assertThat(rel.getTableName()).isEqualTo("owner_tbl");
+        assertThat(rel.getColumns()).containsExactly("partner_id");
+        assertThat(rel.getReferencedTable()).isEqualTo("partner_tbl");
+        assertThat(rel.getReferencedColumns()).containsExactly("id");
+        assertThat(rel.isNoConstraint()).isFalse();
+
+        // Index auto-created
+        assertThat(owner.getIndexes()).hasSize(1);
+        IndexModel ix = owner.getIndexes().values().iterator().next();
+        assertThat(ix.getTableName()).isEqualTo("owner_tbl");
+        assertThat(ix.getColumnNames()).containsExactly("partner_id");
+
+        // no errors
+        verify(messager, never()).printMessage(eq(Diagnostic.Kind.ERROR), anyString(), any());
+    }
+
+    // ---------- process(): OneToOne happy path -> UNIQUE added automatically ----------
+
+    @Test
+    void process_oneToOne_happyPath_adds_unique_when_single_fk_and_no_MapsId() {
+        OneToOne o2o = mock(OneToOne.class);
+        when(o2o.mappedBy()).thenReturn("");
+        when(o2o.optional()).thenReturn(true);
+        when(o2o.cascade()).thenReturn(new CascadeType[0]);
+        when(o2o.fetch()).thenReturn(FetchType.EAGER);
+        when(o2o.orphanRemoval()).thenReturn(false);
+        when(attr.getAnnotation(OneToOne.class)).thenReturn(o2o);
+
+        // no JoinColumn(s), no @MapsId
+        when(attr.getAnnotation(JoinColumns.class)).thenReturn(null);
+        when(attr.getAnnotation(JoinColumn.class)).thenReturn(null);
+        when(attr.getAnnotation(MapsId.class)).thenReturn(null);
+
+        processor.process(attr, owner);
+
+        // UNIQUE constraint expected
+        String uqName = new DefaultNaming(63).uqName("owner_tbl", List.of("partner_id"));
+        assertThat(owner.getConstraints()).containsKey(uqName);
+        ConstraintModel uq = owner.getConstraints().get(uqName);
+        assertThat(uq.getType()).isEqualTo(ConstraintType.UNIQUE);
+        assertThat(uq.getColumns()).containsExactly("partner_id");
+    }
+
+    // ---------- Errors: composite PK but no JoinColumns ----------
+
+    @Test
+    void process_error_when_referenced_has_composite_pk_and_no_joinColumns() {
+        // referenced composite PK 2개
+        when(context.findAllPrimaryKeyColumns(referenced)).thenReturn(List.of(
+                ColumnModel.builder().tableName("partner_tbl").columnName("a").javaType("Long").isPrimaryKey(true).build(),
+                ColumnModel.builder().tableName("partner_tbl").columnName("b").javaType("Long").isPrimaryKey(true).build()
+        ));
+
+        ManyToOne m2o = mock(ManyToOne.class);
+        when(m2o.optional()).thenReturn(true);
+        when(m2o.cascade()).thenReturn(new CascadeType[0]);
+        when(m2o.fetch()).thenReturn(FetchType.EAGER);
+        when(attr.getAnnotation(ManyToOne.class)).thenReturn(m2o);
+
+        when(attr.getAnnotation(JoinColumns.class)).thenReturn(null);
+        when(attr.getAnnotation(JoinColumn.class)).thenReturn(null);
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("Composite primary key"), eq(diagEl));
+        assertThat(owner.isValid()).isFalse();
+        assertThat(owner.getRelationships()).isEmpty();
+    }
+
+    // ---------- Errors: JoinColumns size mismatch ----------
+
+    @Test
+    void process_error_when_joinColumns_size_mismatch() {
+        // referenced composite PK 2개
+        when(context.findAllPrimaryKeyColumns(referenced)).thenReturn(List.of(
+                ColumnModel.builder().tableName("partner_tbl").columnName("a").javaType("Long").isPrimaryKey(true).build(),
+                ColumnModel.builder().tableName("partner_tbl").columnName("b").javaType("Long").isPrimaryKey(true).build()
+        ));
+
+        ManyToOne m2o = mock(ManyToOne.class);
+        when(m2o.optional()).thenReturn(true);
+        when(m2o.cascade()).thenReturn(new CascadeType[0]);
+        when(m2o.fetch()).thenReturn(FetchType.EAGER);
+        when(attr.getAnnotation(ManyToOne.class)).thenReturn(m2o);
+
+        JoinColumn onlyOne = mock(JoinColumn.class);
+        when(onlyOne.name()).thenReturn("fk_a");
+        when(onlyOne.referencedColumnName()).thenReturn("a");
+        ForeignKey fk = mock(ForeignKey.class);
+        when(fk.name()).thenReturn("");
+        when(fk.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(onlyOne.foreignKey()).thenReturn(fk);
+
+        JoinColumns jcs = mock(JoinColumns.class);
+        when(jcs.value()).thenReturn(new JoinColumn[]{onlyOne});
+        when(attr.getAnnotation(JoinColumns.class)).thenReturn(jcs);
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("@JoinColumns size mismatch"), eq(diagEl));
+        assertThat(owner.isValid()).isFalse();
+    }
+
+    // ---------- Errors: duplicate FK column name in composite ----------
+
+    @Test
+    void process_error_when_duplicate_fk_names() {
+        // referenced composite PK 2개
+        when(context.findAllPrimaryKeyColumns(referenced)).thenReturn(List.of(
+                ColumnModel.builder().tableName("partner_tbl").columnName("a").javaType("Long").isPrimaryKey(true).build(),
+                ColumnModel.builder().tableName("partner_tbl").columnName("b").javaType("Long").isPrimaryKey(true).build()
+        ));
+
+        ManyToOne m2o = mock(ManyToOne.class);
+        when(m2o.optional()).thenReturn(true);
+        when(m2o.cascade()).thenReturn(new CascadeType[0]);
+        when(m2o.fetch()).thenReturn(FetchType.EAGER);
+        when(attr.getAnnotation(ManyToOne.class)).thenReturn(m2o);
+
+        JoinColumn jc1 = mock(JoinColumn.class);
+        when(jc1.referencedColumnName()).thenReturn("a");
+        when(jc1.name()).thenReturn("dup_fk");
+        when(jc1.table()).thenReturn("");
+        ForeignKey f1 = mock(ForeignKey.class);
+        when(f1.name()).thenReturn("");
+        when(f1.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(jc1.foreignKey()).thenReturn(f1);
+
+        JoinColumn jc2 = mock(JoinColumn.class);
+        when(jc2.referencedColumnName()).thenReturn("b");
+        when(jc2.name()).thenReturn("dup_fk"); // duplicate
+        when(jc2.table()).thenReturn("");
+        ForeignKey f2 = mock(ForeignKey.class);
+        when(f2.name()).thenReturn("");
+        when(f2.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(jc2.foreignKey()).thenReturn(f2);
+
+        JoinColumns jcs = mock(JoinColumns.class);
+        when(jcs.value()).thenReturn(new JoinColumn[]{jc1, jc2});
+        when(attr.getAnnotation(JoinColumns.class)).thenReturn(jcs);
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("Duplicate foreign key column name"), eq(diagEl));
+        assertThat(owner.getRelationships()).isEmpty();
+    }
+
+    // ---------- Errors: type mismatch with existing column ----------
+
+    @Test
+    void process_error_when_existing_column_type_conflict() {
+        ManyToOne m2o = mock(ManyToOne.class);
+        when(m2o.optional()).thenReturn(true);
+        when(m2o.cascade()).thenReturn(new CascadeType[0]);
+        when(m2o.fetch()).thenReturn(FetchType.EAGER);
+        when(attr.getAnnotation(ManyToOne.class)).thenReturn(m2o);
+
+        when(attr.getAnnotation(JoinColumns.class)).thenReturn(null);
+        when(attr.getAnnotation(JoinColumn.class)).thenReturn(null);
+
+        // 기존에 같은 이름의 컬럼이 있으나 타입이 다름
+        owner.putColumn(ColumnModel.builder()
+                .tableName("owner_tbl").columnName("partner_id").javaType("String").isNullable(true).build());
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("Type mismatch for column 'partner_id'"), eq(diagEl));
+        assertThat(owner.isValid()).isFalse();
+    }
+
+    // ---------- Warning: optional=false & @JoinColumn(nullable=true) ----------
+
+    @Test
+    void process_warns_when_optional_false_but_joinColumn_nullable_true_and_forces_not_null() {
+        ManyToOne m2o = mock(ManyToOne.class);
+        when(m2o.optional()).thenReturn(false); // optional=false
+        when(m2o.cascade()).thenReturn(new CascadeType[0]);
+        when(m2o.fetch()).thenReturn(FetchType.EAGER);
+        when(attr.getAnnotation(ManyToOne.class)).thenReturn(m2o);
+
+        JoinColumn jc = mock(JoinColumn.class);
+        when(jc.referencedColumnName()).thenReturn("");
+        when(jc.name()).thenReturn(""); // will generate default name partner_id
+        when(jc.nullable()).thenReturn(true); // conflicts with optional=false
+        ForeignKey fk = mock(ForeignKey.class);
+        when(fk.name()).thenReturn("");
+        when(fk.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(jc.foreignKey()).thenReturn(fk);
+        when(jc.table()).thenReturn(""); // base table
+
+        when(attr.getAnnotation(JoinColumns.class)).thenReturn(null);
+        when(attr.getAnnotation(JoinColumn.class)).thenReturn(jc);
+
+        processor.process(attr, owner);
+
+        // warning emitted
+        verify(messager).printMessage(eq(Diagnostic.Kind.WARNING),
+                contains("conflicts with optional=false; treating as NOT NULL"), eq(diagEl));
+
+        ColumnModel fkCol = owner.findColumn("owner_tbl", "partner_id");
+        assertThat(fkCol).isNotNull();
+        assertThat(fkCol.isNullable()).isFalse(); // 강제 NOT NULL
+    }
+
+    // ---------- Errors: composite JoinColumns target different tables ----------
+
+    @Test
+    void process_error_when_composite_joinColumns_point_to_different_tables() {
+        // referenced composite PK 2개
+        when(context.findAllPrimaryKeyColumns(referenced)).thenReturn(List.of(
+                ColumnModel.builder().tableName("partner_tbl").columnName("a").javaType("Long").isPrimaryKey(true).build(),
+                ColumnModel.builder().tableName("partner_tbl").columnName("b").javaType("Long").isPrimaryKey(true).build()
+        ));
+
+        // owner 에 secondary table 하나 등록했다고 가정 (resolveJoinColumnTable 비교용)
+        owner.getSecondaryTables().add(SecondaryTableModel.builder().name("owner_sec").build());
+
+        ManyToOne m2o = mock(ManyToOne.class);
+        when(m2o.optional()).thenReturn(true);
+        when(m2o.cascade()).thenReturn(new CascadeType[0]);
+        when(m2o.fetch()).thenReturn(FetchType.EAGER);
+        when(attr.getAnnotation(ManyToOne.class)).thenReturn(m2o);
+
+        JoinColumn jc1 = mock(JoinColumn.class);
+        when(jc1.referencedColumnName()).thenReturn("a");
+        when(jc1.name()).thenReturn("fk_a");
+        when(jc1.table()).thenReturn(""); // resolves to owner_tbl
+        when(jc1.nullable()).thenReturn(true);
+        ForeignKey f1 = mock(ForeignKey.class);
+        when(f1.name()).thenReturn("");
+        when(f1.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(jc1.foreignKey()).thenReturn(f1);
+
+        JoinColumn jc2 = mock(JoinColumn.class);
+        when(jc2.referencedColumnName()).thenReturn("b");
+        when(jc2.name()).thenReturn("fk_b");
+        when(jc2.table()).thenReturn("owner_sec"); // resolves to secondary
+        when(jc2.nullable()).thenReturn(true);
+        ForeignKey f2 = mock(ForeignKey.class);
+        when(f2.name()).thenReturn("");
+        when(f2.value()).thenReturn(ConstraintMode.CONSTRAINT);
+        when(jc2.foreignKey()).thenReturn(f2);
+
+        JoinColumns jcs = mock(JoinColumns.class);
+        when(jcs.value()).thenReturn(new JoinColumn[]{jc1, jc2});
+        when(attr.getAnnotation(JoinColumns.class)).thenReturn(jcs);
+
+        processor.process(attr, owner);
+
+        verify(messager).printMessage(eq(Diagnostic.Kind.ERROR),
+                contains("must target the same table"), eq(diagEl));
+        assertThat(owner.isValid()).isFalse();
+    }
+
+    // ---------- NO_CONSTRAINT propagates ----------
+
+    @Test
+    void process_sets_noConstraint_when_foreignKey_value_is_NO_CONSTRAINT() {
+        ManyToOne m2o = mock(ManyToOne.class);
+        when(m2o.optional()).thenReturn(true);
+        when(m2o.cascade()).thenReturn(new CascadeType[0]);
+        when(m2o.fetch()).thenReturn(FetchType.EAGER);
+        when(attr.getAnnotation(ManyToOne.class)).thenReturn(m2o);
+
+        JoinColumn jc = mock(JoinColumn.class);
+        when(jc.referencedColumnName()).thenReturn("");
+        when(jc.name()).thenReturn("");
+        when(jc.nullable()).thenReturn(true);
+        when(jc.table()).thenReturn("");
+
+        ForeignKey fk = mock(ForeignKey.class);
+        when(fk.name()).thenReturn("");
+        when(fk.value()).thenReturn(ConstraintMode.NO_CONSTRAINT);
+        when(jc.foreignKey()).thenReturn(fk);
+
+        when(attr.getAnnotation(JoinColumns.class)).thenReturn(null);
+        when(attr.getAnnotation(JoinColumn.class)).thenReturn(jc);
+
+        processor.process(attr, owner);
+
+        RelationshipModel rel = owner.getRelationships().values().iterator().next();
+        assertThat(rel.isNoConstraint()).isTrue();
+    }
+}


### PR DESCRIPTION
Relationship 관련 전용 프로세서들의 정상/에러/경고 플로우를 폭넓게 검증하는 단위 테스트를 추가했습니다. FK/JoinTable 전략 및 Unique/Index 부작용까지 포함하여 스키마 모델 변화(컬럼/제약/인덱스/관계)를 엔드투엔드로 확인합니다. `@JoinTable` 모킹 시 `jt.name()` 스텁을 명시적으로 추가해 네이밍 경로도 안정적으로 커버했습니다.

## 주요 변경 사항

### 신규 테스트

- **`ToOneRelationshipProcessorTest`**
    - `supports()` 분기: `@ManyToOne`, `@OneToOne(owning)`, inverse 등
    - 해피패스
        - ManyToOne: 기본 FK 생성, Index 자동 생성, 관계 모델 검증
        - OneToOne: 단일 FK & `@MapsId` 미사용 시 UNIQUE 자동 부여
    - 에러/경고 플로우
        - 참조 엔티티 복합 PK인데 `@JoinColumns` 누락
        - `@JoinColumns` 크기 불일치
        - FK 이름 중복
        - 기존 컬럼 타입 충돌
        - `optional=false` + `@JoinColumn(nullable=true)` 경고 및 NOT NULL 강제
        - 복합 `@JoinColumns`가 서로 다른 테이블을 가리키는 경우
        - `@ForeignKey(NO_CONSTRAINT)` 전달 확인
- **`OneToManyOwningJoinTableProcessorTest`**
    - `supports()` 조합: JoinColumn/JoinTable 유무에 따른 분기
    - 해피패스
        - JoinTable 미지정(기본 네이밍)
        - JoinTable/JoinColumns 명시(1:1)
    - 에러 플로우
        - 컬렉션 아님 / 제네릭 타입 확인 실패
        - owner/target PK 미존재
        - `joinColumns`/`inverseJoinColumns` 카운트 불일치
        - 복합 PK에서 `referencedColumnName` 누락
        - `foreignKey.value` 불일치
        - 양측 FK 이름 충돌
        - JoinTable 이름 충돌/기존 테이블 타입 불일치/기존 FK 컬럼셋 불일치 시 중단
    - 부수효과 검증: FK 컬럼/관계/인덱스/UNIQUE 추가 경로
- **`ManyToManyOwningProcessorTest`**
    - 해피패스(기본/명시적 JoinTable & JoinColumns)
    - 카운트 불일치/이름 충돌/ConstraintMode 불일치
    - 기존 JoinTable 재사용 시 유효성 검증 및 보강 경로
    - `@JoinTable.uniqueConstraints` 처리 확인
        
        *(해당 파일을 함께 올렸다면 본 PR에 포함됩니다. 누락 시 후속 PR로 분리 가능)*

## 커버리지

- JaCoCo 기준으로 relationship 프로세서 라인/브랜치 커버리지가 전체적으로 상승합니다.
    
    (정확 수치는 CI 리포트 참고—본 PR 머지 시 대시보드에서 확인 가능)
    

## 호환성 / 리스크

- 테스트 코드만 추가/보강입니다. 런타임 동작 변경 없음.
- 기존 테스트와 충돌하지 않도록 독립적인 픽스처/모킹 사용.


## 체크리스트

- [x]  정상/오류/경고 케이스 포함
- [x]  UNIQUE/INDEX/관계 생성 등 부작용 검증
- [x]  `@JoinTable.name()` 모킹 보강
- [x]  Mockito 매처 혼용 오류 제거
- [x]  로컬/CI 테스트 통과