### PR TITLE
maven repository 배포 설정 추가 & 모델 역직렬화 이슈 해결

### DIFF
--- a/jinx-cli/build.gradle
+++ b/jinx-cli/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'application'
     id 'maven-publish'
     id 'signing'
+    id("io.github.sgtsilvio.gradle.maven-central-publishing") version "0.4.1"
 }
 
 dependencies {
@@ -59,10 +60,10 @@ publishing {
     }
 }
 
-if (System.getenv('SIGNING_KEY') != null) {
+if (project.findProperty("signingKey") != null) {
     signing {
-        def key = System.getenv('SIGNING_KEY')
-        def pass = System.getenv('SIGNING_PASSWORD')
+        def key = project.findProperty("signingKey") ?: System.getenv('ORG_GRADLE_PROJECT_signingKey')
+        def pass = project.findProperty("signingPassword") ?: System.getenv('ORG_GRADLE_PROJECT_signingPassword')
         useInMemoryPgpKeys(key, pass)
         sign publishing.publications.mavenJava
     }

--- a/jinx-core/build.gradle
+++ b/jinx-core/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java-library'
     id 'maven-publish'
     id 'signing'
+    id("io.github.sgtsilvio.gradle.maven-central-publishing") version "0.4.1"
 }
 
 group = 'io.github.yyubin'
@@ -55,10 +56,10 @@ publishing {
     }
 }
 
-if (System.getenv('SIGNING_KEY') != null) {
+if (project.findProperty("signingKey") != null) {
     signing {
-        def key = System.getenv('SIGNING_KEY')
-        def pass = System.getenv('SIGNING_PASSWORD')
+        def key = project.findProperty("signingKey") ?: System.getenv('ORG_GRADLE_PROJECT_signingKey')
+        def pass = project.findProperty("signingPassword") ?: System.getenv('ORG_GRADLE_PROJECT_signingPassword')
         useInMemoryPgpKeys(key, pass)
         sign publishing.publications.mavenJava
     }

--- a/jinx-core/src/main/java/org/jinx/model/ConstraintModel.java
+++ b/jinx-core/src/main/java/org/jinx/model/ConstraintModel.java
@@ -1,7 +1,9 @@
 package org.jinx.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -10,6 +12,8 @@ import java.util.Optional;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ConstraintModel {
     private String name;
     private String schema;

--- a/jinx-core/src/main/java/org/jinx/model/IndexModel.java
+++ b/jinx-core/src/main/java/org/jinx/model/IndexModel.java
@@ -1,12 +1,18 @@
 package org.jinx.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class IndexModel {
     private String indexName;
     private String tableName;

--- a/jinx-core/src/main/java/org/jinx/model/RelationshipModel.java
+++ b/jinx-core/src/main/java/org/jinx/model/RelationshipModel.java
@@ -2,8 +2,10 @@ package org.jinx.model;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.FetchType;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.jinx.model.naming.CaseNormalizer;
 
 import java.util.ArrayList;
@@ -15,6 +17,8 @@ import java.util.stream.Collectors;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class RelationshipModel {
     private RelationshipType type;
     private String tableName; // Added for FK constraint table (where FK is created)

--- a/jinx-core/src/main/java/org/jinx/model/SequenceModel.java
+++ b/jinx-core/src/main/java/org/jinx/model/SequenceModel.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
 public class SequenceModel {
     private String name;
     @Builder.Default private String schema = null;

--- a/jinx-core/src/main/java/org/jinx/model/TableGeneratorModel.java
+++ b/jinx-core/src/main/java/org/jinx/model/TableGeneratorModel.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
 public class TableGeneratorModel {
     private String name;
     private String table;

--- a/jinx-gradle-plugin/build.gradle
+++ b/jinx-gradle-plugin/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java-gradle-plugin'
     id 'maven-publish'
     id 'signing'
+    id("io.github.sgtsilvio.gradle.maven-central-publishing") version "0.4.1"
 }
 
 dependencies {
@@ -21,7 +22,7 @@ dependencies {
 gradlePlugin {
     plugins {
         jinx {
-            id = 'org.jinx.gradle'
+            id = 'io.github.yyubin.jinx'
             implementationClass = 'org.jinx.gradle.JinxPlugin'
             displayName = 'Jinx Gradle Plugin'
             description = 'Gradle plugin for Jinx JPA DDL generation tool'
@@ -67,15 +68,50 @@ afterEvaluate {
                     }
                 }
             }
+
+            // 플러그인 마커에도 메타데이터 추가
+            all { pub ->
+                if (pub.name.contains('PluginMarkerMaven')) {
+                    pub.pom {
+                        name = 'Jinx Gradle Plugin Marker'
+                        description = 'Gradle plugin marker for Jinx JPA DDL generation tool'
+                        url = 'https://github.com/yyubin/jinx'
+                        licenses {
+                            license {
+                                name = 'The Apache License, Version 2.0'
+                                url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                            }
+                        }
+                        developers {
+                            developer {
+                                id = 'yyubin'
+                                name = 'Yubin'
+                                email = 'yyubin@gmail.com'
+                            }
+                        }
+                        scm {
+                            connection = 'scm:git:git://github.com/yyubin/jinx.git'
+                            developerConnection = 'scm:git:ssh://github.com/yyubin/jinx.git'
+                            url = 'https://github.com/yyubin/jinx'
+                        }
+                    }
+                }
+            }
         }
     }
 
-    if (System.getenv('SIGNING_KEY') != null) {
+    if (project.findProperty("signingKey") != null) {
         signing {
-            def key = System.getenv('SIGNING_KEY')
-            def pass = System.getenv('SIGNING_PASSWORD')
+            def key = project.findProperty("signingKey") ?: System.getenv('ORG_GRADLE_PROJECT_signingKey')
+            def pass = project.findProperty("signingPassword") ?: System.getenv('ORG_GRADLE_PROJECT_signingPassword')
             useInMemoryPgpKeys(key, pass)
             sign publishing.publications.pluginMaven
+            // 플러그인 마커도 서명
+            publishing.publications.all { pub ->
+                if (pub.name.contains('PluginMarkerMaven')) {
+                    sign pub
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
### 상황
Jackson이 IndexModel을 역직렬화할 때 기본 생성자(또는 @JsonCreator)가 없어서 `jinx migrate` 커맨드 입력시 문제 발생.

### 해결
model 쪽 클래스들을 Jackson 친화적으로 변경

추후 불변 모델을 유지하겠다 하면, @JsonCreator + @JsonProperty로 생성자 바인딩 고려 가능.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Maven Central 게시 지원 추가로 배포 용이성 향상.
  - 모델에 기본/전체 생성자 및 알 수 없는 JSON 필드 무시 처리 추가로 직렬화/역직렬화 호환성 개선.
- Chores
  - 서명 설정이 환경 변수 기반에서 Gradle 속성 기반으로 전환되어 CI/로컬 구성 일관성 향상.
  - Gradle 플러그인 게시 메타데이터(라이선스, 개발자, SCM) 보강 및 플러그인 마커 아티팩트 서명 추가.
  - 게시 플러그인 ID가 io.github.yyubin.jinx로 변경됨(기존 빌드 스크립트는 새 ID로 업데이트 필요).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->