### PR TITLE
fix(model): columnKey 도입 이후 맵 정렬에서 비교 가능하도록 `comparable` 도입

### DIFF
--- a/jinx-core/src/main/java/org/jinx/model/ColumnKey.java
+++ b/jinx-core/src/main/java/org/jinx/model/ColumnKey.java
@@ -14,7 +14,7 @@ import java.util.Objects;
  * - canonical: DB별 대소문자 정규화 규칙을 적용한 비교/Map 키 용도
  * - display: 원본 대소문자를 보존한 표시/로그 용도
  */
-public final class ColumnKey {
+public final class ColumnKey implements Comparable<ColumnKey> {
     private static final String DELIMITER = "::";
     
     private final String canonical;  // 정규화된 키 (DB 비교용)
@@ -106,5 +106,19 @@ public final class ColumnKey {
     @Override
     public String toString() {
         return display;
+    }
+
+    @Override
+    public int compareTo(ColumnKey other) {
+        if (other == null) {
+            return 1; // null보다 항상 크게
+        }
+        // canonical 우선 비교
+        int cmp = this.canonical.compareTo(other.canonical);
+        if (cmp != 0) {
+            return cmp;
+        }
+        // canonical이 같으면 display로 tie-break
+        return this.display.compareTo(other.display);
     }
 }

--- a/jinx-core/src/main/java/org/jinx/model/ColumnKey.java
+++ b/jinx-core/src/main/java/org/jinx/model/ColumnKey.java
@@ -109,16 +109,8 @@ public final class ColumnKey implements Comparable<ColumnKey> {
     }
 
     @Override
-    public int compareTo(ColumnKey other) {
-        if (other == null) {
-            return 1; // null보다 항상 크게
-        }
-        // canonical 우선 비교
-        int cmp = this.canonical.compareTo(other.canonical);
-        if (cmp != 0) {
-            return cmp;
-        }
-        // canonical이 같으면 display로 tie-break
-        return this.display.compareTo(other.display);
+    public int compareTo(ColumnKey o) {
+        if (o == null) return 1;
+        return this.canonical.compareTo(o.canonical);
     }
 }


### PR DESCRIPTION
### 발생 이슈
EntityModel.columns가 TreeMap<ColumnKey, ColumnModel> 인데, ColumnKey가 Comparable이 아니고 TreeMap에도 Comparator를 안 줬습니다. 그런데 Jackson이 ORDER_MAP_ENTRIES_BY_KEYS(키 정렬) 옵션 때문에 Map을 정렬하려다, 비교 불가 키라서 FAIL_ON_ORDER_MAP_BY_INCOMPARABLE_KEYS 예외 발생

### 주요 변경점
- 결정적(Deterministic) 정렬을 보장하는 Comparable 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 컬럼 키에 자연스러운 기본 순서를 도입하여 컬럼 관련 목록·테이블·설정 화면에서 정렬이 일관되고 예측 가능하게 표시됩니다.
  * 동일한 기준값일 경우 표시 이름을 활용해 안정적으로 순서가 결정됩니다.
* 리팩터링
  * 내부 정렬 동작을 명확히 해 향후 정렬 일관성과 사용자 경험을 향상했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->