### PR TITLE
MySqlMigrationVisitor getGeneratedSql 오버라이드 제거 및 NPE 방지 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'io.github.yyubin'
-version = '0.0.2'
+version = '0.0.5'
 
 
 allprojects {

--- a/jinx-core/build.gradle
+++ b/jinx-core/build.gradle
@@ -6,7 +6,6 @@ plugins {
 }
 
 group = 'io.github.yyubin'
-version = '0.0.4'
 
 repositories { mavenCentral() }
 

--- a/jinx-core/src/main/java/org/jinx/migration/dialect/mysql/MySqlMigrationVisitor.java
+++ b/jinx-core/src/main/java/org/jinx/migration/dialect/mysql/MySqlMigrationVisitor.java
@@ -132,13 +132,4 @@ public class MySqlMigrationVisitor extends AbstractMigrationVisitor implements
     public void visitModifiedRelationship(RelationshipModel newRelationship, RelationshipModel oldRelationship) {
         alterBuilder.add(new RelationshipModifyContributor(alterBuilder.getTableName(), newRelationship, oldRelationship));
     }
-
-    @Override
-    public String getGeneratedSql() {
-        String alterSql = alterBuilder.build();
-        if (!alterSql.isEmpty()) {
-            sql.add(alterSql);
-        }
-        return sql.toString();
-    }
 }

--- a/jinx-core/src/test/java/org/jinx/migration/dialect/mysql/MySqlMigrationVisitorTest.java
+++ b/jinx-core/src/test/java/org/jinx/migration/dialect/mysql/MySqlMigrationVisitorTest.java
@@ -278,4 +278,31 @@ class MySqlMigrationVisitorTest {
                 PrimaryKeyAddContributor.class.getSimpleName()
         ), sql);
     }
+
+    @Test
+    void getGeneratedSql_diffNull_returnsEmptyAndNoNpe() {
+        DdlDialect dialect = mock(DdlDialect.class);
+        MySqlMigrationVisitor visitor = new MySqlMigrationVisitor(null, dialect);
+        assertDoesNotThrow(() -> {
+            String sql = visitor.getGeneratedSql();
+            assertEquals("", sql);
+        });
+    }
+
+    @Test
+    void getGeneratedSql_diffPresentButNoAlter_noNpeAndEmptyAlter() {
+        DdlDialect dialect = mock(DdlDialect.class);
+
+        EntityModel newEntity = EntityModel.builder().tableName("animals").build();
+        DiffResult.ModifiedEntity diff = DiffResult.ModifiedEntity.builder()
+                .newEntity(newEntity)
+                .build();
+
+        MySqlMigrationVisitor visitor = new MySqlMigrationVisitor(diff, dialect);
+
+        assertDoesNotThrow(() -> {
+            String sql = visitor.getGeneratedSql();
+            assertEquals("", sql);
+        });
+    }
 }


### PR DESCRIPTION
## 개요
MySqlMigrationVisitor에서 getGeneratedSql() 오버라이드 구현이 diff == null 시 NPE를 유발하던 문제를 수정했습니다. 
오버라이드를 제거하고 AbstractMigrationVisitor의 기본 구현을 사용하도록 변경했으며, 관련 동작을 검증하는 테스트를 추가했습니다.

## 변경 사항
- MySqlMigrationVisitor#getGeneratedSql 오버라이드 제거
- diff == null 경로에서 NPE 발생하지 않도록 수정
- 테스트 코드 추가
  - diff == null → getGeneratedSql() 안전 호출 검증
  - diff != null이지만 ALTER 없는 경우에도 안전하게 동작하는지 확인

## 기대 효과
- diff 유무와 관계없이 안정적으로 getGeneratedSql() 호출 가능
- CREATE/DROP-only 시나리오에서도 NPE 회귀 방지
- 테스트로 문제 재발 가능성 최소화
