### PR TITLE
Embeddable record**Support `record` as `@Embeddable` attribute: RecordAttributeDescriptor + Factory integration (APT-only)**

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,11 @@ plugins {
 group = 'io.github.yyubin'
 version = '0.0.7'
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
 
 allprojects {
     repositories { mavenCentral() }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,10 @@
+# Build configuration
+org.gradle.java.home=/Users/mac/Library/Java/JavaVirtualMachines/graalvm-jdk-21.0.8/Contents/Home
+org.gradle.warning.mode=all
+org.gradle.parallel=true
+org.gradle.caching=true
+
+# Publishing metadata
 pomName=Jinx
 pomDescription=JPA DDL generation & Gradle plugin
 pomUrl=https://github.com/yyubin/jinx

--- a/jinx-cli/build.gradle
+++ b/jinx-cli/build.gradle
@@ -6,6 +6,13 @@ plugins {
     id("io.github.sgtsilvio.gradle.maven-central-publishing") version "0.4.1"
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+
 dependencies {
     implementation project(':jinx-core')
 

--- a/jinx-processor/src/main/java/org/jinx/descriptor/AttributeDescriptor.java
+++ b/jinx-processor/src/main/java/org/jinx/descriptor/AttributeDescriptor.java
@@ -17,8 +17,8 @@ public interface AttributeDescriptor {
     boolean hasAnnotation(Class<? extends Annotation> ann);
 
     Element elementForDiagnostics();        // 에러 표시 위치
-    AccessKind accessKind();                // FIELD or PROPERTY
-    enum AccessKind { FIELD, PROPERTY }
+    AccessKind accessKind();                // FIELD, PROPERTY, or RECORD_COMPONENT
+    enum AccessKind { FIELD, PROPERTY, RECORD_COMPONENT }
 
     // Optional helpers for mirror-based lookup (no Class loading)
     default Optional<AnnotationMirror> findAnnotationMirror(String fqcn) {

--- a/jinx-processor/src/main/java/org/jinx/descriptor/RecordAttributeDescriptor.java
+++ b/jinx-processor/src/main/java/org/jinx/descriptor/RecordAttributeDescriptor.java
@@ -1,0 +1,83 @@
+package org.jinx.descriptor;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
+import javax.lang.model.type.WildcardType;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Optional;
+
+public record RecordAttributeDescriptor(VariableElement recordComponent, Types typeUtils, Elements elements) implements AttributeDescriptor {
+
+    @Override
+    public String name() {
+        return recordComponent.getSimpleName().toString();
+    }
+
+    @Override
+    public TypeMirror type() {
+        return recordComponent.asType();
+    }
+
+    @Override
+    public boolean isCollection() {
+        TypeMirror type = recordComponent.asType();
+        if (!(type instanceof DeclaredType declaredType)) {
+            return false;
+        }
+        TypeElement collTe = elements.getTypeElement("java.util.Collection");
+        if (collTe == null) return false;
+
+        TypeMirror lhs = typeUtils.erasure(declaredType);
+        TypeMirror rhs = typeUtils.erasure(collTe.asType());
+        return typeUtils.isAssignable(lhs, rhs);
+    }
+
+    @Override
+    public Optional<DeclaredType> genericArg(int idx) {
+        TypeMirror type = recordComponent.asType();
+        if (!(type instanceof DeclaredType declaredType)) return Optional.empty();
+        List<? extends TypeMirror> typeArgs = declaredType.getTypeArguments();
+        if (typeArgs == null || typeArgs.size() <= idx) return Optional.empty();
+
+        TypeMirror arg = typeArgs.get(idx);
+        if (arg instanceof WildcardType wt) {
+            if (wt.getExtendsBound() != null) {
+                TypeMirror bound = wt.getExtendsBound();
+                return (bound instanceof DeclaredType bdt) ? Optional.of(bdt) : Optional.empty();
+            }
+            return Optional.empty();
+        }
+        if (arg instanceof TypeVariable tv) {
+            TypeMirror upper = tv.getUpperBound();
+            return (upper instanceof DeclaredType bdt) ? Optional.of(bdt) : Optional.empty();
+        }
+        return (arg instanceof DeclaredType adt) ? Optional.of(adt) : Optional.empty();
+    }
+
+    @Override
+    public <A extends Annotation> A getAnnotation(Class<A> ann) {
+        return recordComponent.getAnnotation(ann);
+    }
+
+    @Override
+    public boolean hasAnnotation(Class<? extends Annotation> ann) {
+        return recordComponent.getAnnotation(ann) != null;
+    }
+
+    @Override
+    public Element elementForDiagnostics() {
+        return recordComponent;
+    }
+
+    @Override
+    public AccessKind accessKind() {
+        return AccessKind.RECORD_COMPONENT;
+    }
+}

--- a/jinx-processor/src/main/java/org/jinx/processor/JpaSqlGeneratorProcessor.java
+++ b/jinx-processor/src/main/java/org/jinx/processor/JpaSqlGeneratorProcessor.java
@@ -111,7 +111,7 @@ public class JpaSqlGeneratorProcessor extends AbstractProcessor {
             }
         }
         for (Element element : roundEnv.getElementsAnnotatedWith(Embeddable.class)) {
-            if (element.getKind() == ElementKind.CLASS) {
+            if (element.getKind() == ElementKind.CLASS || element.getKind() == ElementKind.RECORD) {
                 TypeElement typeElement = (TypeElement) element;
                 String qualifiedName = typeElement.getQualifiedName().toString();
 

--- a/jinx-processor/src/test/resources/entities/Address.java
+++ b/jinx-processor/src/test/resources/entities/Address.java
@@ -1,0 +1,16 @@
+package entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record Address(
+    @Column(name = "street_name")
+    String street,
+
+    String city,
+
+    @Column(length = 10)
+    String zipCode
+) {
+}

--- a/jinx-processor/src/test/resources/entities/Employee.java
+++ b/jinx-processor/src/test/resources/entities/Employee.java
@@ -1,0 +1,42 @@
+package entities;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "employees")
+public class Employee {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    private PersonName name;
+
+    @Embedded
+    @AttributeOverrides({
+        @AttributeOverride(name = "street", column = @Column(name = "home_street")),
+        @AttributeOverride(name = "city", column = @Column(name = "home_city"))
+    })
+    private Address homeAddress;
+
+    @Embedded
+    @AttributeOverrides({
+        @AttributeOverride(name = "street", column = @Column(name = "work_street")),
+        @AttributeOverride(name = "city", column = @Column(name = "work_city"))
+    })
+    private Address workAddress;
+
+    // Getters and setters
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public PersonName getName() { return name; }
+    public void setName(PersonName name) { this.name = name; }
+
+    public Address getHomeAddress() { return homeAddress; }
+    public void setHomeAddress(Address homeAddress) { this.homeAddress = homeAddress; }
+
+    public Address getWorkAddress() { return workAddress; }
+    public void setWorkAddress(Address workAddress) { this.workAddress = workAddress; }
+}

--- a/jinx-processor/src/test/resources/entities/OrderIdRecord.java
+++ b/jinx-processor/src/test/resources/entities/OrderIdRecord.java
@@ -1,0 +1,14 @@
+package entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record OrderIdRecord(
+    @Column(name = "customer_id")
+    Long customerId,
+
+    @Column(name = "order_number")
+    String orderNumber
+) {
+}

--- a/jinx-processor/src/test/resources/entities/OrderRecord.java
+++ b/jinx-processor/src/test/resources/entities/OrderRecord.java
@@ -1,0 +1,35 @@
+package entities;
+
+import jakarta.persistence.*;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "order_records")
+public class OrderRecord {
+
+    @EmbeddedId
+    private OrderIdRecord id;
+
+    @Column(name = "total_amount")
+    private BigDecimal totalAmount;
+
+    @Column(name = "order_date")
+    private LocalDateTime orderDate;
+
+    @Embedded
+    private Address deliveryAddress;
+
+    // Getters and setters
+    public OrderIdRecord getId() { return id; }
+    public void setId(OrderIdRecord id) { this.id = id; }
+
+    public BigDecimal getTotalAmount() { return totalAmount; }
+    public void setTotalAmount(BigDecimal totalAmount) { this.totalAmount = totalAmount; }
+
+    public LocalDateTime getOrderDate() { return orderDate; }
+    public void setOrderDate(LocalDateTime orderDate) { this.orderDate = orderDate; }
+
+    public Address getDeliveryAddress() { return deliveryAddress; }
+    public void setDeliveryAddress(Address deliveryAddress) { this.deliveryAddress = deliveryAddress; }
+}

--- a/jinx-processor/src/test/resources/entities/PersonName.java
+++ b/jinx-processor/src/test/resources/entities/PersonName.java
@@ -1,0 +1,13 @@
+package entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record PersonName(
+    @Column(nullable = false)
+    String firstName,
+
+    String lastName
+) {
+}


### PR DESCRIPTION
### 배경

JPA 3.2 스펙에 맞춰 `record` 기반 `@Embeddable`/`@EmbeddedId`를 지원하려면 컴파일 타임(Annotation Processing)에서 **record component**를 속성으로 인식해야 합니다. 기존 구현은 `ElementKind.FIELD/METHOD` 중심이라 `record`를 완전히 커버하지 못했습니다.

### 핵심 변경 사항

1. **RecordAttributeDescriptor** 추가
    - `VariableElement`(RECORD_COMPONENT) 기반 속성 기술자
    - `isCollection()`은 `Types#isAssignable(erasure(T), erasure(Collection))`로 판정
    - `genericArg(int)`는 `DeclaredType/WildcardType/TypeVariable` 상한을 안전히 해석
    - `accessKind() = RECORD_COMPONENT`
2. **AttributeDescriptorFactory** 확장
    - 계층 순회 중 `ElementKind.RECORD_COMPONENT` 수집
    - **우선순위**: `recordComponent` > `@Access` 명시(field/property) > 매핑 애노테이션 위치 > 기본 접근 방식
    - getter 유효성 검증 강화: 파라미터 금지, void 금지, `getXxx`/`isXxx` 규칙, Boolean 반환 타당성, `getClass()` 배제
    - `static`, `transient`, `@Transient` 제외 로직 유지
3. **AttributeDescriptor 헬퍼**
    - `findAnnotationMirror(String fqcn)`, `hasAnnotation(String fqcn)` 추가로 **클래스 로딩 없이** 애노테이션 검색 가능

### 비호환성

- 없음. 기존 클래스 기반 엔티티/임베더블 동작 유지. 리플렉션 도입 없음(컴파일 타임 전용).

### 테스트 계획 (후속 PR 또는 본 PR에 포함 가능)

- [ ]  단순 record `@Embeddable`
- [ ]  중첩 record `@Embeddable`
- [ ]  `@AttributeOverride`/`@AssociationOverride` on record component
- [ ]  `@EmbeddedId`로 record 사용
- [ ]  관계형 매핑과 조합(컬렉션, 연관관계, `ElementCollection`)
- [ ]  getter/field/record 혼합 시 충돌 진단 메시지 검증
- [ ]  `compile-testing` 기반 스냅샷/진단 검증

### 성능/설계 노트

- APT 단계에서 `Types/Elements`만 사용하여 **리플렉션 비용 및 JPMS 이슈 회피**
- record component 조회 캐싱은 후속 단계에서 도입 가능(현재는 코드 단순성 우선)
- 제네릭 인수 해석 시 와일드카드/타입변수 상한 처리로 ORM 추론 안정성 개선

### 마이그레이션 가이드 (요약)

- 기존 클래스 기반 `@Embeddable`은 변경 불필요
- record 사용 예:
    
    ```java
    @Embeddable
    public record Address(@Column(name = "street_name") String street,
                          String city,
                          @Column(length = 10) String zipCode) {}
    
    ```
    
- `@AttributeOverride`는 필드명 대신 **record component명** 기준으로 적용

### 리스크 & 완화

- 접근 우선순위 변경으로 모호성 케이스에서 에러 메시지가 새로 보일 수 있음 → 진단 메시지 명확화로 문제 지점 안내
- 다양한 조합 케이스를 테스트 시나리오에 포함하여 회귀 방지