### PR TITLE
Fix: Primitive & Enum SQL Type Mapping (MySQL)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'io.github.yyubin'
-version = '0.0.7'
+version = '0.0.8'
 
 java {
     toolchain {

--- a/jinx-core/src/main/java/org/jinx/migration/dialect/mysql/MySqlDialect.java
+++ b/jinx-core/src/main/java/org/jinx/migration/dialect/mysql/MySqlDialect.java
@@ -196,6 +196,9 @@ public class MySqlDialect extends AbstractDialect
                 case TIMESTAMP -> sqlType = "DATETIME";
                 default -> sqlType = javaTypeMapped.getSqlType(c.getLength(), c.getPrecision(), c.getScale());
             }
+        } else if (c.getEnumValues() != null && c.getEnumValues().length > 0) {
+            // Handle Enum types (same logic as getLiquibaseTypeName)
+            sqlType = c.isEnumStringMapping() ? "VARCHAR(" + c.getLength() + ")" : "INT";
         } else {
             sqlType = javaTypeMapped.getSqlType(c.getLength(), c.getPrecision(), c.getScale());
         }

--- a/jinx-core/src/main/java/org/jinx/migration/dialect/mysql/MySqlJavaTypeMapper.java
+++ b/jinx-core/src/main/java/org/jinx/migration/dialect/mysql/MySqlJavaTypeMapper.java
@@ -59,6 +59,7 @@ public class MySqlJavaTypeMapper implements JavaTypeMapper {
     );
 
     private static final Map<String, MysqlJavaType> TYPE_MAP = Map.ofEntries(
+            // Boxed types
             entry("java.lang.Integer", new MysqlJavaType("java.lang.Integer", new SqlType("INT", false, false), false, null)),
             entry("java.lang.Long", new MysqlJavaType("java.lang.Long", new SqlType("BIGINT", false, false), false, null)),
             entry("java.lang.String", new MysqlJavaType("java.lang.String", new SqlType("VARCHAR(%d)", true, false), true, null)),
@@ -68,7 +69,16 @@ public class MySqlJavaTypeMapper implements JavaTypeMapper {
             entry("java.lang.Boolean", new MysqlJavaType("java.lang.Boolean", new SqlType("TINYINT(1)", false, false), false, "0")),
             entry("java.time.LocalDate", new MysqlJavaType("java.time.LocalDate", new SqlType("DATE", false, false), true, null)),
             entry("java.time.LocalDateTime", new MysqlJavaType("java.time.LocalDateTime", new SqlType("TIMESTAMP(6)", false, false), true, null)),
-            entry("java.math.BigInteger", new MysqlJavaType("java.math.BigInteger", new SqlType("BIGINT", false, false), false, null))
+            entry("java.math.BigInteger", new MysqlJavaType("java.math.BigInteger", new SqlType("BIGINT", false, false), false, null)),
+            // Primitive types
+            entry("int", new MysqlJavaType("int", new SqlType("INT", false, false), false, null)),
+            entry("long", new MysqlJavaType("long", new SqlType("BIGINT", false, false), false, null)),
+            entry("double", new MysqlJavaType("double", new SqlType("DOUBLE", false, false), false, null)),
+            entry("float", new MysqlJavaType("float", new SqlType("FLOAT", false, false), false, null)),
+            entry("boolean", new MysqlJavaType("boolean", new SqlType("TINYINT(1)", false, false), false, "0")),
+            entry("byte", new MysqlJavaType("byte", new SqlType("TINYINT", false, false), false, null)),
+            entry("short", new MysqlJavaType("short", new SqlType("SMALLINT", false, false), false, null)),
+            entry("char", new MysqlJavaType("char", new SqlType("CHAR(1)", false, false), true, null))
     );
 
     @Override

--- a/jinx-core/src/test/java/org/jinx/migration/dialect/mysql/MySqlDialectTest.java
+++ b/jinx-core/src/test/java/org/jinx/migration/dialect/mysql/MySqlDialectTest.java
@@ -299,6 +299,62 @@ class MySqlDialectTest {
         assertEquals("DROP TABLE IF EXISTS `seq_table`;\n", d.getDropTableGeneratorSql(tg));
     }
 
+    @Test
+    @DisplayName("Enum 타입 처리: EnumType.STRING → VARCHAR(length)")
+    void enumStringMapping() {
+        MySqlDialect d = newDialect();
+
+        ColumnModel enumCol = mock(ColumnModel.class);
+        when(enumCol.getColumnName()).thenReturn("status");
+        when(enumCol.getJavaType()).thenReturn("com.example.Status");
+        when(enumCol.getEnumValues()).thenReturn(new String[]{"ACTIVE", "INACTIVE", "PENDING"});
+        when(enumCol.isEnumStringMapping()).thenReturn(true);
+        when(enumCol.getLength()).thenReturn(20);
+        when(enumCol.getPrecision()).thenReturn(0);
+        when(enumCol.getScale()).thenReturn(0);
+        when(enumCol.isNullable()).thenReturn(false);
+        when(enumCol.getDefaultValue()).thenReturn(null);
+        when(enumCol.getGenerationStrategy()).thenReturn(GenerationStrategy.NONE);
+        when(enumCol.isManualPrimaryKey()).thenReturn(false);
+        when(enumCol.isLob()).thenReturn(false);
+        when(enumCol.getConversionClass()).thenReturn(null);
+        when(enumCol.getSqlTypeOverride()).thenReturn(null);
+        when(enumCol.isVersion()).thenReturn(false);
+        when(enumCol.getTemporalType()).thenReturn(null);
+
+        String def = d.getColumnDefinitionSql(enumCol);
+        assertTrue(def.contains("VARCHAR(20)"), "Expected VARCHAR(20) but got: " + def);
+        assertTrue(def.contains("NOT NULL"), "Expected NOT NULL but got: " + def);
+    }
+
+    @Test
+    @DisplayName("Enum 타입 처리: EnumType.ORDINAL → INT")
+    void enumOrdinalMapping() {
+        MySqlDialect d = newDialect();
+
+        ColumnModel enumCol = mock(ColumnModel.class);
+        when(enumCol.getColumnName()).thenReturn("priority");
+        when(enumCol.getJavaType()).thenReturn("com.example.Priority");
+        when(enumCol.getEnumValues()).thenReturn(new String[]{"LOW", "MEDIUM", "HIGH"});
+        when(enumCol.isEnumStringMapping()).thenReturn(false);  // ORDINAL
+        when(enumCol.getLength()).thenReturn(255);
+        when(enumCol.getPrecision()).thenReturn(0);
+        when(enumCol.getScale()).thenReturn(0);
+        when(enumCol.isNullable()).thenReturn(false);
+        when(enumCol.getDefaultValue()).thenReturn(null);
+        when(enumCol.getGenerationStrategy()).thenReturn(GenerationStrategy.NONE);
+        when(enumCol.isManualPrimaryKey()).thenReturn(false);
+        when(enumCol.isLob()).thenReturn(false);
+        when(enumCol.getConversionClass()).thenReturn(null);
+        when(enumCol.getSqlTypeOverride()).thenReturn(null);
+        when(enumCol.isVersion()).thenReturn(false);
+        when(enumCol.getTemporalType()).thenReturn(null);
+
+        String def = d.getColumnDefinitionSql(enumCol);
+        assertTrue(def.contains("INT"), "Expected INT but got: " + def);
+        assertTrue(def.contains("NOT NULL"), "Expected NOT NULL but got: " + def);
+    }
+
     // --- helpers ---
     private ColumnModel col(String name, String javaType) {
         ColumnModel c = mock(ColumnModel.class);

--- a/jinx-core/src/test/java/org/jinx/migration/dialect/mysql/MySqlJavaTypeMapperTest.java
+++ b/jinx-core/src/test/java/org/jinx/migration/dialect/mysql/MySqlJavaTypeMapperTest.java
@@ -39,6 +39,70 @@ class MySqlJavaTypeMapperTest {
     }
 
     @Nested
+    @DisplayName("Primitive 타입 매핑 확인")
+    class PrimitiveMapping {
+
+        @Test
+        @DisplayName("int → INT")
+        void primitiveIntMapsToInt() {
+            JavaTypeMapper.JavaType t = mapper.map("int");
+            Assertions.assertThat(t.getSqlType(0, 0, 0)).isEqualTo("INT");
+            Assertions.assertThat(t.needsQuotes()).isFalse();
+        }
+
+        @Test
+        @DisplayName("long → BIGINT")
+        void primitiveLongMapsToBigInt() {
+            JavaTypeMapper.JavaType t = mapper.map("long");
+            Assertions.assertThat(t.getSqlType(0, 0, 0)).isEqualTo("BIGINT");
+        }
+
+        @Test
+        @DisplayName("double → DOUBLE")
+        void primitiveDoubleMapsToDouble() {
+            JavaTypeMapper.JavaType t = mapper.map("double");
+            Assertions.assertThat(t.getSqlType(0, 0, 0)).isEqualTo("DOUBLE");
+        }
+
+        @Test
+        @DisplayName("float → FLOAT")
+        void primitiveFloatMapsToFloat() {
+            JavaTypeMapper.JavaType t = mapper.map("float");
+            Assertions.assertThat(t.getSqlType(0, 0, 0)).isEqualTo("FLOAT");
+        }
+
+        @Test
+        @DisplayName("boolean → TINYINT(1) ; default 0")
+        void primitiveBooleanMapsToTinyint() {
+            JavaTypeMapper.JavaType t = mapper.map("boolean");
+            Assertions.assertThat(t.getSqlType(0, 0, 0)).isEqualTo("TINYINT(1)");
+            Assertions.assertThat(t.getDefaultValue()).isEqualTo("0");
+        }
+
+        @Test
+        @DisplayName("byte → TINYINT")
+        void primitiveByteMapsToTinyint() {
+            JavaTypeMapper.JavaType t = mapper.map("byte");
+            Assertions.assertThat(t.getSqlType(0, 0, 0)).isEqualTo("TINYINT");
+        }
+
+        @Test
+        @DisplayName("short → SMALLINT")
+        void primitiveShortMapsToSmallint() {
+            JavaTypeMapper.JavaType t = mapper.map("short");
+            Assertions.assertThat(t.getSqlType(0, 0, 0)).isEqualTo("SMALLINT");
+        }
+
+        @Test
+        @DisplayName("char → CHAR(1)")
+        void primitiveCharMapsToChar1() {
+            JavaTypeMapper.JavaType t = mapper.map("char");
+            Assertions.assertThat(t.getSqlType(0, 0, 0)).isEqualTo("CHAR(1)");
+            Assertions.assertThat(t.needsQuotes()).isTrue();
+        }
+    }
+
+    @Nested
     @DisplayName("가변 길이 & Precision/Scale 형식")
     class VariableTypes {
 


### PR DESCRIPTION
# Fix: Primitive & Enum SQL Type Mapping (MySQL)

## Summary
Primitive 타입(`int`, `boolean`, `double`)과 `@Enumerated` enum 타입이 `TEXT`로 잘못 매핑되는 문제를 수정했습니다.  
이제 JPA 어노테이션에 맞게 올바른 SQL 타입(`INT`, `TINYINT(1)`, `DOUBLE`, `VARCHAR(N)` 등)을 생성합니다.

---

## 주요 변경사항

### 1. Primitive 타입 매핑 추가
- `MySqlJavaTypeMapper`에 8개의 primitive 타입 매핑 추가
  - `int` → `INT`
  - `boolean` → `TINYINT(1)`
  - `double` → `DOUBLE`
  - `float` → `FLOAT`
  - `long` → `BIGINT`
  - `byte` → `TINYINT`
  - `short` → `SMALLINT`
  - `char` → `CHAR(1)`

### 2. Enum 타입 매핑 추가
- `MySqlDialect.getColumnDefinitionSql()`에 Enum 처리 로직 추가
  - `EnumType.STRING` → `VARCHAR(length)`
  - `EnumType.ORDINAL` → `INT`
- 기존 `getLiquibaseTypeName()`과 로직을 통일시켜 DDL과 Liquibase 모두 일관된 타입 생성

---

## 테스트
- `MySqlJavaTypeMapperTest`: 8개의 primitive 타입 매핑 테스트 추가
- `MySqlDialectTest`: Enum(STRING/ORDINAL) 매핑 테스트 추가
- 모든 테스트 통과 (`BUILD SUCCESSFUL`)

---

## 영향
- 10개 이상의 엔티티에서 30개 이상의 필드가 올바른 SQL 타입으로 생성됨
- 하위 호환성 유지, 기존 스냅샷 로직에 영향 없음

---

## 변경 파일
- `jinx-core/src/main/java/org/jinx/migration/dialect/mysql/MySqlJavaTypeMapper.java`
- `jinx-core/src/main/java/org/jinx/migration/dialect/mysql/MySqlDialect.java`
- `jinx-core/src/test/java/org/jinx/migration/dialect/mysql/MySqlJavaTypeMapperTest.java`
- `jinx-core/src/test/java/org/jinx/migration/dialect/mysql/MySqlDialectTest.java`

---

## 상태
- [x] 기능 수정 완료  
- [x] 테스트 추가 및 통과  
- [x] 회귀 없음  
- [x] 릴리즈 준비 완료 (`v0.0.9`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * 버전을 0.0.8로 업데이트했습니다.

* **New Features**
  * MySQL에서 Enum 컬럼 지원을 추가했습니다.
  * Java 타입 매핑을 확장하여 박싱 타입과 프리미티브 타입을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->