### PR TITLE
Standardize and unify English comments across CLI module

### DIFF
--- a/docs/issue/JOINED_INHERITANCE_FK_FIX.md
+++ b/docs/issue/JOINED_INHERITANCE_FK_FIX.md
@@ -174,6 +174,6 @@ public class StatCondition extends Condition {
 
 ## 다음 단계
 
-- [ ] 0.0.8 릴리즈 노트에 포함
+- [ ] 0.0.9 릴리즈 노트에 포함
 - [ ] README 업데이트 (JOINED 상속 사용 예시 추가)
 - [ ] 통합 테스트 케이스 추가 (복잡한 상속 구조)

--- a/jinx-cli/src/main/java/org/jinx/cli/DbCommand.java
+++ b/jinx-cli/src/main/java/org/jinx/cli/DbCommand.java
@@ -2,6 +2,10 @@ package org.jinx.cli;
 
 import picocli.CommandLine;
 
+/**
+ * Database-related subcommands container.
+ * Groups migration, verification, and baseline promotion commands.
+ */
 @CommandLine.Command(
         name = "db",
         description = "데이터베이스 관련 명령어",

--- a/jinx-cli/src/main/java/org/jinx/cli/JinxCli.java
+++ b/jinx-cli/src/main/java/org/jinx/cli/JinxCli.java
@@ -2,13 +2,17 @@ package org.jinx.cli;
 
 import picocli.CommandLine;
 
+/**
+ * Main CLI entry point for Jinx database migration tool.
+ * Provides database schema migration capabilities based on JPA entities.
+ */
 @CommandLine.Command(
-        name = "jinx",                                  // 명령어 이름
-        mixinStandardHelpOptions = true,                // -h, --help 옵션 자동 추가
-        version = "jinx 1.0",                           // -V, --version 옵션
+        name = "jinx",
+        mixinStandardHelpOptions = true,
+        version = "jinx 1.0",
         description = "JPA Entity 기반의 데이터베이스 마이그레이션 툴",
         subcommands = {
-                DbCommand.class // 하위 명령어로 DbCommand를 등록합니다.
+                DbCommand.class
         }
 )
 public class JinxCli {

--- a/jinx-cli/src/main/java/org/jinx/cli/service/SchemaIoService.java
+++ b/jinx-cli/src/main/java/org/jinx/cli/service/SchemaIoService.java
@@ -9,6 +9,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+/**
+ * Service for reading and writing schema files and baseline data.
+ * Handles schema file I/O operations and hash generation.
+ */
 public class SchemaIoService {
 
     private static final String SCHEMA_FILE_PATTERN = "schema-\\d{14}\\.json";
@@ -17,11 +21,24 @@ public class SchemaIoService {
     private final Path schemaDir;
     private final Path outputDir;
 
+    /**
+     * Creates a new schema I/O service.
+     *
+     * @param schemaDir directory containing schema JSON files
+     * @param outputDir directory for baseline and output files
+     */
     public SchemaIoService(Path schemaDir, Path outputDir) {
         this.schemaDir = schemaDir;
         this.outputDir = outputDir;
     }
 
+    /**
+     * Loads the latest schema file from the schema directory.
+     * Schema files are expected to follow the pattern schema-YYYYMMDDHHMMSS.json.
+     *
+     * @return the latest schema model, or null if no valid schema files exist
+     * @throws IOException if an I/O error occurs
+     */
     public SchemaModel loadLatestSchema() throws IOException {
         if (!Files.exists(schemaDir)) {
             return null;
@@ -44,21 +61,45 @@ public class SchemaIoService {
         }
     }
 
+    /**
+     * Loads the baseline schema from the output directory.
+     *
+     * @return the baseline schema model
+     * @throws IOException if an I/O error occurs
+     */
     public SchemaModel loadBaselineSchema() throws IOException {
         BaselineManager baselineManager = new BaselineManager(outputDir);
         return baselineManager.loadBaseline();
     }
 
+    /**
+     * Generates a hash for the given schema model.
+     *
+     * @param schema the schema model to hash
+     * @return the schema hash string
+     */
     public String generateSchemaHash(SchemaModel schema) {
         BaselineManager baselineManager = new BaselineManager(outputDir);
         return baselineManager.generateSchemaHash(schema);
     }
 
+    /**
+     * Gets the hash of the current baseline schema.
+     *
+     * @return the baseline hash, or "initial" if no baseline exists
+     */
     public String getBaselineHash() {
         BaselineManager baselineManager = new BaselineManager(outputDir);
         return baselineManager.getBaselineHash().orElse("initial");
     }
 
+    /**
+     * Promotes the given schema to become the new baseline.
+     *
+     * @param schema the schema model to promote
+     * @param schemaHash the hash of the schema
+     * @throws IOException if an I/O error occurs
+     */
     public void promoteToBaseline(SchemaModel schema, String schemaHash) throws IOException {
         BaselineManager baselineManager = new BaselineManager(outputDir);
         baselineManager.promoteBaseline(schema, schemaHash);

--- a/jinx-cli/src/main/java/org/jinx/cli/service/VerificationService.java
+++ b/jinx-cli/src/main/java/org/jinx/cli/service/VerificationService.java
@@ -2,6 +2,10 @@ package org.jinx.cli.service;
 
 import org.jinx.migration.integration.MigrationToolIntegration;
 
+/**
+ * Service for verifying database schema application status.
+ * Checks if migrations have been applied to the database by querying migration tool metadata.
+ */
 public class VerificationService {
 
     private final String dbUrl;
@@ -9,6 +13,14 @@ public class VerificationService {
     private final String dbPassword;
     private final String migrationTool;
 
+    /**
+     * Creates a new verification service.
+     *
+     * @param dbUrl database connection URL
+     * @param dbUser database username
+     * @param dbPassword database password
+     * @param migrationTool the migration tool being used (jinx, liquibase, flyway)
+     */
     public VerificationService(String dbUrl, String dbUser, String dbPassword, String migrationTool) {
         this.dbUrl = dbUrl;
         this.dbUser = dbUser;
@@ -16,6 +28,14 @@ public class VerificationService {
         this.migrationTool = migrationTool != null ? migrationTool : "jinx";
     }
 
+    /**
+     * Gets the hash of the schema that is currently applied to the database.
+     * If database connection is not available, returns the baseline hash.
+     *
+     * @param expectedHash the expected schema hash
+     * @param baselineHash the baseline schema hash
+     * @return the applied schema hash
+     */
     public String getAppliedSchemaHash(String expectedHash, String baselineHash) {
         if (dbUrl == null || dbUser == null) {
             return baselineHash;
@@ -38,11 +58,25 @@ public class VerificationService {
         }
     }
 
+    /**
+     * Checks if the schema is up to date with what has been applied to the database.
+     *
+     * @param expectedHash the expected schema hash
+     * @param baselineHash the baseline schema hash
+     * @return true if the schema is up to date, false otherwise
+     */
     public boolean isSchemaUpToDate(String expectedHash, String baselineHash) {
         String appliedHash = getAppliedSchemaHash(expectedHash, baselineHash);
         return expectedHash.equals(appliedHash);
     }
 
+    /**
+     * Records that a schema has been applied to the database.
+     * Only records if using jinx migration tool and database connection is available.
+     *
+     * @param schemaHash the hash of the applied schema
+     * @param version the version of the applied schema
+     */
     public void recordSchemaApplication(String schemaHash, String version) {
         if (dbUrl != null && dbUser != null && "jinx".equals(migrationTool.toLowerCase())) {
             try {

--- a/jinx-cli/src/test/java/org/jinx/cli/DbCommandTest.java
+++ b/jinx-cli/src/test/java/org/jinx/cli/DbCommandTest.java
@@ -12,7 +12,7 @@ import java.io.PrintWriter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * DbCommand 테스트
+ * Tests for DbCommand.
  */
 class DbCommandTest {
 
@@ -37,7 +37,7 @@ class DbCommandTest {
     }
 
     @Test
-    @DisplayName("db 명령어 help 출력")
+    @DisplayName("Displays help for db command")
     void testDbCommand_Help() {
         try {
             ByteArrayOutputStream helpOut = new ByteArrayOutputStream();
@@ -51,7 +51,7 @@ class DbCommandTest {
             pwOut.flush();
             pwErr.flush();
 
-            // Picocli는 help 표시 시 exit code 0 또는 2를 반환할 수 있음
+            // Picocli may return exit code 0 or 2 when displaying help
             assertThat(exitCode).isIn(0, 2);
             String output = helpOut.toString() + helpErr.toString();
             assertThat(output).contains("데이터베이스");
@@ -61,14 +61,14 @@ class DbCommandTest {
     }
 
     @Test
-    @DisplayName("db 하위 명령어 없이 실행하면 help 또는 에러 출력")
+    @DisplayName("Displays help or error when executed without subcommand")
     void testDbCommand_NoSubcommand() {
         try {
             int exitCode = new CommandLine(new JinxCli())
                     .execute("db");
 
-            // 하위 명령어가 필요하다는 메시지 또는 help가 출력되어야 함
-            // 출력이 없을 수도 있으므로 exit code만 확인
+            // Should display message about required subcommand or help
+            // May have no output, so only verify exit code
             assertThat(exitCode).isNotZero();
         } finally {
             tearDown();
@@ -76,7 +76,7 @@ class DbCommandTest {
     }
 
     @Test
-    @DisplayName("db verify 하위 명령어 존재 확인")
+    @DisplayName("Verifies db verify subcommand exists")
     void testDbCommand_VerifySubcommand() {
         try {
             ByteArrayOutputStream helpOut = new ByteArrayOutputStream();
@@ -99,7 +99,7 @@ class DbCommandTest {
     }
 
     @Test
-    @DisplayName("db migrate 하위 명령어 존재 확인")
+    @DisplayName("Verifies db migrate subcommand exists")
     void testDbCommand_MigrateSubcommand() {
         try {
             ByteArrayOutputStream helpOut = new ByteArrayOutputStream();
@@ -114,7 +114,7 @@ class DbCommandTest {
             pwErr.flush();
 
             assertThat(exitCode).isZero();
-            // migrate 명령어의 help가 출력되어야 함
+            // Should display help for migrate command
             String output = helpOut.toString() + helpErr.toString();
             assertThat(output).isNotEmpty();
         } finally {
@@ -123,7 +123,7 @@ class DbCommandTest {
     }
 
     @Test
-    @DisplayName("db promote-baseline 하위 명령어 존재 확인")
+    @DisplayName("Verifies db promote-baseline subcommand exists")
     void testDbCommand_PromoteBaselineSubcommand() {
         try {
             ByteArrayOutputStream helpOut = new ByteArrayOutputStream();
@@ -146,13 +146,13 @@ class DbCommandTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 하위 명령어")
+    @DisplayName("Returns error for non-existent subcommand")
     void testDbCommand_InvalidSubcommand() {
         try {
             int exitCode = new CommandLine(new JinxCli())
                     .execute("db", "invalid-command");
 
-            // 잘못된 명령어에 대한 에러가 발생해야 함
+            // Should return error for invalid command
             assertThat(exitCode).isNotZero();
         } finally {
             tearDown();

--- a/jinx-cli/src/test/java/org/jinx/cli/JinxCliTest.java
+++ b/jinx-cli/src/test/java/org/jinx/cli/JinxCliTest.java
@@ -46,7 +46,7 @@ class JinxCliTest {
 
     @Test
     @Disabled("TODO: Update test for new baseline workflow")
-    @DisplayName("스키마 디렉터리 미존재 -> exit‑1 + 오류메시지")
+    @DisplayName("Directory not found returns exit code 1 with error message")
     void dirNotFound() {
         Path notExist = tmp.resolve("no_such_dir");
         try (StreamCaptor sc = new StreamCaptor()) {
@@ -60,7 +60,7 @@ class JinxCliTest {
 
     @Test
     @Disabled("TODO: Update test for new baseline workflow")
-    @DisplayName("두 스키마가 동일 -> No changes detected, exit‑0")
+    @DisplayName("Identical schemas return exit code 0 with no changes detected")
     void noChangesDetected() throws Exception {
         // 동일한 내용이지만 timestamp 가 다른 두 스키마
         writeSchema(LocalDateTime.of(2024,1,1,0,0,0));
@@ -77,7 +77,7 @@ class JinxCliTest {
 
     @Test
     @Disabled("TODO: Update test for new baseline workflow")
-    @DisplayName("지원하지 않는 dialect 지정 -> exit‑1 + IllegalArgumentException 메시지")
+    @DisplayName("Unsupported dialect returns exit code 1 with IllegalArgumentException")
     void unsupportedDialect() throws Exception {
 
         writeSchema(LocalDateTime.of(2024,1,1,0,0,0));

--- a/jinx-cli/src/test/java/org/jinx/cli/MigrateCommandTest.java
+++ b/jinx-cli/src/test/java/org/jinx/cli/MigrateCommandTest.java
@@ -10,7 +10,7 @@ import java.nio.file.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * MigrateCommand 기본 테스트
+ * Basic tests for MigrateCommand.
  */
 class MigrateCommandTest {
 
@@ -49,7 +49,7 @@ class MigrateCommandTest {
     }
 
     @Test
-    @DisplayName("스키마 파일이 없으면 'No HEAD schema found' 메시지 출력")
+    @DisplayName("Displays 'No HEAD schema found' message when no schema file")
     void testNoSchemaFile() {
         try {
             int exitCode = new CommandLine(new MigrateCommand())
@@ -64,7 +64,7 @@ class MigrateCommandTest {
     }
 
     @Test
-    @DisplayName("help 옵션 테스트")
+    @DisplayName("Help option displays migration description")
     void testMigrateHelp() {
         try {
             ByteArrayOutputStream helpOut = new ByteArrayOutputStream();
@@ -88,7 +88,7 @@ class MigrateCommandTest {
     }
 
     @Test
-    @DisplayName("지원하지 않는 dialect 사용 시 에러")
+    @DisplayName("Returns error for unsupported dialect")
     void testUnsupportedDialect() throws IOException {
         // given
         createSchemaFile("20240101000000", """
@@ -117,9 +117,9 @@ class MigrateCommandTest {
                             "--out", outputDir.toString(),
                             "--dialect", "oracle");
 
-            // then - 실패해야 함
+            // then - Should fail
             assertThat(exitCode).isEqualTo(1);
-            // "Unsupported dialect" 또는 "Migration failed" 메시지가 있어야 함
+            // Should contain "Unsupported dialect" or "Migration failed" message
             String errorOutput = errContent.toString();
             assertThat(errorOutput).containsAnyOf("Unsupported dialect", "Migration failed", "oracle");
         } finally {

--- a/jinx-cli/src/test/java/org/jinx/cli/PromoteBaselineCommandTest.java
+++ b/jinx-cli/src/test/java/org/jinx/cli/PromoteBaselineCommandTest.java
@@ -15,7 +15,7 @@ import java.nio.file.Path;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * PromoteBaselineCommand 테스트
+ * Tests for PromoteBaselineCommand.
  */
 class PromoteBaselineCommandTest {
 
@@ -54,7 +54,7 @@ class PromoteBaselineCommandTest {
     }
 
     @Test
-    @DisplayName("스키마가 없으면 에러 반환")
+    @DisplayName("Returns error when no schema exists")
     void testPromoteBaseline_NoSchema() {
         try {
             int exitCode = new CommandLine(new PromoteBaselineCommand())
@@ -70,7 +70,7 @@ class PromoteBaselineCommandTest {
     }
 
     @Test
-    @DisplayName("force 옵션으로 baseline 승격")
+    @DisplayName("Promotes baseline with force option")
     void testPromoteBaseline_Force() throws IOException {
         createSchemaFile("20240101000000", """
                 {"version":"20240101000000","entities":{}}
@@ -88,7 +88,7 @@ class PromoteBaselineCommandTest {
             assertThat(outContent.toString()).contains("Baseline promoted successfully");
             assertThat(outContent.toString()).contains("Version: 20240101000000");
 
-            // baseline 파일이 생성되었는지 확인
+            // Verify baseline file is created
             Path baselineFile = outputDir.resolve("schema-baseline.json");
             assertThat(baselineFile).exists();
         } finally {
@@ -97,28 +97,28 @@ class PromoteBaselineCommandTest {
     }
 
     @Test
-    @DisplayName("force 없이 검증 성공 시 baseline 승격")
+    @DisplayName("Promotes baseline after successful verification without force")
     void testPromoteBaseline_WithVerification() throws IOException {
-        // 초기 스키마 생성 및 baseline 설정
+        // Create initial schema and set baseline
         createSchemaFile("20240101000000", """
                 {"version":"20240101000000","entities":{}}
                 """);
 
         Files.createDirectories(outputDir);
 
-        // 첫 번째 promote (force)
+        // First promote (force)
         new CommandLine(new PromoteBaselineCommand())
                 .execute("-p", schemaDir.toString(),
                         "--out", outputDir.toString(),
                         "--force");
 
         try {
-            // 같은 스키마에 대해 force 없이 promote (검증 성공해야 함)
+            // Promote without force for same schema (should succeed verification)
             int exitCode = new CommandLine(new PromoteBaselineCommand())
                     .execute("-p", schemaDir.toString(),
                             "--out", outputDir.toString());
 
-            // DB 연결이 없으므로 baseline과 비교하여 동일하면 성공
+            // No DB connection, succeeds if identical to baseline
             assertThat(exitCode).isZero();
             assertThat(outContent.toString()).contains("Baseline promoted successfully");
         } finally {
@@ -127,9 +127,9 @@ class PromoteBaselineCommandTest {
     }
 
     @Test
-    @DisplayName("스키마가 변경되었는데 force 없으면 실패")
+    @DisplayName("Fails without force when schema changes")
     void testPromoteBaseline_FailWithoutForce() throws IOException {
-        // 초기 스키마 생성 및 baseline 설정
+        // Create initial schema and set baseline
         createSchemaFile("20240101000000", """
                 {"version":"20240101000000","entities":{}}
                 """);
@@ -141,13 +141,13 @@ class PromoteBaselineCommandTest {
                         "--out", outputDir.toString(),
                         "--force");
 
-        // 새로운 스키마 생성 (변경됨)
+        // Create new schema (changed)
         createSchemaFile("20240102000000", """
                 {"version":"20240102000000","entities":{"User":{}}}
                 """);
 
         try {
-            // force 없이 promote 시도 (검증 실패해야 함)
+            // Attempt promote without force (should fail verification)
             int exitCode = new CommandLine(new PromoteBaselineCommand())
                     .execute("-p", schemaDir.toString(),
                             "--out", outputDir.toString());
@@ -161,7 +161,7 @@ class PromoteBaselineCommandTest {
     }
 
     @Test
-    @DisplayName("help 옵션 테스트")
+    @DisplayName("Help option displays promote baseline description")
     void testPromoteBaseline_Help() {
         try {
             int exitCode = new CommandLine(new PromoteBaselineCommand())
@@ -175,7 +175,7 @@ class PromoteBaselineCommandTest {
     }
 
     @Test
-    @DisplayName("baseline 파일 내용 검증")
+    @DisplayName("Verifies baseline file content")
     void testPromoteBaseline_BaselineFileContent() throws IOException {
         createSchemaFile("20240101000000", """
                 {"version":"20240101000000","entities":{}}
@@ -189,7 +189,7 @@ class PromoteBaselineCommandTest {
                             "--out", outputDir.toString(),
                             "--force");
 
-            // baseline 파일 내용 확인
+            // Verify baseline file content
             Path baselineFile = outputDir.resolve("schema-baseline.json");
             assertThat(baselineFile).exists();
 
@@ -197,7 +197,7 @@ class PromoteBaselineCommandTest {
             assertThat(baselineContent).contains("\"version\":\"20240101000000\"");
             assertThat(baselineContent).contains("\"entities\"");
 
-            // metadata 파일도 확인
+            // Also verify metadata file
             Path metadataFile = outputDir.resolve("baseline-metadata.json");
             if (Files.exists(metadataFile)) {
                 String metadataContent = Files.readString(metadataFile);

--- a/jinx-cli/src/test/java/org/jinx/cli/VerifyCommandTest.java
+++ b/jinx-cli/src/test/java/org/jinx/cli/VerifyCommandTest.java
@@ -15,7 +15,7 @@ import java.nio.file.Path;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * VerifyCommand 테스트
+ * Tests for VerifyCommand.
  */
 class VerifyCommandTest {
 
@@ -54,7 +54,7 @@ class VerifyCommandTest {
     }
 
     @Test
-    @DisplayName("스키마가 없으면 에러 반환")
+    @DisplayName("Returns error when no schema exists")
     void testVerify_NoSchema() {
         try {
             int exitCode = new CommandLine(new VerifyCommand())
@@ -68,7 +68,7 @@ class VerifyCommandTest {
     }
 
     @Test
-    @DisplayName("baseline이 없고 DB 연결 정보도 없으면 초기 상태로 간주")
+    @DisplayName("Considers as initial state when no baseline and no DB connection")
     void testVerify_NoBaselineNoDb() throws IOException {
         createSchemaFile("20240101000000", """
                 {"version":"20240101000000","entities":{}}
@@ -78,8 +78,8 @@ class VerifyCommandTest {
             int exitCode = new CommandLine(new VerifyCommand())
                     .execute("-p", schemaDir.toString(), "--out", outputDir.toString());
 
-            // DB 연결 정보가 없으므로 baseline (initial)과 비교
-            // 최신 스키마 해시 != "initial" 이므로 mismatch
+            // No DB connection, compare with baseline (initial)
+            // Latest schema hash != "initial", so mismatch
             assertThat(exitCode).isEqualTo(1);
             assertThat(outContent.toString()).contains("Schema mismatch detected");
         } finally {
@@ -88,16 +88,16 @@ class VerifyCommandTest {
     }
 
     @Test
-    @DisplayName("baseline과 최신 스키마가 동일하면 up-to-date")
+    @DisplayName("Returns up-to-date when baseline matches latest schema")
     void testVerify_UpToDate() throws IOException {
-        // 스키마 생성
+        // Create schema
         createSchemaFile("20240101000000", """
                 {"version":"20240101000000","entities":{}}
                 """);
 
         Files.createDirectories(outputDir);
 
-        // baseline 생성 (promote-baseline 시뮬레이션)
+        // Create baseline (simulate promote-baseline)
         int promoteCode = new CommandLine(new PromoteBaselineCommand())
                 .execute("-p", schemaDir.toString(),
                         "--out", outputDir.toString(),
@@ -106,7 +106,7 @@ class VerifyCommandTest {
         assertThat(promoteCode).isZero();
 
         try {
-            // verify 실행
+            // Execute verify
             int exitCode = new CommandLine(new VerifyCommand())
                     .execute("-p", schemaDir.toString(), "--out", outputDir.toString());
 
@@ -118,9 +118,9 @@ class VerifyCommandTest {
     }
 
     @Test
-    @DisplayName("스키마가 변경되면 mismatch 감지")
+    @DisplayName("Detects mismatch when schema changes")
     void testVerify_SchemaMismatch() throws IOException {
-        // 초기 스키마 생성 및 baseline 설정
+        // Create initial schema and set baseline
         createSchemaFile("20240101000000", """
                 {"version":"20240101000000","entities":{}}
                 """);
@@ -132,13 +132,13 @@ class VerifyCommandTest {
                         "--out", outputDir.toString(),
                         "--force");
 
-        // 새로운 스키마 생성 (변경됨)
+        // Create new schema (changed)
         createSchemaFile("20240102000000", """
                 {"version":"20240102000000","entities":{"User":{}}}
                 """);
 
         try {
-            // verify 실행
+            // Execute verify
             int exitCode = new CommandLine(new VerifyCommand())
                     .execute("-p", schemaDir.toString(), "--out", outputDir.toString());
 
@@ -151,7 +151,7 @@ class VerifyCommandTest {
     }
 
     @Test
-    @DisplayName("help 옵션 테스트")
+    @DisplayName("Help option displays verification description")
     void testVerify_Help() {
         try {
             int exitCode = new CommandLine(new VerifyCommand())

--- a/jinx-cli/src/test/java/org/jinx/cli/service/SchemaIoServiceTest.java
+++ b/jinx-cli/src/test/java/org/jinx/cli/service/SchemaIoServiceTest.java
@@ -16,7 +16,7 @@ import java.time.format.DateTimeFormatter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * SchemaIoService 테스트
+ * Tests for SchemaIoService.
  */
 class SchemaIoServiceTest {
 
@@ -43,14 +43,14 @@ class SchemaIoServiceTest {
     }
 
     @Test
-    @DisplayName("스키마 디렉토리가 없으면 null 반환")
+    @DisplayName("Returns null when schema directory does not exist")
     void testLoadLatestSchema_DirectoryNotExists() throws IOException {
         SchemaModel schema = service.loadLatestSchema();
         assertThat(schema).isNull();
     }
 
     @Test
-    @DisplayName("스키마 파일이 없으면 null 반환")
+    @DisplayName("Returns null when no schema files exist")
     void testLoadLatestSchema_NoSchemaFiles() throws IOException {
         Files.createDirectories(schemaDir);
         SchemaModel schema = service.loadLatestSchema();
@@ -58,9 +58,9 @@ class SchemaIoServiceTest {
     }
 
     @Test
-    @DisplayName("가장 최신 스키마 파일 로드")
+    @DisplayName("Loads the most recent schema file")
     void testLoadLatestSchema_LoadsLatest() throws IOException {
-        // 여러 스키마 파일 생성
+        // Create multiple schema files
         createSchemaFile("20240101000000", """
                 {"version":"20240101000000","entities":{}}
                 """);
@@ -80,16 +80,16 @@ class SchemaIoServiceTest {
     }
 
     @Test
-    @DisplayName("잘못된 형식의 파일은 무시")
+    @DisplayName("Ignores files with invalid format")
     void testLoadLatestSchema_IgnoresInvalidFormat() throws IOException {
         Files.createDirectories(schemaDir);
 
-        // 잘못된 형식의 파일들
+        // Invalid format files
         Files.writeString(schemaDir.resolve("schema.json"), "{}");
         Files.writeString(schemaDir.resolve("schema-abc.json"), "{}");
         Files.writeString(schemaDir.resolve("other.json"), "{}");
 
-        // 올바른 형식의 파일
+        // Valid format file
         createSchemaFile("20240101000000", """
                 {"version":"20240101000000","entities":{}}
                 """);
@@ -101,7 +101,7 @@ class SchemaIoServiceTest {
     }
 
     @Test
-    @DisplayName("스키마 해시 생성")
+    @DisplayName("Generates schema hash")
     void testGenerateSchemaHash() {
         SchemaModel schema = SchemaModel.builder()
                 .version("20240101000000")
@@ -114,7 +114,7 @@ class SchemaIoServiceTest {
     }
 
     @Test
-    @DisplayName("동일한 스키마는 동일한 해시 생성")
+    @DisplayName("Generates same hash for identical schemas")
     void testGenerateSchemaHash_SameSchemasSameHash() {
         SchemaModel schema1 = SchemaModel.builder()
                 .version("20240101000000")
@@ -131,14 +131,14 @@ class SchemaIoServiceTest {
     }
 
     @Test
-    @DisplayName("baseline이 없으면 'initial' 반환")
+    @DisplayName("Returns 'initial' when no baseline exists")
     void testGetBaselineHash_NoBaseline() {
         String hash = service.getBaselineHash();
         assertThat(hash).isEqualTo("initial");
     }
 
     @Test
-    @DisplayName("baseline 승격")
+    @DisplayName("Promotes schema to baseline")
     void testPromoteToBaseline() throws IOException {
         Files.createDirectories(outputDir);
 
@@ -149,17 +149,17 @@ class SchemaIoServiceTest {
         String hash = service.generateSchemaHash(schema);
         service.promoteToBaseline(schema, hash);
 
-        // baseline 파일이 생성되었는지 확인
+        // Verify baseline file is created
         Path baselineFile = outputDir.resolve("schema-baseline.json");
         assertThat(baselineFile).exists();
 
-        // baseline hash가 올바른지 확인
+        // Verify baseline hash is correct
         String baselineHash = service.getBaselineHash();
         assertThat(baselineHash).isEqualTo(hash);
     }
 
     @Test
-    @DisplayName("현재 시간 기준으로 스키마 파일명 패턴 테스트")
+    @DisplayName("Tests schema filename pattern with current timestamp")
     void testSchemaFilePattern() throws IOException {
         LocalDateTime now = LocalDateTime.now();
         String timestamp = now.format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));

--- a/jinx-cli/src/test/java/org/jinx/cli/service/VerificationServiceTest.java
+++ b/jinx-cli/src/test/java/org/jinx/cli/service/VerificationServiceTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * VerificationService 테스트
+ * Tests for VerificationService.
  */
 class VerificationServiceTest {
 
@@ -15,12 +15,12 @@ class VerificationServiceTest {
 
     @BeforeEach
     void setUp() {
-        // DB 연결 없이 테스트 (null로 설정)
+        // Test without DB connection (set to null)
         service = new VerificationService(null, null, null, "jinx");
     }
 
     @Test
-    @DisplayName("DB 연결 정보가 없으면 baseline hash 반환")
+    @DisplayName("Returns baseline hash when no DB connection info")
     void testGetAppliedSchemaHash_NoDbConnection() {
         String expectedHash = "hash123";
         String baselineHash = "baseline456";
@@ -31,7 +31,7 @@ class VerificationServiceTest {
     }
 
     @Test
-    @DisplayName("expected hash와 applied hash가 같으면 up-to-date")
+    @DisplayName("Returns true when expected hash matches applied hash")
     void testIsSchemaUpToDate_WhenHashesMatch() {
         String hash = "hash123";
 
@@ -41,7 +41,7 @@ class VerificationServiceTest {
     }
 
     @Test
-    @DisplayName("expected hash와 applied hash가 다르면 not up-to-date")
+    @DisplayName("Returns false when expected hash differs from applied hash")
     void testIsSchemaUpToDate_WhenHashesDifferent() {
         String expectedHash = "hash123";
         String baselineHash = "baseline456";
@@ -52,7 +52,7 @@ class VerificationServiceTest {
     }
 
     @Test
-    @DisplayName("migration tool이 null이면 jinx로 기본 설정")
+    @DisplayName("Defaults to jinx when migration tool is null")
     void testMigrationToolDefaultValue() {
         VerificationService serviceWithNullTool = new VerificationService(
                 "jdbc:h2:mem:test",
@@ -61,14 +61,14 @@ class VerificationServiceTest {
                 null
         );
 
-        // 기본값이 "jinx"인지 확인하기 위해 recordSchemaApplication 호출 시 예외가 발생하지 않는지 확인
-        // (실제 DB가 없으므로 경고 메시지만 출력됨)
+        // Verify default is "jinx" by checking no exception when calling recordSchemaApplication
+        // (Only warning message will be printed as there's no actual DB)
         serviceWithNullTool.recordSchemaApplication("hash123", "20240101000000");
-        // 예외가 발생하지 않으면 성공
+        // Success if no exception thrown
     }
 
     @Test
-    @DisplayName("record schema application - jinx migration tool")
+    @DisplayName("Records schema application with jinx migration tool")
     void testRecordSchemaApplication_JinxTool() {
         VerificationService jinxService = new VerificationService(
                 "jdbc:h2:mem:test",
@@ -77,13 +77,13 @@ class VerificationServiceTest {
                 "jinx"
         );
 
-        // DB가 없어도 예외가 발생하지 않고 경고만 출력되는지 확인
+        // Verify no exception thrown, only warning printed when no DB
         jinxService.recordSchemaApplication("hash123", "20240101000000");
-        // 예외가 발생하지 않으면 성공
+        // Success if no exception thrown
     }
 
     @Test
-    @DisplayName("record schema application - liquibase는 기록하지 않음")
+    @DisplayName("Does not record schema application with liquibase tool")
     void testRecordSchemaApplication_LiquibaseTool() {
         VerificationService liquibaseService = new VerificationService(
                 "jdbc:h2:mem:test",
@@ -92,13 +92,13 @@ class VerificationServiceTest {
                 "liquibase"
         );
 
-        // liquibase 모드에서는 recordSchemaApplication이 아무것도 하지 않음
+        // In liquibase mode, recordSchemaApplication does nothing
         liquibaseService.recordSchemaApplication("hash123", "20240101000000");
-        // 예외가 발생하지 않으면 성공
+        // Success if no exception thrown
     }
 
     @Test
-    @DisplayName("record schema application - flyway는 기록하지 않음")
+    @DisplayName("Does not record schema application with flyway tool")
     void testRecordSchemaApplication_FlywayTool() {
         VerificationService flywayService = new VerificationService(
                 "jdbc:h2:mem:test",
@@ -107,26 +107,26 @@ class VerificationServiceTest {
                 "flyway"
         );
 
-        // flyway 모드에서는 recordSchemaApplication이 아무것도 하지 않음
+        // In flyway mode, recordSchemaApplication does nothing
         flywayService.recordSchemaApplication("hash123", "20240101000000");
-        // 예외가 발생하지 않으면 성공
+        // Success if no exception thrown
     }
 
     @Test
-    @DisplayName("migration tool 대소문자 무시")
+    @DisplayName("Migration tool name is case-insensitive")
     void testMigrationToolCaseInsensitive() {
         VerificationService service1 = new VerificationService(null, null, null, "JINX");
         VerificationService service2 = new VerificationService(null, null, null, "JiNx");
         VerificationService service3 = new VerificationService(null, null, null, "jinx");
 
-        // 모두 동일하게 처리되어야 함 (예외 발생하지 않음)
+        // All should be handled identically (no exception)
         service1.recordSchemaApplication("hash", "version");
         service2.recordSchemaApplication("hash", "version");
         service3.recordSchemaApplication("hash", "version");
     }
 
     @Test
-    @DisplayName("지원하지 않는 migration tool은 false 반환하여 baseline hash 사용")
+    @DisplayName("Returns baseline hash for unsupported migration tool")
     void testUnsupportedMigrationTool() {
         // given
         VerificationService unknownService = new VerificationService(
@@ -139,7 +139,7 @@ class VerificationServiceTest {
         String expectedHash = "sha256:expected";
         String baselineHash = "sha256:baseline";
 
-        // when - DB 연결 실패하므로 baseline hash 반환
+        // when - DB connection fails, returns baseline hash
         String appliedHash = unknownService.getAppliedSchemaHash(expectedHash, baselineHash);
 
         // then
@@ -147,7 +147,7 @@ class VerificationServiceTest {
     }
 
     @Test
-    @DisplayName("DB 연결 실패 시에도 예외 없이 baseline hash 반환")
+    @DisplayName("Returns baseline hash without exception on DB connection failure")
     void testDbConnectionFailureReturnsBaselineHash() {
         // given
         VerificationService service = new VerificationService(
@@ -163,19 +163,19 @@ class VerificationServiceTest {
         // when
         String appliedHash = service.getAppliedSchemaHash(expectedHash, baselineHash);
 
-        // then - 예외가 발생해도 baseline hash 반환
+        // then - Returns baseline hash even if exception occurs
         assertThat(appliedHash).isEqualTo(baselineHash);
     }
 
     @Test
-    @DisplayName("isSchemaUpToDate는 getAppliedSchemaHash 결과를 사용")
+    @DisplayName("isSchemaUpToDate uses getAppliedSchemaHash result")
     void testIsSchemaUpToDateUsesGetAppliedSchemaHash() {
-        // given - DB 연결 없음, baseline hash 반환
+        // given - No DB connection, returns baseline hash
         VerificationService service = new VerificationService(null, null, null, "jinx");
         String expectedHash = "sha256:expected";
         String baselineHash = "sha256:baseline";
 
-        // when - expectedHash와 baseline이 다르므로 false
+        // when - expectedHash differs from baseline, so false
         boolean upToDate = service.isSchemaUpToDate(expectedHash, baselineHash);
 
         // then
@@ -183,12 +183,12 @@ class VerificationServiceTest {
     }
 
     @Test
-    @DisplayName("recordSchemaApplication - DB 정보가 없으면 아무것도 하지 않음")
+    @DisplayName("recordSchemaApplication does nothing when no DB info")
     void testRecordSchemaApplication_NoDbInfo() {
         // given
         VerificationService service = new VerificationService(null, null, null, "jinx");
 
-        // when & then - 예외 발생하지 않음
+        // when & then - No exception thrown
         service.recordSchemaApplication("hash", "version");
     }
 }


### PR DESCRIPTION
This PR refines the documentation and comments within the CLI module to maintain a consistent and professional English style across the codebase.

### Details

- Converted all comments from Korean to English.
- Standardized Javadoc formatting and inline comment tone.
- Clarified parameter and return descriptions in method-level comments.
- Removed unnecessary or outdated remarks.

### Impact
No functional changes — documentation only.
Improves developer experience and onboarding for contributors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 스키마 검증 과정 개선 및 HEAD 스키마 누락 시 우아한 종료 처리
  * 기준선 승격 전 검증 단계 추가로 안정성 향상

* **리팩토링**
  * 스키마 로딩 및 검증 로직 재구성으로 안정성 개선
  * 위험한 변경사항 처리 및 오류 메시지 명확화

* **문서화**
  * 코드 주석 및 문서 국제화 완료

<!-- end of auto-generated comment: release notes by coderabbit.ai -->