### PR TITLE
Standardize and unify English comments across Processor module

### DIFF
--- a/jinx-processor/src/main/java/org/jinx/descriptor/AttributeDescriptor.java
+++ b/jinx-processor/src/main/java/org/jinx/descriptor/AttributeDescriptor.java
@@ -7,17 +7,44 @@ import javax.lang.model.type.TypeMirror;
 import java.lang.annotation.Annotation;
 import java.util.Optional;
 
+/**
+ * An abstraction over a persistent attribute (field or property) of an entity.
+ * <p>
+ * This interface provides a unified way to access information about an attribute,
+ * regardless of whether it is accessed via a field or a getter method.
+ */
 public interface AttributeDescriptor {
-    String name();                          // 속성명 (orders)
-    TypeMirror type();                      // 전체 타입
+    /** @return The attribute name (e.g., "orders"). */
+    String name();
+
+    /** @return The full type of the attribute. */
+    TypeMirror type();
+
+    /** @return True if the attribute is a collection type. */
     boolean isCollection();
+
+    /** @return The generic type argument at the specified index. */
     Optional<DeclaredType> genericArg(int idx);
 
+    /**
+     * Gets the annotation of the specified type on this attribute.
+     * @param ann The annotation class.
+     * @return The annotation instance, or null if not present.
+     */
     <A extends Annotation> A getAnnotation(Class<A> ann);
+
+    /**
+     * Checks if the attribute has an annotation of the specified type.
+     * @param ann The annotation class.
+     * @return True if the annotation is present.
+     */
     boolean hasAnnotation(Class<? extends Annotation> ann);
 
-    Element elementForDiagnostics();        // 에러 표시 위치
-    AccessKind accessKind();                // FIELD, PROPERTY, or RECORD_COMPONENT
+    /** @return The element to use for error reporting. */
+    Element elementForDiagnostics();
+
+    /** @return The kind of access: FIELD, PROPERTY, or RECORD_COMPONENT. */
+    AccessKind accessKind();
     enum AccessKind { FIELD, PROPERTY, RECORD_COMPONENT }
 
     // Optional helpers for mirror-based lookup (no Class loading)
@@ -25,7 +52,7 @@ public interface AttributeDescriptor {
         return elementForDiagnostics().getAnnotationMirrors().stream()
                 .filter(am -> am.getAnnotationType().toString().equals(fqcn))
                 .findFirst()
-                .map(am -> (AnnotationMirror) am); // Optional<? extends ...> → Optional<...> 고정
+                .map(am -> (AnnotationMirror) am); // Cast Optional<? extends ...> to Optional<...>
     }
 
     default boolean hasAnnotation(String fqcn) {

--- a/jinx-processor/src/main/java/org/jinx/handler/AbstractColumnResolver.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/AbstractColumnResolver.java
@@ -12,6 +12,12 @@ import org.jinx.util.ColumnUtils;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 
+/**
+ * An abstract base class for {@link ColumnResolver} implementations.
+ * <p>
+ * This class provides common functionality for processing standard JPA annotations
+ * like {@code @Lob}, {@code @Enumerated}, and {@code @Temporal} that affect column definitions.
+ */
 public abstract class AbstractColumnResolver implements ColumnResolver {
     protected final ProcessingContext context;
 
@@ -19,8 +25,15 @@ public abstract class AbstractColumnResolver implements ColumnResolver {
         this.context = context;
     }
 
+    /**
+     * Applies common JPA annotations to a {@link ColumnModel.ColumnModelBuilder}.
+     *
+     * @param builder The column model builder to configure.
+     * @param field The field element being processed.
+     * @param type The type of the field.
+     */
     protected void applyCommonAnnotations(ColumnModel.ColumnModelBuilder builder, VariableElement field, TypeMirror type) {
-        // @Lob 처리
+        // Handle @Lob
         if (field.getAnnotation(Lob.class) != null) {
             builder.isLob(true);
             String javaType = type.toString();
@@ -31,7 +44,7 @@ public abstract class AbstractColumnResolver implements ColumnResolver {
             }
         }
 
-        // @Enumerated 처리
+        // Handle @Enumerated
         Enumerated enumerated = field.getAnnotation(Enumerated.class);
         if (enumerated != null) {
             boolean isStringMapping = enumerated.value() == EnumType.STRING;
@@ -41,7 +54,7 @@ public abstract class AbstractColumnResolver implements ColumnResolver {
             }
         }
 
-        // @Temporal 처리
+        // Handle @Temporal
         Temporal temporal = field.getAnnotation(Temporal.class);
         if (temporal != null) {
             builder.temporalType(temporal.value());

--- a/jinx-processor/src/main/java/org/jinx/handler/ColumnHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/ColumnHandler.java
@@ -13,6 +13,13 @@ import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
 import java.util.Map;
 
+/**
+ * Handles the creation of {@link ColumnModel} instances from various sources.
+ * <p>
+ * This class acts as a facade, delegating the actual column resolution logic
+ * to a set of specialized {@link ColumnResolver} and {@link AttributeColumnResolver}
+ * implementations. It also provides validation for table names.
+ */
 public class ColumnHandler {
     private final ProcessingContext context;
     private final SequenceHandler sequenceHandler;
@@ -28,14 +35,37 @@ public class ColumnHandler {
         this.attributeBasedResolver = new AttributeBasedEntityResolver(context, sequenceHandler);
     }
 
+    /**
+     * Creates a ColumnModel from a field element, considering overrides.
+     *
+     * @param field The field element.
+     * @param overrides A map of property overrides.
+     * @return A new ColumnModel instance.
+     */
     public ColumnModel createFrom(VariableElement field, Map<String, String> overrides) {
         return typeBasedResolver.resolve(field, null, null, overrides);
     }
 
+    /**
+     * Creates a ColumnModel from a field's type with a specific column name.
+     *
+     * @param field The field element.
+     * @param type The type of the column.
+     * @param columnName The explicit name for the column.
+     * @return A new ColumnModel instance.
+     */
     public ColumnModel createFromFieldType(VariableElement field, TypeMirror type, String columnName) {
         return fieldBasedResolver.resolve(field, type, columnName, Map.of());
     }
 
+    /**
+     * Creates a ColumnModel from an attribute descriptor, applying overrides and validating the table name.
+     *
+     * @param attribute The attribute descriptor.
+     * @param entity The owning entity model.
+     * @param overrides A map of property overrides.
+     * @return A new, validated ColumnModel instance.
+     */
     public ColumnModel createFromAttribute(AttributeDescriptor attribute, EntityModel entity, Map<String, String> overrides) {
         ColumnModel column = attributeBasedResolver.resolve(attribute, null, null, overrides);
         if (column == null) {
@@ -49,6 +79,15 @@ public class ColumnHandler {
         return column;
     }
 
+    /**
+     * Creates a ColumnModel from an attribute's type with a specific column name and validates the table name.
+     *
+     * @param attribute The attribute descriptor.
+     * @param entity The owning entity model.
+     * @param type The type of the column.
+     * @param columnName The explicit name for the column.
+     * @return A new, validated ColumnModel instance.
+     */
     public ColumnModel createFromAttributeType(AttributeDescriptor attribute, EntityModel entity, TypeMirror type, String columnName) {
         ColumnModel column = attributeBasedResolver.resolve(attribute, type, columnName, Map.of());
         if (column == null) {

--- a/jinx-processor/src/main/java/org/jinx/handler/ConstraintHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/ConstraintHandler.java
@@ -15,6 +15,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Handles the processing of custom {@link Constraint} and {@link Constraints} annotations.
+ * <p>
+ * This handler discovers constraint annotations on elements and attributes,
+ * converts them into {@link ConstraintModel} instances, and adds them to a list
+ * for further processing by other handlers.
+ */
 public class ConstraintHandler {
     private final ProcessingContext context;
 
@@ -22,6 +29,14 @@ public class ConstraintHandler {
         this.context = context;
     }
 
+    /**
+     * Processes {@code @Constraint} and {@code @Constraints} annotations on a given {@link Element}.
+     *
+     * @param element The element to inspect for annotations.
+     * @param fieldName The name of the field associated with the constraint.
+     * @param constraints The list to which the created {@link ConstraintModel}s will be added.
+     * @param tableName The name of the table for the constraint.
+     */
     public void processConstraints(Element element, String fieldName, List<ConstraintModel> constraints, String tableName) {
         Constraint c1 = element.getAnnotation(Constraint.class);
         Constraints cs = element.getAnnotation(Constraints.class);
@@ -45,7 +60,7 @@ public class ConstraintHandler {
                     .name(nullIfBlank(c.value()))
                     .type(type)
                     .columns(fieldName != null ? List.of(fieldName) : List.of())
-                    .checkClause(checkExpr) // <- nullable
+                    .checkClause(checkExpr) // can be nullable
                     .build();
 
             if (c.onDelete() != OnDeleteAction.NO_ACTION) m.setOnDelete(c.onDelete());
@@ -55,6 +70,14 @@ public class ConstraintHandler {
         }
     }
 
+    /**
+     * Processes {@code @Constraint} and {@code @Constraints} annotations on a given {@link AttributeDescriptor}.
+     *
+     * @param attr The attribute descriptor to inspect for annotations.
+     * @param fieldName The name of the field associated with the constraint.
+     * @param constraints The list to which the created {@link ConstraintModel}s will be added.
+     * @param tableName The name of the table for the constraint.
+     */
     public void processConstraints(AttributeDescriptor attr, String fieldName, List<ConstraintModel> constraints, String tableName) {
         Constraint c1 = attr.getAnnotation(Constraint.class);
         Constraints cs = attr.getAnnotation(Constraints.class);
@@ -78,7 +101,7 @@ public class ConstraintHandler {
                     .name(nullIfBlank(c.value()))
                     .type(type)
                     .columns(List.of(fieldName))
-                    .checkClause(checkExpr) // <- nullable
+                    .checkClause(checkExpr) // can be nullable
                     .build();
 
             if (c.onDelete() != OnDeleteAction.NO_ACTION) m.setOnDelete(c.onDelete());

--- a/jinx-processor/src/main/java/org/jinx/handler/ElementCollectionHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/ElementCollectionHandler.java
@@ -31,6 +31,15 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+/**
+ * Handles the processing of {@code @ElementCollection} annotations.
+ *
+ * <p>This handler is responsible for creating a separate collection table for a persistent
+ * collection of basic types or embeddable classes. It follows a two-phase
+ * validate-then-commit pattern to ensure that the collection table and its components
+ * (foreign keys, primary keys, value columns, map key columns, order columns) are only
+ * added to the schema model if all configurations are valid.
+ */
 public class ElementCollectionHandler {
 
     private final ProcessingContext context;
@@ -40,7 +49,7 @@ public class ElementCollectionHandler {
     private final Elements elementUtils;
 
     /**
-     * 2단계 검증→커밋 패턴을 위한 검증 결과를 담는 내부 클래스
+     * Inner class to hold validation results for the two-phase validate-then-commit pattern.
      */
     private static class ValidationResult {
         private final List<String> errors = new ArrayList<>();
@@ -49,7 +58,7 @@ public class ElementCollectionHandler {
         private final List<IndexModel> pendingIndexes = new ArrayList<>();
         private final List<ConstraintModel> pendingConstraints = new ArrayList<>();
         private EntityModel collectionEntity;
-        private boolean committed = false; // 재진입 방지 플래그
+        private boolean committed = false; // Flag to prevent re-entry
 
         public void addError(String error) {
             errors.add(error);
@@ -88,12 +97,13 @@ public class ElementCollectionHandler {
         }
 
         /**
-         * 컬럼명 중복 검증 - FK, Map Key, Value, Order 컬럼 간 충돌 체크 + 기존 컬럼과의 충돌
+         * Validates for duplicate column names, checking for conflicts between FK, Map Key, Value, and Order columns,
+         * as well as with existing columns.
          */
         private void validateColumnNameDuplicates() {
             Set<String> columnNames = new HashSet<>();
             
-            // 이미 collectionEntity에 존재하는 컬럼과의 충돌도 포함 (Embeddable 경로 등)
+            // Also includes conflicts with columns already present in the collectionEntity (e.g., from Embeddable paths).
             if (collectionEntity != null && collectionEntity.getColumns() != null) {
                 for (ColumnModel existing : collectionEntity.getColumns().values()) {
                     if (existing.getColumnName() != null) {
@@ -103,7 +113,7 @@ public class ElementCollectionHandler {
                 }
             }
             
-            // 대기 중인 컬럼들 검증
+            // Validate pending columns.
             for (ColumnModel column : pendingColumns) {
                 String columnName = column.getColumnName();
                 if (columnName == null || columnName.isBlank()) {
@@ -120,12 +130,13 @@ public class ElementCollectionHandler {
         }
 
         /**
-         * 제약명 중복 검증 - 관계(FK) 제약명 충돌 체크 + 기존 관계와의 충돌
+         * Validates for duplicate constraint names, checking for conflicts with relationship (FK) constraints
+         * and existing constraints.
          */
         private void validateConstraintNameDuplicates() {
             Set<String> constraintNames = new HashSet<>();
             
-            // 이미 collectionEntity에 존재하는 관계와의 충돌도 포함 (Embeddable/다른 경로 등)
+            // Also includes conflicts with relationships already present in the collectionEntity (e.g., from Embeddable or other paths).
             if (collectionEntity != null && collectionEntity.getRelationships() != null) {
                 for (RelationshipModel existing : collectionEntity.getRelationships().values()) {
                     if (existing.getConstraintName() != null && !existing.getConstraintName().trim().isEmpty()) {
@@ -135,7 +146,7 @@ public class ElementCollectionHandler {
                 }
             }
             
-            // 대기 중인 관계들 검증
+            // Validate pending relationships.
             for (RelationshipModel relationship : pendingRelationships) {
                 String constraintName = relationship.getConstraintName();
                 if (constraintName == null || constraintName.trim().isEmpty()) {
@@ -143,7 +154,7 @@ public class ElementCollectionHandler {
                     continue;
                 }
                 
-                // 대소문자 구분 없는 중복 검증 (DB는 보통 대소문자 구분 안 함)
+                // Case-insensitive duplicate check (databases are often case-insensitive).
                 String normalizedName = constraintName.trim().toLowerCase(java.util.Locale.ROOT);
                 if (!constraintNames.add(normalizedName)) {
                     addError("Duplicate constraint name in collection table: " + constraintName);
@@ -152,7 +163,7 @@ public class ElementCollectionHandler {
         }
 
         /**
-         * 최종 중복 검증 수행 (validate 단계 말미에서 호출)
+         * Performs final duplication validation (called at the end of the validation phase).
          */
         public void performFinalValidation() {
             validateColumnNameDuplicates();
@@ -162,13 +173,13 @@ public class ElementCollectionHandler {
         }
 
         /**
-         * 인덱스/제약조건 중복 검증 - 이름 중복과 의미 중복 모두 체크
+         * Validates for duplicate indexes/constraints, checking for both name and semantic duplication.
          */
         private void validateIndexAndConstraintDuplicates() {
-            // 이름 중복 검증 (대소문자 무시)
+            // Name duplication check (case-insensitive).
             Set<String> names = new HashSet<>();
             
-            // 기존 인덱스/제약조건 이름 수집
+            // Collect existing index/constraint names.
             if (collectionEntity != null) {
                 if (collectionEntity.getIndexes() != null) {
                     for (IndexModel existing : collectionEntity.getIndexes().values()) {
@@ -186,7 +197,7 @@ public class ElementCollectionHandler {
                 }
             }
             
-            // 대기 중인 인덱스 이름 중복 검증
+            // Validate pending index name duplicates.
             for (IndexModel ix : pendingIndexes) {
                 String k = ix.getIndexName().toLowerCase(java.util.Locale.ROOT);
                 if (!names.add(k)) {
@@ -194,7 +205,7 @@ public class ElementCollectionHandler {
                 }
             }
             
-            // 대기 중인 제약조건 이름 중복 검증
+            // Validate pending constraint name duplicates.
             for (ConstraintModel c : pendingConstraints) {
                 String k = c.getName().toLowerCase(java.util.Locale.ROOT);
                 if (!names.add(k)) {
@@ -202,7 +213,7 @@ public class ElementCollectionHandler {
                 }
             }
             
-            // 의미 중복 검증 (동일 테이블+컬럼셋+유형)
+            // Semantic duplication check (same table + column set + type).
             Set<String> shapes = new HashSet<>();
 
             if (collectionEntity != null && collectionEntity.getConstraints() != null) {
@@ -228,19 +239,19 @@ public class ElementCollectionHandler {
         }
 
         /**
-         * 인덱스/제약조건이 참조하는 컬럼 존재성 검증
+         * Validates that columns referenced by indexes/constraints exist.
          */
         private void validateIndexAndConstraintColumnsExist() {
             Set<String> cols = new HashSet<>();
             
-            // 대기 중인 컬럼들 수집
+            // Collect pending columns.
             for (ColumnModel cm : pendingColumns) {
                 if (cm.getColumnName() != null) {
                     cols.add(cm.getColumnName().toLowerCase(java.util.Locale.ROOT));
                 }
             }
             
-            // 기존 컬럼들도 포함 (임베디드 선반영 등)
+            // Also include existing columns (e.g., pre-applied from embeddables).
             if (collectionEntity != null && collectionEntity.getColumns() != null) {
                 for (ColumnModel cm : collectionEntity.getColumns().values()) {
                     if (cm.getColumnName() != null) {
@@ -249,7 +260,7 @@ public class ElementCollectionHandler {
                 }
             }
             
-            // 인덱스가 참조하는 컬럼 검증
+            // Validate columns referenced by indexes.
             for (IndexModel ix : pendingIndexes) {
                 for (String colName : ix.getColumnNames()) {
                     if (!cols.contains(colName.toLowerCase(java.util.Locale.ROOT))) {
@@ -258,7 +269,7 @@ public class ElementCollectionHandler {
                 }
             }
             
-            // 제약조건이 참조하는 컬럼 검증
+            // Validate columns referenced by constraints.
             for (ConstraintModel c : pendingConstraints) {
                 for (String colName : c.getColumns()) {
                     if (!cols.contains(colName.toLowerCase(java.util.Locale.ROOT))) {
@@ -269,46 +280,46 @@ public class ElementCollectionHandler {
         }
 
         /**
-         * 순수 커밋 - 예외 없이 모델에 반영만 수행 (재진입 방지)
+         * Pure commit - applies changes to the model without exceptions (prevents re-entry).
          */
         public void commitToModel() {
-            // 재진입 방지: 이미 커밋된 경우 무시
+            // Re-entry prevention: ignore if already committed.
             if (committed) {
                 return;
             }
             
-            // 검증 완료 상태에서만 호출되므로 예외 없음
-            // 컬럼 → 인덱스 → 제약 → 관계 순으로 커밋
+            // No exceptions, as this is only called in a validated state.
+            // Commit in the order: columns -> indexes -> constraints -> relationships.
             
-            // 모든 컬럼을 일괄 추가
+            // Add all columns in bulk.
             for (ColumnModel column : pendingColumns) {
                 collectionEntity.putColumn(column);
             }
             
-            // 모든 인덱스를 일괄 추가
+            // Add all indexes in bulk.
             for (IndexModel ix : pendingIndexes) {
                 collectionEntity.getIndexes().put(ix.getIndexName(), ix);
             }
             
-            // 모든 제약조건을 일괄 추가
+            // Add all constraints in bulk.
             for (ConstraintModel c : pendingConstraints) {
                 String key = ConstraintShapes.shapeKey(c);
                 collectionEntity.getConstraints().put(key, c);
             }
 
-            // 모든 관계를 일괄 추가
+            // Add all relationships in bulk.
             for (RelationshipModel relationship : pendingRelationships) {
                 collectionEntity.getRelationships().put(relationship.getConstraintName(), relationship);
             }
             
-            // 커밋 완료 플래그 설정
+            // Set the commit completion flag.
             committed = true;
         }
     }
 
     /**
-     * TypeMirror 기반의 synthetic AttributeDescriptor 구현
-     * @Embeddable 값 타입을 EmbeddedHandler에 전달할 때 사용
+     * A synthetic AttributeDescriptor implementation based on a TypeMirror.
+     * Used to pass @Embeddable value types to the EmbeddedHandler.
      */
     private static class SyntheticTypeAttributeDescriptor implements AttributeDescriptor {
         private final String name;
@@ -376,24 +387,29 @@ public class ElementCollectionHandler {
         processElementCollection(fieldDescriptor, ownerEntity);
     }
 
-    // Main AttributeDescriptor-based method for @ElementCollection processing
+    /**
+     * Main entry point for processing an {@code @ElementCollection} attribute.
+     *
+     * @param attribute The descriptor for the attribute annotated with @ElementCollection.
+     * @param ownerEntity The model of the entity that owns the collection.
+     */
     public void processElementCollection(AttributeDescriptor attribute, EntityModel ownerEntity) {
-        // ========== 1단계: 검증 (메모리 상에서만 생성) ==========
+        // ========== Phase 1: Validation (in-memory creation only) ==========
         ValidationResult validation = validateElementCollection(attribute, ownerEntity);
 
-        // ========== 2단계: 커밋 (오류 없을 경우만) ==========
+        // ========== Phase 2: Commit (only if there are no errors) ==========
         if (validation.hasErrors()) {
-            // 모든 검증 오류를 APT 메시지로 출력
+            // Print all validation errors as APT messages.
             for (String error : validation.getErrors()) {
                 context.getMessager().printMessage(Diagnostic.Kind.ERROR, error, attribute.elementForDiagnostics());
             }
-            return; // 부분 생성 없이 완전 롤백
+            return; // Full rollback without partial creation.
         }
 
-        // 검증 성공: 모델에 일괄 커밋 (예외 없음, 순수 커밋)
+        // Validation successful: commit to the model in bulk (no exceptions, pure commit).
         validation.commitToModel();
         
-        // 완성된 컬렉션 테이블 모델을 스키마에 등록
+        // Register the completed collection table model with the schema.
         context.getSchemaModel().getEntities().putIfAbsent(
             validation.collectionEntity.getEntityName(), 
             validation.collectionEntity
@@ -401,12 +417,12 @@ public class ElementCollectionHandler {
     }
 
     /**
-     * 1단계: 검증 단계 - 모든 컬렉션 구성요소를 메모리상에서만 생성하고 검증
+     * Phase 1: Validation - Creates and validates all collection components in memory only.
      */
     private ValidationResult validateElementCollection(AttributeDescriptor attribute, EntityModel ownerEntity) {
         ValidationResult result = new ValidationResult();
 
-        // 0. 기본 값 null/blank 검증 - NPE 방어
+        // 0. Basic null/blank validation to prevent NPEs.
         if (ownerEntity.getTableName() == null || ownerEntity.getTableName().isBlank()) {
             result.addError("Owner entity has no tableName; cannot derive collection table name for @ElementCollection on " + attribute.name());
             return result;
@@ -416,7 +432,7 @@ public class ElementCollectionHandler {
             return result;
         }
 
-        // 1. 컬렉션 테이블 이름 결정 및 새 EntityModel 생성
+        // 1. Determine the collection table name and create a new EntityModel.
         String defaultTableName = ownerEntity.getTableName() + "_" + attribute.name();
 
         CollectionTable collectionTable = attribute.getAnnotation(CollectionTable.class);
@@ -425,13 +441,13 @@ public class ElementCollectionHandler {
                 : defaultTableName;
 
         EntityModel collectionEntity = EntityModel.builder()
-                .entityName(tableName) // 테이블 이름을 고유 식별자로 사용
+                .entityName(tableName) // Use table name as a unique identifier
                 .tableName(tableName)
                 .tableType(EntityModel.TableType.COLLECTION_TABLE)
                 .build();
         result.setCollectionEntity(collectionEntity);
 
-        // 1-1. @CollectionTable의 indexes/uniqueConstraints 반영
+        // 1-1. Apply indexes/uniqueConstraints from @CollectionTable.
         if (collectionTable != null) {
             var adapter = new org.jinx.handler.builtins.CollectionTableAdapter(collectionTable, context, tableName);
             
@@ -443,7 +459,7 @@ public class ElementCollectionHandler {
             }
         }
 
-        // 2. 컬렉션의 제네릭 타입 분석 (Map vs Collection) - FK 생성 전 검증
+        // 2. Analyze the collection's generic type (Map vs. Collection) - validation before FK creation.
         TypeMirror attributeType = attribute.type();
         if (!(attributeType instanceof DeclaredType declaredType)) {
             result.addError("Cannot determine collection type for @ElementCollection");
@@ -465,14 +481,14 @@ public class ElementCollectionHandler {
             return result;
         }
 
-        // 3. 소유자 엔티티의 PK 정보 수집
+        // 3. Collect the owner entity's PK information.
         List<ColumnModel> ownerPkColumns = context.findAllPrimaryKeyColumns(ownerEntity);
         if (ownerPkColumns.isEmpty()) {
             result.addError("Owner entity " + ownerEntity.getEntityName() + " must have a primary key for @ElementCollection");
             return result;
         }
 
-        // 4. @CollectionTable의 joinColumns 설정 또는 기본값으로 FK 컬럼 생성
+        // 4. Configure joinColumns from @CollectionTable or create FK columns with default values.
         JoinColumn[] joinColumns = (collectionTable != null) ? collectionTable.joinColumns() : new JoinColumn[0];
 
         if (joinColumns.length > 0 && joinColumns.length != ownerPkColumns.size()) {
@@ -481,7 +497,7 @@ public class ElementCollectionHandler {
             return result;
         }
 
-        // FK 컬럼들 생성 (referencedColumnName 우선 매핑) - 메모리상에서만 생성
+        // Create FK columns (prioritizing referencedColumnName mapping) - in-memory only.
         java.util.List<String> fkColumnNames = new java.util.ArrayList<>();
         java.util.Map<String, ColumnModel> ownerPkByName = new java.util.HashMap<>();
         for (ColumnModel pk : ownerPkColumns) ownerPkByName.put(pk.getColumnName(), pk);
@@ -504,28 +520,28 @@ public class ElementCollectionHandler {
                     .columnName(fkColumnName)
                     .tableName(tableName)
                     .javaType(ownerPkCol.getJavaType())
-                    .isPrimaryKey(true) // 컬렉션 테이블에서는 FK가 PK의 일부가 됨
+                    .isPrimaryKey(true) // In a collection table, the FK is part of the PK
                     .isNullable(false)
                     .build();
-            result.addColumn(fkColumn); // 즉시 putColumn 대신 검증 결과에 추가
+            result.addColumn(fkColumn); // Add to validation results instead of calling putColumn immediately
             fkColumnNames.add(fkColumnName);
         }
 
-        // 5. Map Key 컬럼 처리 - 메모리상에서만 생성
+        // 5. Process Map Key columns - in-memory only.
         if (isMap) {
-            // @MapKeyClass나 @MapKey에 의해 키 타입이 재정의될 수 있음
+            // The key type can be overridden by @MapKeyClass or @MapKey.
             TypeMirror actualKeyType = resolveMapKeyType(attribute, keyType);
             
             if (actualKeyType != null) {
-                // 키 타입이 엔티티인지 확인
+                // Check if the key type is an entity.
                 Element keyElement = context.getTypeUtils().asElement(actualKeyType);
                 boolean isEntityKey = keyElement != null && keyElement.getAnnotation(Entity.class) != null;
                 
                 if (isEntityKey) {
-                    // @MapKeyJoinColumn(s)로 엔티티 키 처리
+                    // Process entity keys with @MapKeyJoinColumn(s).
                     processMapKeyJoinColumns(attribute, actualKeyType, tableName, result);
                 } else {
-                    // 기본 타입 키 처리 (@MapKeyColumn)
+                    // Process basic type keys (@MapKeyColumn).
                     MapKeyColumn mapKeyColumn = attribute.getAnnotation(MapKeyColumn.class);
                     String mapKeyColumnName = (mapKeyColumn != null && !mapKeyColumn.name().isEmpty())
                             ? mapKeyColumn.name()
@@ -537,10 +553,10 @@ public class ElementCollectionHandler {
                         keyColumn.setMapKey(true);
                         keyColumn.setNullable(false);
 
-                        // @MapKeyColumn 메타데이터 반영 (PK 규칙 우선)
+                        // Apply @MapKeyColumn metadata (PK rules take precedence).
                         if (mapKeyColumn != null) {
-                            keyColumn.setNullable(false); // PK는 항상 NOT NULL (nullable 요청 무시)
-                            if (mapKeyColumn.length() != 255) { // 기본값이 아닌 경우만
+                            keyColumn.setNullable(false); // PK is always NOT NULL (ignore nullable request).
+                            if (mapKeyColumn.length() != 255) { // Only if it's not the default value.
                                 keyColumn.setLength(mapKeyColumn.length());
                             }
                             if (mapKeyColumn.precision() != 0) {
@@ -554,31 +570,31 @@ public class ElementCollectionHandler {
                             }
                         }
 
-                        // Map Key 특수 어노테이션 처리
+                        // Process special Map Key annotations.
                         processMapKeyAnnotations(attribute, keyColumn, actualKeyType);
 
-                        result.addColumn(keyColumn); // 즉시 putColumn 대신 검증 결과에 추가
+                        result.addColumn(keyColumn); // Add to validation results instead of calling putColumn immediately
                     }
                 }
             }
         }
 
-        // 6. Element (Value) 컬럼 처리 - 메모리상에서만 생성
+        // 6. Process Element (Value) columns - in-memory only.
         boolean isList = context.isSubtype(declaredType, "java.util.List");
         
         Element valueElement = context.getTypeUtils().asElement(valueType);
         if (valueElement != null && valueElement.getAnnotation(Embeddable.class) != null) {
-            // 값이 Embeddable 타입인 경우 - 현재는 임시 EntityModel에 직접 추가
-            // TODO: EmbeddedHandler도 2단계 패턴으로 변경 후 검증 결과 통합 필요
+            // If the value is an Embeddable type - currently added directly to the temporary EntityModel.
+            // TODO: After changing EmbeddedHandler to a two-phase pattern, validation results need to be integrated.
             AttributeDescriptor valueAttribute = new SyntheticTypeAttributeDescriptor(
-                attribute.name() + "_value",   // 적절한 진단용/로깅용 이름
-                valueType,                     // DeclaredType 등 실제 값 타입
+                attribute.name() + "_value",   // Appropriate name for diagnostics/logging.
+                valueType,                     // The actual value type, such as DeclaredType.
                 attribute.elementForDiagnostics()
             );
             embeddedHandler.processEmbedded(valueAttribute, collectionEntity, new HashSet<>());
-            // TODO: Embeddable 필드들의 PK 승격 처리 필요 (Set의 경우)
+            // TODO: PK promotion for Embeddable fields needs to be handled (for Sets).
         } else {
-            // 값이 기본 타입인 경우
+            // If the value is a basic type.
             Column columnAnnotation = attribute.getAnnotation(Column.class);
             String elementColumnName = (columnAnnotation != null && !columnAnnotation.name().isEmpty())
                     ? columnAnnotation.name()
@@ -586,14 +602,14 @@ public class ElementCollectionHandler {
 
             ColumnModel elementColumn = ColumnBuilderFactory.fromType(valueType, elementColumnName, tableName);
             if (elementColumn != null) {
-                boolean isSetPk = !isList && !isMap; // Set/Collection의 값은 PK에 포함
+                boolean isSetPk = !isList && !isMap; // The value in a Set/Collection is part of the PK.
                 elementColumn.setPrimaryKey(isSetPk);
                 if (isSetPk) elementColumn.setNullable(false);
-                result.addColumn(elementColumn); // 즉시 putColumn 대신 검증 결과에 추가
+                result.addColumn(elementColumn); // Add to validation results instead of calling putColumn immediately
             }
         }
 
-        // 7. @OrderColumn 처리 (List인 경우) - 메모리상에서만 생성
+        // 7. Process @OrderColumn (for Lists) - in-memory only.
         if (isList) {
             OrderColumn orderColumn = attribute.getAnnotation(OrderColumn.class);
             if (orderColumn != null) {
@@ -605,13 +621,13 @@ public class ElementCollectionHandler {
                         .tableName(tableName)
                         .javaType("java.lang.Integer")
                         .isPrimaryKey(true)            // (owner PK + order) = PK
-                        .isNullable(false)             // PK는 NULL 불가
+                        .isNullable(false)             // PK cannot be NULL.
                         .build();
-                result.addColumn(orderCol); // 즉시 putColumn 대신 검증 결과에 추가
+                result.addColumn(orderCol); // Add to validation results instead of calling putColumn immediately
             }
         }
 
-        // 8. 외래 키 관계 모델 생성 - 메모리상에서만 생성
+        // 8. Create foreign key relationship model - in-memory only.
         List<String> ownerPkNames = ownerPkColumns.stream().map(ColumnModel::getColumnName).toList();
 
         RelationshipModel fkRelationship = RelationshipModel.builder()
@@ -624,25 +640,25 @@ public class ElementCollectionHandler {
                 .build();
         result.addRelationship(fkRelationship);
 
-        // 9. 최종 중복 검증 (임베디드로 선반영된 컬럼/관계 포함)
+        // 9. Final duplication validation (including pre-applied columns/relationships from embeddables).
         result.performFinalValidation();
         
         return result;
     }
 
     /**
-     * Map 키가 엔티티인 경우 @MapKeyJoinColumn(s) 처리
+     * Processes @MapKeyJoinColumn(s) when the map key is an entity.
      */
     private void processMapKeyJoinColumns(AttributeDescriptor attribute, TypeMirror keyType, 
                                         String tableName, ValidationResult result) {
-        // 키 엔티티의 PK 컬럼들 조회
+        // Look up the key entity's PK columns.
         Element keyElement = context.getTypeUtils().asElement(keyType);
         if (keyElement == null || !(keyElement instanceof TypeElement keyTypeElement)) {
             result.addError("Cannot resolve key entity type for @MapKeyJoinColumn");
             return;
         }
 
-        // 키 엔티티의 EntityModel을 스키마에서 찾아서 PK 컬럼들 수집 (FQCN 사용)
+        // Find the key entity's EntityModel in the schema and collect its PK columns (using FQCN).
         String keyFqcn = keyTypeElement.getQualifiedName().toString();
         EntityModel keyEntity = context.getSchemaModel().getEntities().get(keyFqcn);
         if (keyEntity == null) {
@@ -656,7 +672,7 @@ public class ElementCollectionHandler {
             return;
         }
 
-        // @MapKeyJoinColumn(s) 어노테이션 처리
+        // Process @MapKeyJoinColumn(s) annotations.
         MapKeyJoinColumn[] mapKeyJoinColumns = getMapKeyJoinColumns(attribute);
         
         if (mapKeyJoinColumns.length > 0 && mapKeyJoinColumns.length != keyPkColumns.size()) {
@@ -665,7 +681,7 @@ public class ElementCollectionHandler {
             return;
         }
 
-        // 키 FK 컬럼들 생성 (이름 목록과 동시에 수집)
+        // Create key FK columns (collecting names at the same time).
         Map<String, ColumnModel> keyPkByName = new HashMap<>();
         for (ColumnModel pk : keyPkColumns) {
             keyPkByName.put(pk.getColumnName(), pk);
@@ -683,14 +699,14 @@ public class ElementCollectionHandler {
                     result.addError("MapKeyJoinColumn.referencedColumnName not found in key entity PKs: " + mkjc.referencedColumnName());
                     return;
                 }
-                // 중복 referencedColumnName 검출
+                // Detect duplicate referencedColumnName.
                 if (!usedReferencedColumns.add(keyPkCol.getColumnName())) {
                     result.addError("Duplicate MapKeyJoinColumn.referencedColumnName: " + keyPkCol.getColumnName());
                     return;
                 }
             } else {
                 keyPkCol = keyPkColumns.get(i);
-                // 기본 매핑에서도 중복 방지
+                // Prevent duplicates in default mapping as well.
                 if (!usedReferencedColumns.add(keyPkCol.getColumnName())) {
                     result.addError("Duplicate key PK column reference: " + keyPkCol.getColumnName());
                     return;
@@ -705,18 +721,18 @@ public class ElementCollectionHandler {
                     .columnName(keyFkColumnName)
                     .tableName(tableName)
                     .javaType(keyPkCol.getJavaType())
-                    .isPrimaryKey(true)  // Map 키 FK는 컬렉션 테이블 PK의 일부
+                    .isPrimaryKey(true)  // The Map key FK is part of the collection table's PK
                     .isNullable(false)
                     .isMapKey(true)
                     .build();
             
             result.addColumn(keyFkColumn);
-            keyFkColumnNames.add(keyFkColumnName);  // 생성한 이름을 즉시 리스트에 추가
+            keyFkColumnNames.add(keyFkColumnName);  // Immediately add the created name to the list.
         }
 
         List<String> keyPkColumnNames = keyPkColumns.stream().map(ColumnModel::getColumnName).toList();
         RelationshipModel keyRelationship = RelationshipModel.builder()
-                .type(RelationshipType.ELEMENT_COLLECTION)  // Map key FK도 ElementCollection의 일부
+                .type(RelationshipType.ELEMENT_COLLECTION)  // The Map key FK is also part of the ElementCollection.
                 .tableName(tableName)
                 .columns(keyFkColumnNames)
                 .referencedTable(keyEntity.getTableName())
@@ -729,10 +745,10 @@ public class ElementCollectionHandler {
     }
 
     /**
-     * @MapKeyClass, @MapKey 어노테이션을 고려하여 실제 Map 키 타입을 결정
+     * Determines the actual Map key type, considering @MapKeyClass and @MapKey annotations.
      */
     private TypeMirror resolveMapKeyType(AttributeDescriptor attribute, TypeMirror defaultKeyType) {
-        // 1) @MapKeyClass 우선순위가 높음
+        // 1) @MapKeyClass has higher priority.
         MapKeyClass mapKeyClass = attribute.getAnnotation(MapKeyClass.class);
         if (mapKeyClass != null) {
             TypeElement keyClassElement = classValToTypeElement(() -> mapKeyClass.value());
@@ -741,31 +757,31 @@ public class ElementCollectionHandler {
             }
         }
         
-        // 2) @MapKey는 특별한 처리 (키 필드명 지정)
+        // 2) @MapKey requires special handling (specifies the key field name).
         MapKey mapKey = attribute.getAnnotation(MapKey.class);
         if (mapKey != null && !mapKey.name().isEmpty()) {
-            // @MapKey(name="fieldName")은 값 엔티티의 특정 필드를 키로 사용
-            // 여기서는 타입 정보만 필요하므로 defaultKeyType 반환
-            // 실제 컬럼명은 processMapKeyAnnotations에서 처리
+            // @MapKey(name="fieldName") uses a specific field of the value entity as the key.
+            // Only type information is needed here, so return defaultKeyType.
+            // The actual column name is handled in processMapKeyAnnotations.
             return defaultKeyType;
         }
         
-        // 3) 기본값 사용 (제네릭 타입 인자)
+        // 3) Use the default value (generic type argument).
         return defaultKeyType;
     }
     
     /**
-     * Map Key 관련 어노테이션들을 처리하여 ColumnModel 설정
+     * Processes Map Key related annotations to configure the ColumnModel.
      */
     private void processMapKeyAnnotations(AttributeDescriptor attribute, ColumnModel keyColumn, TypeMirror keyType) {
-        // @MapKey 처리 - 키 필드명 지정
+        // Process @MapKey - specifies the key field name.
         MapKey mapKey = attribute.getAnnotation(MapKey.class);
         if (mapKey != null && !mapKey.name().isEmpty()) {
-            // @MapKey(name="fieldName")의 경우 컬럼명을 해당 필드명으로 재설정
+            // For @MapKey(name="fieldName"), reset the column name to the specified field name.
             keyColumn.setColumnName(mapKey.name());
         }
         
-        // @MapKeyEnumerated 처리
+        // Process @MapKeyEnumerated.
         MapKeyEnumerated mapKeyEnumerated = attribute.getAnnotation(MapKeyEnumerated.class);
         if (mapKeyEnumerated != null) {
             keyColumn.setEnumStringMapping(mapKeyEnumerated.value() == EnumType.STRING);
@@ -774,7 +790,7 @@ public class ElementCollectionHandler {
             }
         }
 
-        // @MapKeyTemporal 처리
+        // Process @MapKeyTemporal.
         MapKeyTemporal mapKeyTemporal = attribute.getAnnotation(MapKeyTemporal.class);
         if (mapKeyTemporal != null) {
             keyColumn.setTemporalType(mapKeyTemporal.value());
@@ -782,7 +798,7 @@ public class ElementCollectionHandler {
     }
 
     /**
-     * @MapKeyJoinColumn 또는 @MapKeyJoinColumns 어노테이션에서 배열 추출
+     * Extracts an array from @MapKeyJoinColumn or @MapKeyJoinColumns annotations.
      */
     private MapKeyJoinColumn[] getMapKeyJoinColumns(AttributeDescriptor attribute) {
         MapKeyJoinColumns mapKeyJoinColumns = attribute.getAnnotation(MapKeyJoinColumns.class);
@@ -799,8 +815,8 @@ public class ElementCollectionHandler {
     }
     
     /**
-     * 클래스값(annotation)에서 TypeElement를 안전하게 추출합니다.
-     * APT 환경에서 MirroredTypeException을 적절히 처리합니다.
+     * Safely extracts a TypeElement from a class value in an annotation.
+     * Properly handles MirroredTypeException in an APT environment.
      */
     private TypeElement classValToTypeElement(java.util.function.Supplier<Class<?>> getter) {
         try {

--- a/jinx-processor/src/main/java/org/jinx/handler/SequenceHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/SequenceHandler.java
@@ -11,6 +11,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Handles the processing of {@link SequenceGenerator} annotations.
+ * <p>
+ * This handler discovers {@code @SequenceGenerator} and {@code @SequenceGenerators}
+ * annotations at the class level and registers them as {@link SequenceModel} instances
+ * in the global schema model.
+ */
 public class SequenceHandler {
     private final ProcessingContext context;
 
@@ -18,7 +25,11 @@ public class SequenceHandler {
         this.context = context;
     }
 
-    // 클래스 레벨의 @SequenceGenerator와 @SequenceGenerators 처리
+    /**
+     * Processes class-level {@code @SequenceGenerator} and {@code @SequenceGenerators} annotations.
+     *
+     * @param typeElement The TypeElement of the class to process.
+     */
     public void processSequenceGenerators(TypeElement typeElement) {
         List<SequenceGenerator> sequenceGenerators = new ArrayList<>();
         SequenceGenerator single = typeElement.getAnnotation(SequenceGenerator.class);
@@ -31,7 +42,12 @@ public class SequenceHandler {
         }
     }
 
-    // 단일 @SequenceGenerator 처리 공통 메서드
+    /**
+     * Common method to process a single {@code @SequenceGenerator} annotation.
+     *
+     * @param sg The SequenceGenerator annotation instance.
+     * @param element The element on which the annotation was found, for error reporting.
+     */
     public void processSingleGenerator(SequenceGenerator sg, Element element) {
         if (sg.name().isBlank()) {
             context.getMessager().printMessage(javax.tools.Diagnostic.Kind.ERROR,
@@ -39,7 +55,7 @@ public class SequenceHandler {
             return;
         }
         if (context.getSchemaModel().getSequences().containsKey(sg.name())) {
-            // 중복 시 조용히 넘어갈까..?
+            // Ignore if already registered.
             return;
         }
         context.getSchemaModel().getSequences().computeIfAbsent(sg.name(), key ->

--- a/jinx-processor/src/main/java/org/jinx/handler/TableGeneratorHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/TableGeneratorHandler.java
@@ -11,6 +11,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Handles the processing of {@link TableGenerator} annotations.
+ * <p>
+ * This handler discovers {@code @TableGenerator} and {@code @TableGenerators}
+ * annotations at the class level and registers them as {@link TableGeneratorModel} instances
+ * in the global schema model.
+ */
 public class TableGeneratorHandler {
     private final ProcessingContext context;
 
@@ -18,7 +25,11 @@ public class TableGeneratorHandler {
         this.context = context;
     }
 
-    // 클래스 레벨의 @TableGenerator와 @TableGenerators 처리
+    /**
+     * Processes class-level {@code @TableGenerator} and {@code @TableGenerators} annotations.
+     *
+     * @param typeElement The TypeElement of the class to process.
+     */
     public void processTableGenerators(TypeElement typeElement) {
         List<TableGenerator> tableGenerators = new ArrayList<>();
         TableGenerator single = typeElement.getAnnotation(TableGenerator.class);
@@ -31,7 +42,12 @@ public class TableGeneratorHandler {
         }
     }
 
-    // 단일 @TableGenerator 처리 공통 메서드
+    /**
+     * Common method to process a single {@code @TableGenerator} annotation.
+     *
+     * @param tg The TableGenerator annotation instance.
+     * @param element The element on which the annotation was found, for error reporting.
+     */
     public void processSingleGenerator(TableGenerator tg, Element element) {
         if (tg.name().isBlank()) {
             context.getMessager().printMessage(javax.tools.Diagnostic.Kind.ERROR,
@@ -39,7 +55,8 @@ public class TableGeneratorHandler {
             return;
         }
         if (context.getSchemaModel().getTableGenerators().containsKey(tg.name())) {
-            return;  // 중복 시 무시
+            // Ignore if duplicate.
+            return;
         }
         context.getSchemaModel().getTableGenerators().computeIfAbsent(tg.name(), key ->
                 TableGeneratorModel.builder()

--- a/jinx-processor/src/main/java/org/jinx/handler/builtins/CollectionElementResolver.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/builtins/CollectionElementResolver.java
@@ -10,6 +10,9 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 import java.util.Map;
 
+/**
+ * A {@link org.jinx.handler.ColumnResolver} for basic type elements within an {@code @ElementCollection}.
+ */
 public class CollectionElementResolver extends AbstractColumnResolver {
 
     public CollectionElementResolver(ProcessingContext context) {
@@ -22,7 +25,7 @@ public class CollectionElementResolver extends AbstractColumnResolver {
         ColumnModel.ColumnModelBuilder builder = ColumnModel.builder()
                 .columnName(columnName)
                 .javaType(type.toString())
-                .isPrimaryKey(false) // 컬렉션 요소는 기본적으로 PK가 아님
+                .isPrimaryKey(false) // Collection elements are not part of the primary key by default.
                 .isNullable(column == null || column.nullable())
                 .length(column != null ? column.length() : 255)
                 .precision(column != null ? column.precision() : 0)

--- a/jinx-processor/src/main/java/org/jinx/handler/builtins/CollectionTableAdapter.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/builtins/CollectionTableAdapter.java
@@ -1,6 +1,5 @@
 package org.jinx.handler.builtins;
 
-import jakarta.persistence.CheckConstraint;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Index;
 import jakarta.persistence.UniqueConstraint;
@@ -15,6 +14,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * An adapter that wraps a {@link CollectionTable} annotation to expose its properties
+ * through the {@link TableLike} interface.
+ */
 public class CollectionTableAdapter implements TableLike {
     private final CollectionTable collectionTable;
     private final ProcessingContext context;
@@ -38,7 +41,7 @@ public class CollectionTableAdapter implements TableLike {
         if (name.isEmpty()) {
             return (effectiveTableName != null && !effectiveTableName.isEmpty())
                    ? effectiveTableName
-                   : "_anonymous_collection_"; // 안전 폴백
+                   : "_anonymous_collection_"; // Safe fallback.
         }
         return name;
     }
@@ -57,18 +60,18 @@ public class CollectionTableAdapter implements TableLike {
     public List<IndexModel> getIndexes() {
         List<IndexModel> indexes = new ArrayList<>();
         for (Index index : collectionTable.indexes()) {
-            // 먼저 컬럼명을 트리밍하고 빈 토큰 제거
+            // First, trim column names and remove empty tokens.
             List<String> columnNames = Arrays.stream(index.columnList().split(","))
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
                 .toList();
             
-            // 빈 컬럼 리스트인 경우 건너뛰기
+            // Skip if the column list is empty.
             if (columnNames.isEmpty()) {
                 continue;
             }
             
-            // 트리밍된 컬럼 리스트로 인덱스명 생성
+            // Generate index name from the trimmed column list.
             String indexName = index.name().isEmpty()
                 ? context.getNaming().ixName(getName(), columnNames)
                 : index.name();
@@ -87,7 +90,7 @@ public class CollectionTableAdapter implements TableLike {
     public List<ConstraintModel> getConstraints() {
         List<ConstraintModel> constraints = new ArrayList<>();
         
-        // UniqueConstraints 처리
+        // Process UniqueConstraints.
         for (UniqueConstraint uc : collectionTable.uniqueConstraints()) {
             List<String> cols = Arrays.stream(uc.columnNames())
                 .map(String::trim)

--- a/jinx-processor/src/main/java/org/jinx/handler/relationship/InverseRelationshipProcessor.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/relationship/InverseRelationshipProcessor.java
@@ -81,18 +81,18 @@ public final class InverseRelationshipProcessor implements RelationshipProcessor
         TypeElement targetEntityElement = targetEntityElementOpt.get();
         String targetEntityName = targetEntityElement.getQualifiedName().toString();
 
-        // 대상 엔티티에서 mappedBy 속성이 존재하는지 확인합니다.
-        // 참고: 대상 엔티티가 아직 처리되지 않은 경우(지연 처리 시나리오) 유효성 검사를 생략합니다.
+        // Verify that the mappedBy attribute exists on the target entity
+        // Note: Skip validation if target entity hasn't been processed yet (deferred processing scenario)
         EntityModel targetEntityModel = context.getSchemaModel().getEntities().get(targetEntityName);
         if (targetEntityModel == null) {
-            // 대상 엔티티가 아직 처리되지 않음 - 지연 처리(deferred processing)에서는 정상적인 상황
-            // 유효성 검사는 조용히 건너뜁니다 (대상 엔티티가 준비된 이후 후속 단계에서 검증됨)
+            // Target entity not processed yet - this is normal in deferred processing
+            // Skip validation silently (will be validated in a later pass when target is ready)
             return;
         }
 
         AttributeDescriptor mappedByAttr = findMappedByAttribute(ownerEntity.getEntityName(), targetEntityName, mappedBy);
         if (mappedByAttr == null) {
-            // 대상 엔티티는 존재하지만 mappedBy 속성을 찾을 수 없는 경우 - 설정 오류
+            // Target entity exists but mappedBy attribute not found - this is a configuration error
             context.getMessager().printMessage(Diagnostic.Kind.WARNING,
                     "Cannot find mappedBy attribute '" + mappedBy + "' on target entity " + targetEntityName +
                             " for inverse @OneToMany. Relationship may be incomplete.", attr.elementForDiagnostics());
@@ -121,18 +121,18 @@ public final class InverseRelationshipProcessor implements RelationshipProcessor
         TypeElement targetEntityElement = targetEntityElementOpt.get();
         String targetEntityName = targetEntityElement.getQualifiedName().toString();
 
-        // 대상 엔티티에서 mappedBy 속성이 존재하는지 확인합니다.
-        // 참고: 대상 엔티티가 아직 처리되지 않은 경우(지연 처리 시나리오) 유효성 검사를 생략합니다.
+        // Verify that the mappedBy attribute exists on the target entity
+        // Note: Skip validation if target entity hasn't been processed yet (deferred processing scenario)
         EntityModel targetEntityModel = context.getSchemaModel().getEntities().get(targetEntityName);
         if (targetEntityModel == null) {
-            // 대상 엔티티가 아직 처리되지 않음 - 지연 처리(deferred processing)에서는 정상적인 상황입니다.
-            // 유효성 검사를 조용히 건너뜁니다 (대상 엔티티가 준비된 이후 후속 단계에서 검증됨)
+            // Target entity not processed yet - this is normal in deferred processing
+            // Skip validation silently (will be validated in a later pass when target is ready)
             return;
         }
 
         AttributeDescriptor mappedByAttr = findMappedByAttribute(ownerEntity.getEntityName(), targetEntityName, mappedBy);
         if (mappedByAttr == null) {
-            // 대상 엔티티는 존재하지만 mappedBy 속성을 찾을 수 없는 경우 - 설정 오류
+            // Target entity exists but mappedBy attribute not found - this is a configuration error
             context.getMessager().printMessage(Diagnostic.Kind.WARNING,
                     "Cannot find mappedBy attribute '" + mappedBy + "' on target entity " + targetEntityName +
                             " for inverse @ManyToMany. Relationship may be incomplete.", attr.elementForDiagnostics());
@@ -186,9 +186,9 @@ public final class InverseRelationshipProcessor implements RelationshipProcessor
     }
 
     /**
-     * AttributeDescriptorFactory.extractAttributeName()과 동일한 네이밍 규칙을 사용하여
-     * 대상 엔티티에서 대응되는 속성 디스크립터를 찾습니다.
-     * 캐싱(caching)과 순환 감지(cycle detection)을 지원합니다.
+     * Finds the corresponding attribute descriptor in the target entity
+     * using the same naming convention as AttributeDescriptorFactory.extractAttributeName()
+     * Supports caching and cycle detection
      */
     private AttributeDescriptor findMappedByAttribute(String ownerEntityName, String targetEntityName, String mappedByAttributeName) {
         // Check for infinite recursion

--- a/jinx-processor/src/main/java/org/jinx/handler/relationship/JoinTableDetails.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/relationship/JoinTableDetails.java
@@ -4,6 +4,19 @@ import org.jinx.model.EntityModel;
 
 import java.util.Map;
 
+/**
+ * Details for creating or validating a join table in many-to-many or one-to-many relationships
+ *
+ * @param joinTableName            the name of the join table
+ * @param ownerFkToPkMap          mapping from owner-side FK column names to owner entity PK column names
+ * @param inverseFkToPkMap        mapping from inverse-side FK column names to referenced entity PK column names
+ * @param ownerEntity             the owning entity model
+ * @param referencedEntity        the referenced (target) entity model
+ * @param ownerFkConstraintName   explicit FK constraint name for the owner side (null if not specified)
+ * @param inverseFkConstraintName explicit FK constraint name for the inverse side (null if not specified)
+ * @param ownerNoConstraint       true if owner-side FK should not create a database constraint
+ * @param inverseNoConstraint     true if inverse-side FK should not create a database constraint
+ */
 public record JoinTableDetails(
         String joinTableName,
         Map<String, String> ownerFkToPkMap,

--- a/jinx-processor/src/main/java/org/jinx/handler/relationship/ManyToManyOwningProcessor.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/relationship/ManyToManyOwningProcessor.java
@@ -61,7 +61,7 @@ public final class ManyToManyOwningProcessor implements RelationshipProcessor {
             return;
         }
 
-        // attr.isCollection()으로 이미 검증했으므로 중복 Collection 검사 제거
+        // Duplicate Collection check removed - already validated by attr.isCollection()
 
         Optional<TypeElement> referencedTypeElementOpt = support.resolveTargetEntity(attr, null, null, null, manyToMany);
         if (referencedTypeElementOpt.isEmpty()) return;
@@ -167,7 +167,7 @@ public final class ManyToManyOwningProcessor implements RelationshipProcessor {
         JoinTableDetails details = new JoinTableDetails(joinTableName, ownerFkToPkMap, inverseFkToPkMap,
                 ownerEntity, referencedEntity, ownerFkConstraint, inverseFkConstraint, ownerNoConstraint, inverseNoConstraint);
 
-        // JoinTable 이름이 owner/referenced 엔티티 테이블명과 충돌하는지 검증
+        // Validate that JoinTable name does not conflict with owner/referenced entity table names
         try {
             joinSupport.validateJoinTableNameConflict(joinTableName, ownerEntity, referencedEntity, attr);
         } catch (IllegalStateException ex) {
@@ -176,14 +176,14 @@ public final class ManyToManyOwningProcessor implements RelationshipProcessor {
 
         EntityModel existing = context.getSchemaModel().getEntities().get(joinTableName);
         if (existing != null) {
-            // 조인테이블 이름 충돌 검증: 기존 엔티티가 진짜 조인테이블인지 확인
+            // Validate join table name conflict: check if existing entity is truly a join table
             if (existing.getTableType() != EntityModel.TableType.JOIN_TABLE) {
                 context.getMessager().printMessage(Diagnostic.Kind.ERROR,
                         "JoinTable name '" + joinTableName + "' conflicts with a non-join entity/table.", attr.elementForDiagnostics());
                 return;
             }
 
-            // 기존 JoinTable의 FK 컬럼셋이 일치하는지 검증 (스키마 일관성 보장)
+            // Validate FK column set consistency of existing JoinTable (ensures schema consistency)
             try {
                 joinSupport.validateJoinTableFkConsistency(existing, details, attr);
             } catch (IllegalStateException ex) {
@@ -207,7 +207,7 @@ public final class ManyToManyOwningProcessor implements RelationshipProcessor {
         joinSupport.ensureJoinTableColumns(joinTableEntity, ownerPks, referencedPks, ownerFkToPkMap, inverseFkToPkMap, attr);
         joinSupport.ensureJoinTableRelationships(joinTableEntity, details);
 
-        // N:N semantics: composite PK(owner_fk + target_fk)
+        // N:N semantics: composite PK (owner_fk + target_fk)
         addManyToManyPkConstraint(joinTableEntity, ownerFkToPkMap, inverseFkToPkMap);
 
         // Process @JoinTable.uniqueConstraints
@@ -243,7 +243,7 @@ public final class ManyToManyOwningProcessor implements RelationshipProcessor {
         Map<String, String> mapping = new LinkedHashMap<>();
         if (joinColumns == null || joinColumns.length == 0) {
             for (ColumnModel pk : referencedPks) {
-                // 조인테이블의 FK 네이밍: 참조 테이블명 기반 (entityTableName + referencedPK)
+                // Join table FK naming: based on referenced table name (entityTableName + referencedPK)
                 String fk = context.getNaming().foreignKeyColumnName(entityTableName, pk.getColumnName());
                 if (mapping.containsKey(fk)) {
                     context.getMessager().printMessage(Diagnostic.Kind.ERROR,
@@ -264,7 +264,7 @@ public final class ManyToManyOwningProcessor implements RelationshipProcessor {
                             "referencedColumnName '" + pkName + "' is not a primary key column of " + entityTableName + " (side=" + side + ")", attr.elementForDiagnostics());
                     return null;
                 }
-                // 조인테이블의 FK 네이밍: 참조 테이블명 기반 (entityTableName + referencedPK)
+                // Join table FK naming: based on referenced table name (entityTableName + referencedPK)
                 String fkName = jc.name().isEmpty()
                         ? context.getNaming().foreignKeyColumnName(entityTableName, pkName)
                         : jc.name();
@@ -287,7 +287,7 @@ public final class ManyToManyOwningProcessor implements RelationshipProcessor {
         cols.addAll(inverseFkToPkMap.keySet());
         if (cols.isEmpty()) return;
 
-        // 컬럼 순서 유지: owner_fk → target_fk 순으로 (성능 최적화를 위해)
+        // Maintain column order: owner_fk → target_fk (for performance optimization)
         String pkName = context.getNaming().pkName(joinTableEntity.getTableName(), cols);
         if (!joinTableEntity.getConstraints().containsKey(pkName)) {
             ConstraintModel pkConstraint = ConstraintModel.builder()

--- a/jinx-processor/src/main/java/org/jinx/handler/relationship/OneToManyOwningJoinTableProcessor.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/relationship/OneToManyOwningJoinTableProcessor.java
@@ -63,7 +63,7 @@ public final class OneToManyOwningJoinTableProcessor implements RelationshipProc
             return;
         }
 
-        // attr.isCollection()으로 이미 검증했으므로 중복 Collection 검사 제거
+        // Duplicate Collection check removed - already validated by attr.isCollection()
 
         Optional<TypeElement> targetEntityElementOpt = support.resolveTargetEntity(attr, null, null, oneToMany, null);
         if (targetEntityElementOpt.isEmpty()) return;
@@ -191,19 +191,19 @@ public final class OneToManyOwningJoinTableProcessor implements RelationshipProc
                 ownerFkConstraint, targetFkConstraint, ownerNoConstraint, inverseNoConstraint
         );
 
-        // JoinTable 이름이 owner/referenced 엔티티 테이블명과 충돌하는지 검증
+        // Validate that JoinTable name does not conflict with owner/referenced entity table names
         if (!joinSupport.validateJoinTableNameConflict(joinTableName, ownerEntity, targetEntity, attr)) return;
 
         EntityModel existing = context.getSchemaModel().getEntities().get(joinTableName);
         if (existing != null) {
-            // 조인테이블 이름 충돌 검증: 기존 엔티티가 진짜 조인테이블인지 확인
+            // Validate join table name conflict: check if existing entity is truly a join table
             if (existing.getTableType() != EntityModel.TableType.JOIN_TABLE) {
                 context.getMessager().printMessage(Diagnostic.Kind.ERROR,
                         "JoinTable name '" + joinTableName + "' conflicts with a non-join entity/table.", attr.elementForDiagnostics());
                 return;
             }
 
-            // 기존 JoinTable의 FK 컬럼셋이 일치하는지 검증 (스키마 일관성 보장)
+            // Validate FK column set consistency of existing JoinTable (ensures schema consistency)
             if (!joinSupport.validateJoinTableFkConsistency(existing, details, attr)) return;
 
             joinSupport.ensureJoinTableColumns(existing, ownerPks, targetPks, ownerFkToPkMap, targetFkToPkMap, attr);
@@ -257,7 +257,7 @@ public final class OneToManyOwningJoinTableProcessor implements RelationshipProc
         Map<String, String> mapping = new LinkedHashMap<>();
         if (joinColumns == null || joinColumns.length == 0) {
             for (ColumnModel pk : referencedPks) {
-                // 조인테이블의 FK 네이밍: 참조 테이블명 기반 (entityTableName + referencedPK)
+                // Join table FK naming: based on referenced table name (entityTableName + referencedPK)
                 String fk = context.getNaming().foreignKeyColumnName(entityTableName, pk.getColumnName());
                 if (mapping.containsKey(fk)) {
                     context.getMessager().printMessage(Diagnostic.Kind.ERROR,
@@ -278,7 +278,7 @@ public final class OneToManyOwningJoinTableProcessor implements RelationshipProc
                             "referencedColumnName '" + pkName + "' is not a primary key column of " + entityTableName + " (side=" + side + ")", attr.elementForDiagnostics());
                     return null;
                 }
-                // 조인테이블의 FK 네이밍: 참조 테이블명 기반 (entityTableName + referencedPK)
+                // Join table FK naming: based on referenced table name (entityTableName + referencedPK)
                 String fkName = jc.name().isEmpty()
                         ? context.getNaming().foreignKeyColumnName(entityTableName, pkName)
                         : jc.name();

--- a/jinx-processor/src/main/java/org/jinx/manager/ConstraintManager.java
+++ b/jinx-processor/src/main/java/org/jinx/manager/ConstraintManager.java
@@ -9,6 +9,12 @@ import org.jinx.util.ConstraintKeys;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Manages the lifecycle of constraints within an {@link EntityModel}.
+ * <p>
+ * This manager provides a centralized way to add, remove, and find unique constraints,
+ * ensuring that they are identified by a canonical key to prevent duplicates.
+ */
 public class ConstraintManager {
     private final ProcessingContext context;
 
@@ -16,6 +22,15 @@ public class ConstraintManager {
         this.context = context;
     }
 
+    /**
+     * Adds a unique constraint to the entity model if a constraint with the same
+     * canonical key is not already present.
+     *
+     * @param entity The entity model to modify.
+     * @param table The table for the constraint.
+     * @param cols The list of columns in the constraint.
+     * @param whereOpt An optional WHERE clause for partial/filtered constraints.
+     */
     public void addUniqueIfAbsent(EntityModel entity, String table, List<String> cols, Optional<String> whereOpt) {
         String where = whereOpt.orElse(null);
         String key = ConstraintKeys.canonicalKey(
@@ -34,12 +49,20 @@ public class ConstraintManager {
                 .tableName(table)
                 .type(ConstraintType.UNIQUE)
                 .columns(cols)
-                .where(where) // <-- nullable string
+                .where(where) // can be a nullable string
                 .build();
 
         entity.getConstraints().put(key, c);
     }
 
+    /**
+     * Removes a unique constraint from the entity model if it exists.
+     *
+     * @param entity The entity model to modify.
+     * @param table The table of the constraint.
+     * @param cols The list of columns in the constraint.
+     * @param whereOpt An optional WHERE clause for the constraint.
+     */
     public void removeUniqueIfPresent(EntityModel entity, String table, List<String> cols, Optional<String> whereOpt) {
         String where = whereOpt.orElse(null);
         String key = ConstraintKeys.canonicalKey(
@@ -52,6 +75,15 @@ public class ConstraintManager {
         entity.getConstraints().remove(key);
     }
 
+    /**
+     * Finds a unique constraint in the entity model based on its canonical key.
+     *
+     * @param entity The entity model to search.
+     * @param table The table of the constraint.
+     * @param cols The list of columns in the constraint.
+     * @param whereOpt An optional WHERE clause for the constraint.
+     * @return An {@link Optional} containing the found {@link ConstraintModel}, or empty if not found.
+     */
     public Optional<ConstraintModel> findUnique(EntityModel entity, String table, List<String> cols, Optional<String> whereOpt) {
         String where = whereOpt.orElse(null);
         String key = ConstraintKeys.canonicalKey(

--- a/jinx-processor/src/main/java/org/jinx/naming/Naming.java
+++ b/jinx-processor/src/main/java/org/jinx/naming/Naming.java
@@ -9,11 +9,11 @@ public interface Naming {
     
     /**
      * Foreign key column naming strategy.
-     * 
+     *
      * Usage patterns:
-     * - 일반 엔티티의 FK: foreignKeyColumnName(fieldName, referencedPK) - 속성명 기반
-     * - 조인테이블의 FK: foreignKeyColumnName(entityTableName, referencedPK) - 참조 테이블명 기반
-     * 
+     * - Regular entity FK: foreignKeyColumnName(fieldName, referencedPK) - attribute name based
+     * - Join table FK: foreignKeyColumnName(entityTableName, referencedPK) - referenced table name based
+     *
      * @param ownerName For regular entities: field name, For join tables: referenced entity table name
      * @param referencedPkColumnName Referenced primary key column name
      * @return Foreign key column name

--- a/jinx-processor/src/main/java/org/jinx/util/ConstraintShapes.java
+++ b/jinx-processor/src/main/java/org/jinx/util/ConstraintShapes.java
@@ -10,9 +10,23 @@ import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 
+/**
+ * Utility class to generate canonical "shape keys" for constraints and indexes.
+ * <p>
+ * These keys are used to uniquely identify a constraint or index based on its
+ * semantic properties (type, table, columns, etc.), allowing for reliable
+ * detection of duplicates regardless of the assigned name.
+ */
 public final class ConstraintShapes {
     private ConstraintShapes() {}
 
+    /**
+     * Generates a canonical shape key for a {@link ConstraintModel}.
+     * For UNIQUE and PRIMARY_KEY constraints, column order is ignored.
+     *
+     * @param c The constraint model.
+     * @return A unique string representing the constraint's shape.
+     */
     public static String shapeKey(ConstraintModel c) {
         String table = norm(c.getTableName());
         List<String> colsInput = c.getColumns() != null ? c.getColumns() : List.of();
@@ -24,7 +38,7 @@ public final class ConstraintShapes {
             Collections.sort(sorted);
             colsKey = String.join(",", sorted);
         } else {
-            // 순서 의미 유지
+            // Preserve order for other constraint types.
             colsKey = String.join(",", cols);
         }
 
@@ -35,8 +49,15 @@ public final class ConstraintShapes {
         return c.getType() + "|" + table + "|" + colsKey + "|" + whereKey;
     }
 
+    /**
+     * Generates a canonical shape key for an {@link IndexModel}.
+     * Column order is preserved for indexes.
+     *
+     * @param ix The index model.
+     * @return A unique string representing the index's shape.
+     */
     public static String shapeKey(IndexModel ix) {
-        // 인덱스는 순서 의미 유지
+        // Preserve order for indexes.
         String table = norm(ix.getTableName());
         String colsKey = (ix.getColumnNames() != null ? ix.getColumnNames() : List.<String>of())
                 .stream()


### PR DESCRIPTION
This PR refines the documentation and comments within the Processor module to ensure a consistent and professional English style across the codebase.

### Details

- Converted all comments from Korean to English.
- Standardized Javadoc formatting and inline comment tone.
- Clarified parameter and return descriptions in method-level comments.
- Removed unnecessary or outdated remarks.

### Impact
No functional changes — documentation only.
Improves developer experience and onboarding for contributors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 설정 값 명시적 재정의 기능 추가
  * 중첩된 임베디드 타입 처리 개선
  * 복잡한 데이터베이스 관계 매핑 지원 강화

* **버그 수정**
  * 중복 제약 조건 감지 로직 개선
  * 관계 처리 검증 강화

* **개선**
  * 설정 프로필 기반 로딩 및 오버라이드 처리 최적화
  * 라운드별 상태 관리 안정성 향상
  * 오류 메시지 및 문서화 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->