### PR TITLE
@ElementCollection 처리 중 PK 미등록 오류 수정 (Two-Phase Processing 적용)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Jinx scans your JPA annotations to generate **schema snapshots (JSON)** and automatically produces **DDL SQL** and **Liquibase migration YAML** by comparing changes across snapshots.
 
-**MySQL First** | **JDK 21+ Required** | **Latest Version: 0.0.18** | **JPA 3.2.0 Supported**
+**MySQL First** | **JDK 21+ Required** | **Latest Version: 0.0.19** | **JPA 3.2.0 Supported**
 
 ---
 
@@ -30,8 +30,8 @@ https://github.com/yyubin/jinx-test
 
 ```gradle
 dependencies {
-    annotationProcessor("io.github.yyubin:jinx-processor:0.0.18")
-    implementation("io.github.yyubin:jinx-core:0.0.18")
+    annotationProcessor("io.github.yyubin:jinx-processor:0.0.19")
+    implementation("io.github.yyubin:jinx-core:0.0.19")
 }
 ````
 
@@ -143,7 +143,7 @@ Below is a minimal example of integrating Jinx into a Spring Boot project.
 val jinxCli by configurations.creating
 
 dependencies {
-    jinxCli("io.github.yyubin:jinx-cli:0.0.18")
+    jinxCli("io.github.yyubin:jinx-cli:0.0.19")
 }
 ```
 
@@ -198,7 +198,7 @@ Once approved, you can apply it as:
 
 ```kotlin
 plugins {
-    id("org.jinx.gradle") version "0.0.18"
+    id("org.jinx.gradle") version "0.0.19"
 }
 ```
 
@@ -208,7 +208,7 @@ Until then, you may apply it manually:
 buildscript {
     repositories { mavenCentral() }
     dependencies {
-        classpath("org.jinx:jinx-gradle:0.0.18")
+        classpath("org.jinx:jinx-gradle:0.0.19")
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'io.github.yyubin'
-version = '0.0.18'
+version = '0.0.19'
 
 java {
     toolchain {

--- a/jinx-gradle-plugin/build.gradle
+++ b/jinx-gradle-plugin/build.gradle
@@ -67,7 +67,7 @@ afterEvaluate {
                         developer {
                             id = 'yyubin'
                             name = 'Yubin'
-                            email = 'yyubin@gmail.com'
+                            email = 'hazing0910@gmail.com'
                         }
                     }
 
@@ -79,7 +79,6 @@ afterEvaluate {
                 }
             }
 
-            // Plugin Marker: Plugin Portal 게시용, Maven Central에서는 의미 없음
             all { pub ->
                 if (pub.name.contains("PluginMarkerMaven")) {
                     pub.pom {
@@ -98,7 +97,7 @@ afterEvaluate {
                             developer {
                                 id = 'yyubin'
                                 name = 'Yubin'
-                                email = 'yyubin@gmail.com'
+                                email = 'hazing0910@gmail.com'
                             }
                         }
 

--- a/jinx-processor/src/main/java/org/jinx/descriptor/AttributeDescriptorFactory.java
+++ b/jinx-processor/src/main/java/org/jinx/descriptor/AttributeDescriptorFactory.java
@@ -235,7 +235,9 @@ public class AttributeDescriptorFactory {
     }
 
     private Map<String, AttributeCandidate> collectAttributeCandidates(TypeElement typeElement) {
-        Map<String, AttributeCandidate> candidates = new HashMap<>();
+        // Use LinkedHashMap to preserve field declaration order, ensuring deterministic processing
+        // This prevents issues where @ElementCollection might be processed before @Id
+        Map<String, AttributeCandidate> candidates = new LinkedHashMap<>();
         collectAttributesFromHierarchy(typeElement, candidates);
         return candidates;
     }

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 **Jinx**는 JPA 애노테이션을 스캔해 스키마 스냅샷(JSON)을 만들고, 이전 스냅샷과 비교하여 **DB 마이그레이션 SQL**과 **Liquibase YAML**을 자동 생성하는 도구입니다.
 
-**현재 MySQL 우선 지원** | **JDK 21+ 필요** | **최신 릴리즈: 0.0.18**
+**현재 MySQL 우선 지원** | **JDK 21+ 필요** | **최신 릴리즈: 0.0.19**
 
 ## 빠른 시작
 
@@ -14,8 +14,8 @@ sidebar_position: 1
 
 ```gradle
 dependencies {
-    annotationProcessor "io.github.yyubin:jinx-processor:0.0.18"
-    implementation "io.github.yyubin:jinx-core:0.0.18"
+    annotationProcessor "io.github.yyubin:jinx-processor:0.0.19"
+    implementation "io.github.yyubin:jinx-core:0.0.19"
 }
 ```
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/intro.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/intro.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 **Jinx** is a tool that scans JPA annotations to create schema snapshots (JSON) and automatically generates **DB migration SQL** and **Liquibase YAML** by comparing with previous snapshots.
 
-**Currently prioritizes MySQL support** | **Requires JDK 21+** | **Latest release: 0.0.18**
+**Currently prioritizes MySQL support** | **Requires JDK 21+** | **Latest release: 0.0.19**
 
 ## Quick Start
 
@@ -14,8 +14,8 @@ sidebar_position: 1
 
 ```gradle
 dependencies {
-    annotationProcessor "io.github.yyubin:jinx-processor:0.0.18"
-    implementation "io.github.yyubin:jinx-core:0.0.18"
+    annotationProcessor "io.github.yyubin:jinx-processor:0.0.19"
+    implementation "io.github.yyubin:jinx-core:0.0.19"
 }
 ```
 


### PR DESCRIPTION
## 주요 변경사항
- EntityHandler에 Two-Phase Processing 도입  
  - Phase 1: @Id 우선 처리해 PK를 먼저 등록  
  - Phase 2: @ElementCollection, @Embedded, 관계 필드 처리
- AttributeDescriptorFactory에서 HashMap → LinkedHashMap으로 교체  
  - 필드 선언 순서 유지  
  - 비결정적 순서로 @ElementCollection이 먼저 처리되는 문제 차단

## 해결된 문제
기존에는 HashMap의 비결정적 순서로 인해 @ElementCollection이 @Id보다 먼저 처리되며  
“Owner entity must have a primary key” 오류가 발생했음.  
Two-Phase Processing으로 PK 선등록이 보장되며 문제 해결.

## 테스트 결과
- Jinx 전체 테스트 통과 (ElementCollectionHandlerTest, EntityHandlerTest 등)
- Gesellschaft 실제 케이스 빌드 성공 확인

## 추가 보장
- @Id + @ElementCollection
- @EmbeddedId + @ElementCollection
- 복합키 및 상속 구조에서도 안정적으로 처리됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버전 0.0.19 출시

* **Chores**
  * 버전을 0.0.19로 업그레이드
  * 개발자 이메일 정보 업데이트

* **Bug Fixes**
  * 특성 처리 순서의 결정성 개선으로 예측 가능한 처리 보장
  * 기본키 필드 우선 처리로 속성 등록 안정성 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->