### PR TITLE
fix: MigrationGenerator 컬럼 전파 버그 수정 및 테스트 보강 (v0.0.21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Jinx analyzes your **JPA annotations at compile time**, generates **schema snaps
 
 Liquibase YAML is supported as an **output dialect**, but **SQL is the primary and most thoroughly validated output format**.
 
-**MySQL First** | **JDK 21+ Required** | **Latest Version: 0.0.20** | **JPA 3.2.0 Supported**
+**MySQL First** | **JDK 21+ Required** | **Latest Version: 0.0.21** | **JPA 3.2.0 Supported**
 
 ---
 
@@ -86,8 +86,8 @@ Liquibase support is **not the core model**, but a translation layer on top of S
 
 ```gradle
 dependencies {
-    annotationProcessor("io.github.yyubin:jinx-processor:0.0.20")
-    implementation("io.github.yyubin:jinx-core:0.0.20")
+    annotationProcessor("io.github.yyubin:jinx-processor:0.0.21")
+    implementation("io.github.yyubin:jinx-core:0.0.21")
 }
 ```
 
@@ -176,7 +176,7 @@ CREATE INDEX `ix_bird__zoo_id` ON `Bird` (`zoo_id`);
 
 ```kotlin
 plugins {
-    id("io.github.yyubin.jinx") version "0.0.20"
+    id("io.github.yyubin.jinx") version "0.0.21"
 }
 ```
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -11,7 +11,7 @@ Jinx는 **컴파일 타임에 JPA 애노테이션을 분석**하여
 Liquibase YAML도 **출력 포맷 중 하나**로 지원하지만,  
 **SQL이 주력이며 가장 많이 검증된 출력 결과**입니다.
 
-**MySQL 우선 지원** | **JDK 21+ 필요** | **최신 버전: 0.0.20** | **JPA 3.2.0 지원**
+**MySQL 우선 지원** | **JDK 21+ 필요** | **최신 버전: 0.0.21** | **JPA 3.2.0 지원**
 
 ---
 
@@ -98,8 +98,8 @@ Liquibase는 핵심 모델이 아니라
 
 ```gradle
 dependencies {
-    annotationProcessor("io.github.yyubin:jinx-processor:0.0.20")
-    implementation("io.github.yyubin:jinx-core:0.0.20")
+    annotationProcessor("io.github.yyubin:jinx-processor:0.0.21")
+    implementation("io.github.yyubin:jinx-core:0.0.21")
 }
 ````
 
@@ -155,7 +155,7 @@ jinx db migrate \
 
 ```kotlin
 plugins {
-    id("io.github.yyubin.jinx") version "0.0.20"
+    id("io.github.yyubin.jinx") version "0.0.21"
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'io.github.yyubin'
-version = '0.0.20'
+version = '0.0.21'
 
 java {
     toolchain {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,6 @@ pomScmConnection=scm:git:git://github.com/yyubin/jinx.git
 pomScmDeveloperConnection=scm:git:ssh://github.com/yyubin/jinx.git
 pomDeveloperName=Yubin
 pomDeveloperUrl=https://github.com/yyubin
+
+gradle.publish.key=WwM1Rl6tSxGhCDa274HQ9I4VN1rxNsEZ
+gradle.publish.secret=v0eXPVNI0E8HYyssncIF483evMt28JUT

--- a/jinx-core/src/main/java/org/jinx/migration/MigrationGenerator.java
+++ b/jinx-core/src/main/java/org/jinx/migration/MigrationGenerator.java
@@ -37,7 +37,7 @@ public class MigrationGenerator {
         // 1-1) ModifiedEntity: DROP 단계
         for (var m : diff.getModifiedTables()) {
             var v = providers.tableContentVisitor().apply(m);
-            diff.tableContentAccept(v, DiffResult.TableContentPhase.DROP);
+            m.accept(v, DiffResult.TableContentPhase.DROP);
             out.append(v.getGeneratedSql()).append('\n');
         }
 
@@ -60,14 +60,14 @@ public class MigrationGenerator {
         // 2-2) ModifiedEntity: ALTER 단계
         for (var m : diff.getModifiedTables()) {
             var v = providers.tableContentVisitor().apply(m);
-            diff.tableContentAccept(v, DiffResult.TableContentPhase.ALTER);
+            m.accept(v, DiffResult.TableContentPhase.ALTER);
             out.append(v.getGeneratedSql()).append('\n');
         }
 
         // 3) FK 추가 단계
         for (var m : diff.getModifiedTables()) {
             var v = providers.tableContentVisitor().apply(m);
-            diff.tableContentAccept(v, DiffResult.TableContentPhase.FK_ADD);
+            m.accept(v, DiffResult.TableContentPhase.FK_ADD);
             out.append(v.getGeneratedSql()).append('\n');
         }
 

--- a/jinx-core/src/test/java/org/jinx/migration/MigrationGeneratorTest.java
+++ b/jinx-core/src/test/java/org/jinx/migration/MigrationGeneratorTest.java
@@ -40,8 +40,9 @@ class MigrationGeneratorTest {
         when(newEntity.getTableName()).thenReturn("t_new");
         when(me.getNewEntity()).thenReturn(newEntity);
         when(diff.getModifiedTables()).thenReturn(List.of(me));
+        when(diff.getAddedTables()).thenReturn(List.of());
 
-        // tableContentAccept: Phase 별로 녹화형 비지터에 visit* 호출 → SQL 축적
+        // ModifiedEntity.accept: Phase 별로 녹화형 비지터에 visit* 호출 → SQL 축적
         doAnswer(inv -> {
             TableContentVisitor v = inv.getArgument(0);
             DiffResult.TableContentPhase phase = inv.getArgument(1);
@@ -53,7 +54,7 @@ class MigrationGeneratorTest {
                 v.visitDroppedPrimaryKey();
             }
             return null;
-        }).when(diff).tableContentAccept(any(), eq(DiffResult.TableContentPhase.DROP));
+        }).when(me).accept(any(), eq(DiffResult.TableContentPhase.DROP));
 
         doAnswer(inv -> {
             TableContentVisitor v = inv.getArgument(0);
@@ -67,7 +68,7 @@ class MigrationGeneratorTest {
                 v.visitModifiedColumn(newCol, oldCol);
             }
             return null;
-        }).when(diff).tableContentAccept(any(), eq(DiffResult.TableContentPhase.ALTER));
+        }).when(me).accept(any(), eq(DiffResult.TableContentPhase.ALTER));
 
         doAnswer(inv -> {
             TableContentVisitor v = inv.getArgument(0);
@@ -78,7 +79,7 @@ class MigrationGeneratorTest {
                 v.visitAddedRelationship(rel);
             }
             return null;
-        }).when(diff).tableContentAccept(any(), eq(DiffResult.TableContentPhase.FK_ADD));
+        }).when(me).accept(any(), eq(DiffResult.TableContentPhase.FK_ADD));
 
         // tableAccept: DROPPED/RENAMED/ADDED 각각 호출 시 녹화형 비지터에 visit* 호출
         doAnswer(inv -> {
@@ -208,8 +209,8 @@ class MigrationGeneratorTest {
         DiffResult diff = mock(DiffResult.class);
         when(diff.getWarnings()).thenReturn(List.of());
         when(diff.getModifiedTables()).thenReturn(List.of());
+        when(diff.getAddedTables()).thenReturn(List.of());
         doNothing().when(diff).tableAccept(any(), any());
-        doNothing().when(diff).tableContentAccept(any(), any());
         doNothing().when(diff).sequenceAccept(any(), any(), any());
         doNothing().when(diff).tableGeneratorAccept(any(), any(), any());
 

--- a/jinx-gradle-plugin/build.gradle
+++ b/jinx-gradle-plugin/build.gradle
@@ -81,89 +81,89 @@ if (project.findProperty("signingKey") != null) {
         def key = project.findProperty("signingKey") ?: System.getenv('ORG_GRADLE_PROJECT_signingKey')
         def pass = project.findProperty("signingPassword") ?: System.getenv('ORG_GRADLE_PROJECT_signingPassword')
         useInMemoryPgpKeys(key, pass)
-        sign publishing.publications.mavenJava
+        sign publishing.publications
     }
 }
 
-//afterEvaluate {
-//
-//    publishing {
-//        publications {
-//            named('pluginMaven', MavenPublication) {
-//                artifactId = 'jinx-gradle-plugin'
-//
-//                pom {
-//                    name = 'jinx-gradle-plugin'
-//                    description = 'Gradle plugin for Jinx JPA DDL generation tool'
-//                    url = 'https://github.com/yyubin/jinx'
-//
-//                    licenses {
-//                        license {
-//                            name = 'The Apache License, Version 2.0'
-//                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-//                        }
-//                    }
-//
-//                    developers {
-//                        developer {
-//                            id = 'yyubin'
-//                            name = 'Yubin'
-//                            email = 'hazing0910@gmail.com'
-//                        }
-//                    }
-//
-//                    scm {
-//                        connection = 'scm:git:git://github.com/yyubin/jinx.git'
-//                        developerConnection = 'scm:git:ssh://github.com/yyubin/jinx.git'
-//                        url = 'https://github.com/yyubin/jinx'
-//                    }
-//                }
-//            }
-//
-//            all { pub ->
-//                if (pub.name.contains("PluginMarkerMaven")) {
-//                    pub.pom {
-//                        name = 'Jinx Gradle Plugin Marker'
-//                        description = 'Gradle plugin marker for Jinx JPA DDL generation tool'
-//                        url = 'https://github.com/yyubin/jinx'
-//
-//                        licenses {
-//                            license {
-//                                name = 'The Apache License, Version 2.0'
-//                                url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-//                            }
-//                        }
-//
-//                        developers {
-//                            developer {
-//                                id = 'yyubin'
-//                                name = 'Yubin'
-//                                email = 'hazing0910@gmail.com'
-//                            }
-//                        }
-//
-//                        scm {
-//                            connection = 'scm:git:git://github.com/yyubin/jinx.git'
-//                            developerConnection = 'scm:git:ssh://github.com/yyubin/jinx.git'
-//                            url = 'https://github.com/yyubin/jinx'
-//                        }
-//                    }
-//                }
-//            }
-//        }
-//    }
-//}
-//
-//signing {
-//    setRequired(false)
-//
-//    if (project.hasProperty("signingKey")) {
-//        useInMemoryPgpKeys(
-//                project.findProperty("signingKey"),
-//                project.findProperty("signingPassword")
-//        )
-//
-//        sign(publishing.publications.named("pluginMaven"))
-//    }
-//}
+afterEvaluate {
+
+    publishing {
+        publications {
+            named('pluginMaven', MavenPublication) {
+                artifactId = 'jinx-gradle-plugin'
+
+                pom {
+                    name = 'jinx-gradle-plugin'
+                    description = 'Gradle plugin for Jinx JPA DDL generation tool'
+                    url = 'https://github.com/yyubin/jinx'
+
+                    licenses {
+                        license {
+                            name = 'The Apache License, Version 2.0'
+                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id = 'yyubin'
+                            name = 'Yubin'
+                            email = 'hazing0910@gmail.com'
+                        }
+                    }
+
+                    scm {
+                        connection = 'scm:git:git://github.com/yyubin/jinx.git'
+                        developerConnection = 'scm:git:ssh://github.com/yyubin/jinx.git'
+                        url = 'https://github.com/yyubin/jinx'
+                    }
+                }
+            }
+
+            all { pub ->
+                if (pub.name.contains("PluginMarkerMaven")) {
+                    pub.pom {
+                        name = 'Jinx Gradle Plugin Marker'
+                        description = 'Gradle plugin marker for Jinx JPA DDL generation tool'
+                        url = 'https://github.com/yyubin/jinx'
+
+                        licenses {
+                            license {
+                                name = 'The Apache License, Version 2.0'
+                                url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                            }
+                        }
+
+                        developers {
+                            developer {
+                                id = 'yyubin'
+                                name = 'Yubin'
+                                email = 'hazing0910@gmail.com'
+                            }
+                        }
+
+                        scm {
+                            connection = 'scm:git:git://github.com/yyubin/jinx.git'
+                            developerConnection = 'scm:git:ssh://github.com/yyubin/jinx.git'
+                            url = 'https://github.com/yyubin/jinx'
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+signing {
+    setRequired(false)
+
+    if (project.hasProperty("signingKey")) {
+        useInMemoryPgpKeys(
+                project.findProperty("signingKey"),
+                project.findProperty("signingPassword")
+        )
+
+        sign(publishing.publications.named("pluginMaven"))
+    }
+}
 

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 **Jinx**는 JPA 애노테이션을 스캔해 스키마 스냅샷(JSON)을 만들고, 이전 스냅샷과 비교하여 **DB 마이그레이션 SQL**과 **Liquibase YAML**을 자동 생성하는 도구입니다.
 
-**현재 MySQL 우선 지원** | **JDK 21+ 필요** | **최신 릴리즈: 0.0.20**
+**현재 MySQL 우선 지원** | **JDK 21+ 필요** | **최신 릴리즈: 0.0.21**
 
 ## 빠른 시작
 
@@ -14,8 +14,8 @@ sidebar_position: 1
 
 ```gradle
 dependencies {
-    annotationProcessor "io.github.yyubin:jinx-processor:0.0.20"
-    implementation "io.github.yyubin:jinx-core:0.0.20"
+    annotationProcessor "io.github.yyubin:jinx-processor:0.0.21"
+    implementation "io.github.yyubin:jinx-core:0.0.21"
 }
 ```
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/intro.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/intro.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 **Jinx** is a tool that scans JPA annotations to create schema snapshots (JSON) and automatically generates **DB migration SQL** and **Liquibase YAML** by comparing with previous snapshots.
 
-**Currently prioritizes MySQL support** | **Requires JDK 21+** | **Latest release: 0.0.20**
+**Currently prioritizes MySQL support** | **Requires JDK 21+** | **Latest release: 0.0.21**
 
 ## Quick Start
 
@@ -14,8 +14,8 @@ sidebar_position: 1
 
 ```gradle
 dependencies {
-    annotationProcessor "io.github.yyubin:jinx-processor:0.0.20"
-    implementation "io.github.yyubin:jinx-core:0.0.20"
+    annotationProcessor "io.github.yyubin:jinx-processor:0.0.21"
+    implementation "io.github.yyubin:jinx-core:0.0.21"
 }
 ```
 


### PR DESCRIPTION
이번 PR에서는 `MigrationGenerator`에서 **컬럼 변경이 모든 테이블로 잘못 전파되던 버그**를 수정하고, 해당 동작을 검증하는 테스트를 보강했습니다.
또한 릴리즈에 맞춰 문서/예제 및 배포 설정을 함께 정비했습니다.

---

## 수정 효과

이제 특정 테이블에 컬럼을 추가하더라도 **의도한 테이블에만 DDL이 생성**됩니다.

```sql
-- 수정 전 (버그)
ALTER TABLE follow ADD COLUMN taste_tag VARCHAR(100);
ALTER TABLE users ADD COLUMN taste_tag VARCHAR(100);
ALTER TABLE review_reaction ADD COLUMN taste_tag VARCHAR(100);
-- 모든 테이블에 중복 적용

-- 수정 후 (정상 동작)
ALTER TABLE users ADD COLUMN taste_tag VARCHAR(100);
```

---

## 변경 내역

### 1. 버그 수정 – `MigrationGenerator.java`

다음 3곳에서 잘못된 visitor 호출을 수정했습니다.

* **DROP 단계 (Line 40)**
  `diff.tableContentAccept()` → `m.accept()`
* **ALTER 단계 (Line 63)**
  `diff.tableContentAccept()` → `m.accept()`
* **FK_ADD 단계 (Line 70)**
  `diff.tableContentAccept()` → `m.accept()`

이를 통해 컬럼/제약 변경이 실제 변경 대상 테이블에만 적용되도록 수정했습니다.

---

### 2. 테스트 수정 – `MigrationGeneratorTest.java`

* DROP 단계

  * Lines 44–56: `diff.tableContentAccept()` mock → `me.accept()` mock
* ALTER 단계

  * Lines 58–70: `diff.tableContentAccept()` mock → `me.accept()` mock
* FK_ADD 단계

  * Lines 72–81: `diff.tableContentAccept()` mock → `me.accept()` mock
* 공통 보완

  * Line 43, 211: `diff.getAddedTables()` stub 추가

---

### 3. 릴리즈 및 배포 정비

* README, 문서, 예제의 버전을 **0.0.21**로 업데이트
* Gradle 플러그인 **POM 설정 리팩토링** 및 **Signing 재활성화**
* `gradle.publish.key`, `gradle.publish.secret`를 `gradle.properties`에 추가

---

## 테스트 결과

* `jinx-core` 테스트: 통과
* 전체 프로젝트 테스트: 통과



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 버전을 0.0.20에서 0.0.21로 업그레이드했습니다.
  * 빌드 및 배포 설정을 개선했습니다.

* **Documentation**
  * README 및 웹사이트 문서의 버전 참조를 최신 버전으로 업데이트했습니다.
  * 의존성 및 설치 가이드 문서를 업데이트했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->