### PR TITLE
chore: bump version to 0.0.22 and update documentation/examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,121 +1,51 @@
-# 🧾 CHANGELOG
+## 📝 CHANGELOG
 
-## [0.0.20] - 2025-12-27
-### 🔧 Fixed
-- **컬럼 변경이 모든 테이블로 잘못 전파되던 버그 수정** - `MigrationGenerator`에서 특정 테이블의 컬럼 추가/수정/삭제 시 모든 테이블에 동일한 DDL이 중복 생성되던 심각한 버그 해결
-    - **원인**: `diff.tableContentAccept()`가 모든 `modifiedTables`를 순회하면서 각 visitor를 적용하여 O(N²) 복잡도로 중복 처리
-    - **해결**: `m.accept()`로 변경하여 각 visitor가 자신의 테이블만 처리하도록 수정
-    - **영향**: DROP, ALTER, FK_ADD 3개 단계 모두 수정
+### [Released - 0.0.22]
 
-### 🧩 Changed
-- **MigrationGenerator.java** (3곳 수정):
-    - DROP 단계 (Line 40): `diff.tableContentAccept(v, DROP)` → `m.accept(v, DROP)`
-    - ALTER 단계 (Line 63): `diff.tableContentAccept(v, ALTER)` → `m.accept(v, ALTER)`
-    - FK_ADD 단계 (Line 70): `diff.tableContentAccept(v, FK_ADD)` → `m.accept(v, FK_ADD)`
+#### 🐛 Fixed
 
-### 🧪 Tests
-- **MigrationGeneratorTest.java** 업데이트:
-    - DROP 단계 (Lines 44-56): `diff.tableContentAccept()` mock → `me.accept()` mock
-    - ALTER 단계 (Lines 58-70): `diff.tableContentAccept()` mock → `me.accept()` mock
-    - FK_ADD 단계 (Lines 72-81): `diff.tableContentAccept()` mock → `me.accept()` mock
-    - `diff.getAddedTables()` stub 추가 (Lines 43, 211)
-- 전체 프로젝트 테스트 통과 (`BUILD SUCCESSFUL`)
+* 컬럼 리네임 시 인덱스, 제약조건, 외래키 SQL 생성 순서가 잘못되어
+  **존재하지 않는 컬럼을 참조하는 인덱스가 먼저 생성되던 문제 수정**
+* MySQL 마이그레이션에서 `ModifyContributor`가
+  `DROP + CREATE`를 한 번에 수행하던 구조로 인해 발생하던
+  **컬럼 의존성 순서 오류 해결**
 
-### 📈 Impact
-- **성능 개선**: O(N²) → O(N) 복잡도로 감소 (N = 테이블 수)
-- **SQL 크기 감소**: 불필요한 중복 ALTER 문 제거
-- **정확성 보장**: 이제 컬럼 변경이 의도한 테이블에만 적용됨
+#### 🛠 Changed
 
-**수정 전 (버그):**
-```sql
-ALTER TABLE follow ADD COLUMN taste_tag VARCHAR(100);      -- 잘못된 중복
-ALTER TABLE users ADD COLUMN taste_tag VARCHAR(100);       -- 의도한 테이블
-ALTER TABLE review_reaction ADD COLUMN taste_tag VARCHAR(100);  -- 잘못된 중복
--- ... 모든 테이블에 중복 적용
-```
+* 인덱스 / 제약조건 / 외래키 수정 로직을
+  `ModifyContributor` 방식에서 **Drop + Add Contributor 분리 방식**으로 변경
+* priority 체계에 맞게 다음 순서가 보장되도록 개선:
 
-**수정 후 (정상):**
-```sql
-ALTER TABLE users ADD COLUMN taste_tag VARCHAR(100);       -- 올바름
-```
+  ```
+  DROP (Index / Constraint / FK)
+  → COLUMN DROP / ADD
+  → ADD (Index / Constraint / FK)
+  ```
 
-### 🔐 Security
-- **Publishing credentials 보안 강화**:
-    - `gradle.properties`에서 `gradle.publish.key`, `gradle.publish.secret` 제거
-    - `local.properties` (gitignore에 포함)로 credentials 분리
-    - `PUBLISHING.md` 가이드 추가
+#### 🧩 Internal
 
-### 📚 Documentation
-- README 및 예제 버전을 0.0.20으로 업데이트
-- `PUBLISHING.md` 추가: Gradle Plugin Portal 퍼블리싱 가이드 및 보안 사고 대응 방법
+* `MySqlMigrationVisitor`에서 다음 메서드 동작 변경:
+
+  * `visitModifiedIndex`
+  * `visitModifiedConstraint`
+  * `visitModifiedRelationship`
+* 내부적으로 더 이상 사용되지 않는 Contributor 클래스 발생:
+
+  * `IndexModifyContributor`
+  * `ConstraintModifyContributor`
+  * `RelationshipModifyContributor`
+    (추후 제거 가능)
 
 ---
 
-## [0.0.13] - 2025-10-24
-### 🔧 Fixed
-- **ToOne 관계 FK 누락 문제 수정** - `@ManyToOne` / `@OneToOne` 관계에서 참조 대상 엔티티가 알파벳순으로 나중에 처리되는 경우 외래키(FK) 컬럼이 DDL에서 누락되던 문제 해결
-    - **Processor 단계**: Deferred Processing 메커니즘 추가하여 엔티티 처리 순서와 무관하게 모든 FK 컬럼 생성 보장
-    - **SQL 생성 단계**: `CreateTableBuilder.defaultsFrom()`에서 FK 제약 조건 SQL 생성 누락 문제 수정
-    - 순환 의존성(circular dependencies) 지원
-    - Referenced entity 누락 시 조용히 실패하던 문제 해결 → NOTE 메시지로 디버깅 용이성 향상
-- **OneToOne 관계 UNIQUE 제약 조건 누락 문제 수정** - `@OneToOne` 관계에서 `@JoinColumn.unique` 값과 무관하게 항상 UNIQUE 제약 조건 생성 (Hibernate 동작과 일치)
-- **Inverse 관계 검증 경고 제거** - `@OneToMany(mappedBy=...)` 검증 시 target entity가 아직 처리되지 않은 경우 불필요한 WARNING 출력 제거
+### 🔍 영향 범위
 
-### 🧩 Changed
-- **Processor 모듈**:
-    - `ToOneRelationshipProcessor.process()` 로직 개선:
-        - Referenced entity가 아직 처리되지 않은 경우 자동으로 deferred queue에 추가
-        - 중복 처리 방지 로직 추가 (재시도 시 이미 생성된 관계는 스킵하되 UNIQUE 제약 조건은 확인)
-        - `@OneToOne` 관계는 `@JoinColumn.unique` 값과 무관하게 항상 UNIQUE 제약 조건 추가
-    - `EntityHandler.runDeferredPostProcessing()`에 관계 재처리 로직 추가:
-        - JOINED 상속 및 @MapsId와 함께 ToOne 관계도 재처리
-    - `InverseRelationshipProcessor` 검증 로직 개선:
-        - Target entity가 아직 처리되지 않은 경우 조용히 스킵 (불필요한 WARNING 제거)
-- **Core 모듈**:
-    - `CreateTableBuilder.defaultsFrom()` 메서드 개선:
-        - `entity.getRelationships()`를 순회하여 `RelationshipAddContributor` 추가
-        - FK 제약 조건이 CREATE TABLE 이후 ALTER TABLE로 정상 생성됨
-
-### 🧪 Tests
-- `ToOneRelationshipProcessorTest`에 Deferred Processing 단위 테스트 4개 추가:
-    - `process_defers_when_referenced_entity_not_found()`
-    - `process_defers_only_once_when_referenced_entity_not_found()`
-    - `process_skips_when_relationship_already_processed()`
-    - `process_succeeds_after_referenced_entity_becomes_available()`
-- `DeferredToOneRelationshipProcessingTest` 통합 테스트 3개 추가:
-    - `manyToOne_deferred_processing_creates_fk_after_retry()`
-    - `multiple_manyToOne_deferred_processing()`
-    - `oneToOne_deferred_processing_creates_fk_with_unique()`
-
-### 📈 Impact
-- 엔티티 처리 순서 의존성 제거 → 안정적인 DDL 생성 보장
-- 복잡한 엔티티 관계 그래프에서도 모든 FK가 올바르게 생성됨
-- 하위 호환성 유지 (기존 동작 변경 없음, 누락되던 FK만 추가)
-
-### 📚 Documentation
-- `docs/issue/TOONE_DEFERRED_PROCESSING_FIX.md` 추가: 문제 분석, 해결 방법, 테스트 결과 상세 문서화
+* 컬럼 리네임과 함께 인덱스 / 제약조건 / 외래키가 변경되는 모든 MySQL 마이그레이션 시나리오
+* 기존 마이그레이션 SQL의 **실행 안정성 및 순서 보장성 향상**
 
 ---
 
-## [0.0.9] - 2025-10-23
-### 🔧 Fixed
-- **Primitive 타입**(`int`, `boolean`, `double` 등)이 `TEXT`로 잘못 매핑되던 문제 수정
-    - 이제 JPA 어노테이션에 맞게 `INT`, `TINYINT(1)`, `DOUBLE` 등으로 올바르게 매핑됨
-- **Enum 타입**(`@Enumerated(EnumType.STRING | ORDINAL)`)의 SQL 매핑 오류 수정
-    - `EnumType.STRING` → `VARCHAR(length)`
-    - `EnumType.ORDINAL` → `INT`
-- DDL 생성 로직을 Liquibase 타입 매핑 로직과 일관되게 통합
+### ✅ 검증
 
-### 🧩 Changed
-- `MySqlJavaTypeMapper`에 8개의 Primitive 타입 매핑 추가:
-    - `int`, `long`, `double`, `float`, `boolean`, `byte`, `short`, `char`
-- `MySqlDialect.getColumnDefinitionSql()`에 Enum 타입 처리 로직 추가
-
-### 🧪 Tests
-- Primitive 타입 매핑 테스트 8개 추가 (`MySqlJavaTypeMapperTest`)
-- Enum 타입 매핑 테스트 2개 추가 (`MySqlDialectTest`)
-- 전체 테스트 통과 및 회귀 없음
-
-### 📈 Impact
-- 10개 이상의 엔티티, 30개 이상의 컬럼이 잘못된 `TEXT` 타입에서 올바른 SQL 타입으로 수정됨
-- 완전한 하위 호환 유지 및 릴리즈 안정성 검증 완료
+* 컬럼 리네임 + 인덱스 변경 시나리오에서 SQL 생성 순서 확인
+* 실제 MySQL 환경에서 마이그레이션 SQL 정상 실행 확인

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Jinx analyzes your **JPA annotations at compile time**, generates **schema snaps
 
 Liquibase YAML is supported as an **output dialect**, but **SQL is the primary and most thoroughly validated output format**.
 
-**MySQL First** | **JDK 21+ Required** | **Latest Version: 0.0.21** | **JPA 3.2.0 Supported**
+**MySQL First** | **JDK 21+ Required** | **Latest Version: 0.0.22** | **JPA 3.2.0 Supported**
 
 ---
 
@@ -86,8 +86,8 @@ Liquibase support is **not the core model**, but a translation layer on top of S
 
 ```gradle
 dependencies {
-    annotationProcessor("io.github.yyubin:jinx-processor:0.0.21")
-    implementation("io.github.yyubin:jinx-core:0.0.21")
+    annotationProcessor("io.github.yyubin:jinx-processor:0.0.22")
+    implementation("io.github.yyubin:jinx-core:0.0.22")
 }
 ```
 
@@ -176,7 +176,7 @@ CREATE INDEX `ix_bird__zoo_id` ON `Bird` (`zoo_id`);
 
 ```kotlin
 plugins {
-    id("io.github.yyubin.jinx") version "0.0.21"
+    id("io.github.yyubin.jinx") version "0.0.22"
 }
 ```
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -11,7 +11,7 @@ Jinx는 **컴파일 타임에 JPA 애노테이션을 분석**하여
 Liquibase YAML도 **출력 포맷 중 하나**로 지원하지만,  
 **SQL이 주력이며 가장 많이 검증된 출력 결과**입니다.
 
-**MySQL 우선 지원** | **JDK 21+ 필요** | **최신 버전: 0.0.21** | **JPA 3.2.0 지원**
+**MySQL 우선 지원** | **JDK 21+ 필요** | **최신 버전: 0.0.22** | **JPA 3.2.0 지원**
 
 ---
 
@@ -98,8 +98,8 @@ Liquibase는 핵심 모델이 아니라
 
 ```gradle
 dependencies {
-    annotationProcessor("io.github.yyubin:jinx-processor:0.0.21")
-    implementation("io.github.yyubin:jinx-core:0.0.21")
+    annotationProcessor("io.github.yyubin:jinx-processor:0.0.22")
+    implementation("io.github.yyubin:jinx-core:0.0.22")
 }
 ````
 
@@ -155,7 +155,7 @@ jinx db migrate \
 
 ```kotlin
 plugins {
-    id("io.github.yyubin.jinx") version "0.0.21"
+    id("io.github.yyubin.jinx") version "0.0.22"
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'io.github.yyubin'
-version = '0.0.21'
+version = '0.0.22'
 
 java {
     toolchain {

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 **Jinx**는 JPA 애노테이션을 스캔해 스키마 스냅샷(JSON)을 만들고, 이전 스냅샷과 비교하여 **DB 마이그레이션 SQL**과 **Liquibase YAML**을 자동 생성하는 도구입니다.
 
-**현재 MySQL 우선 지원** | **JDK 21+ 필요** | **최신 릴리즈: 0.0.21**
+**현재 MySQL 우선 지원** | **JDK 21+ 필요** | **최신 릴리즈: 0.0.22**
 
 ## 빠른 시작
 
@@ -14,8 +14,8 @@ sidebar_position: 1
 
 ```gradle
 dependencies {
-    annotationProcessor "io.github.yyubin:jinx-processor:0.0.21"
-    implementation "io.github.yyubin:jinx-core:0.0.21"
+    annotationProcessor "io.github.yyubin:jinx-processor:0.0.22"
+    implementation "io.github.yyubin:jinx-core:0.0.22"
 }
 ```
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/intro.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/intro.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 **Jinx** is a tool that scans JPA annotations to create schema snapshots (JSON) and automatically generates **DB migration SQL** and **Liquibase YAML** by comparing with previous snapshots.
 
-**Currently prioritizes MySQL support** | **Requires JDK 21+** | **Latest release: 0.0.21**
+**Currently prioritizes MySQL support** | **Requires JDK 21+** | **Latest release: 0.0.22**
 
 ## Quick Start
 
@@ -14,8 +14,8 @@ sidebar_position: 1
 
 ```gradle
 dependencies {
-    annotationProcessor "io.github.yyubin:jinx-processor:0.0.21"
-    implementation "io.github.yyubin:jinx-core:0.0.21"
+    annotationProcessor "io.github.yyubin:jinx-processor:0.0.22"
+    implementation "io.github.yyubin:jinx-core:0.0.22"
 }
 ```
 


### PR DESCRIPTION
- Update versions in README, docs, changelog, and examples to 0.0.22.
- Adjust Gradle plugin version to 0.0.22 in build files.
- Ensure MySQL migration behavior and SQL generation order improvements are documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트 v0.0.22

* **릴리스(Release)**
  * 버전을 0.0.22로 업데이트했습니다.
  * 변경 로그를 새로운 릴리스 항목으로 정리했습니다.

* **문서(Documentation)**
  * 모든 문서 및 종속성 참고 자료의 버전 번호를 0.0.22로 업데이트했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->