### PR TITLE
Fix: 백킹 필드 없는 getter가 영속 속성으로 잘못 인식되는 버그 수정

### DIFF
--- a/jinx-processor/src/main/java/org/jinx/descriptor/AttributeDescriptorFactory.java
+++ b/jinx-processor/src/main/java/org/jinx/descriptor/AttributeDescriptorFactory.java
@@ -141,14 +141,13 @@ public class AttributeDescriptorFactory {
                 return Optional.of(new FieldAttributeDescriptor(field, typeUtils, elements));
             }
         } else {
-            // Default FIELD access or when defaultAccessType is FIELD
+            // Default FIELD access: only fields are persistent attributes.
+            // A getter without a backing field is a computed method and must NOT be mapped
+            // as a column. (JPA spec §2.3: In field-based access, only fields are persistent.)
             if (field != null) {
                 return Optional.of(new FieldAttributeDescriptor(field, typeUtils, elements));
             }
-            // If no field but getter exists, fall back to property access
-            if (getter != null) {
-                return createPropertyDescriptor(getter);
-            }
+            // No field → not a persistent attribute in FIELD access mode.
         }
 
         return Optional.empty();


### PR DESCRIPTION
FIELD access 모드에서 **백킹 필드가 없는 getter (`getXxx()`, `isXxx()`)가 영속 속성으로 잘못 인식되어 컬럼이 생성되는 버그**를 수정했습니다.

기존 로직에서는 `field == null`이어도 getter가 존재하면 `PropertyAttributeDescriptor`를 생성하는 fallback이 있어 계산 메서드까지 컬럼으로 매핑되었습니다.

```java
if (getter != null) {
    return createPropertyDescriptor(getter);
}
```

이를 제거하여 **FIELD access 모드에서는 필드만 영속 속성으로 처리**하도록 수정했습니다.

이 변경으로 `isSuccessful()`, `getFullName()` 같은 **백킹 필드 없는 계산 메서드는 더 이상 컬럼으로 생성되지 않습니다.**

JPA spec §2.3에 따라 FIELD access에서는 **필드만 persistent attribute**로 취급됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 속성 매핑 로직을 개선하여 데이터 처리의 일관성과 정확성을 향상시켰습니다.
  * 특정 시나리오에서 발생하던 예상치 못한 속성 인식 문제를 해결했습니다.
  * 기존의 필드 처리 동작은 유지되며, 전체적으로 더욱 안정적이고 예측 가능한 동작을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->