### PR TITLE
Fix: JOINED 상속에서 부모 컬럼이 자식 테이블에 중복 생성되는 문제 수정

### DIFF
--- a/jinx-processor/src/main/java/org/jinx/handler/EntityHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/EntityHandler.java
@@ -223,13 +223,12 @@ public class EntityHandler {
         TypeMirror superclass = type.getSuperclass();
         if (superclass.getKind() != TypeKind.DECLARED) return;
 
-        Optional<TypeElement> parentElementOptional = findNearestJoinedParentEntity(type);
+        Optional<TypeElement> parentElementOptional = findJoinedDirectParent(type);
         if (parentElementOptional.isEmpty()) {
             return;
         }
         TypeElement parentType = parentElementOptional.get();
-        Inheritance parentInheritance = parentType.getAnnotation(Inheritance.class);
-        if (parentInheritance == null || parentInheritance.strategy() != InheritanceType.JOINED) return;
+        // @Inheritance check removed: findJoinedDirectParent already confirmed JOINED hierarchy
 
         // Lookup parent entity model/PK columns
         EntityModel parentEntity = context.getSchemaModel().getEntities()
@@ -279,17 +278,34 @@ public class EntityHandler {
         }
     }
 
-    // Utility to protect against multi-level inheritance
-    private Optional<TypeElement> findNearestJoinedParentEntity(TypeElement type) {
+    /**
+     * O(n) single-pass: walks up the class hierarchy once and returns the <em>direct</em>
+     * {@code @Entity} parent, confirming the hierarchy is JOINED along the way.
+     *
+     * <p>Algorithm:
+     * <ol>
+     *   <li>First {@code @Entity} encountered → recorded as {@code directParent}.</li>
+     *   <li>Continue walking up.</li>
+     *   <li>When an ancestor with {@code @Inheritance(JOINED)} is found → hierarchy confirmed,
+     *       return {@code directParent} (not the root).</li>
+     *   <li>If a conflicting strategy (SINGLE_TABLE / TABLE_PER_CLASS) is found → error.</li>
+     *   <li>If no JOINED root is found → not a JOINED child, return empty.</li>
+     * </ol>
+     *
+     * <p>Previously this method was named {@code findNearestJoinedParentEntity} and mistakenly
+     * returned the JOINED <em>root</em> instead of the direct parent, causing all 3+ level
+     * children to create FK directly to the root table (Bug 3).
+     */
+    private Optional<TypeElement> findJoinedDirectParent(TypeElement type) {
         Set<String> seen = new java.util.HashSet<>();
         TypeMirror sup = type.getSuperclass();
+        TypeElement directParent = null;
 
         while (sup.getKind() == TypeKind.DECLARED) {
             TypeElement p = (TypeElement) ((DeclaredType) sup).asElement();
             String qn = p.getQualifiedName().toString();
 
             if (!seen.add(qn)) {
-                // Log warning and stop
                 context.getMessager().printMessage(
                         javax.tools.Diagnostic.Kind.WARNING,
                         "Detected inheritance cycle near: " + qn + " while scanning for JOINED parent of " +
@@ -298,36 +314,33 @@ public class EntityHandler {
                 break;
             }
 
-            // Continue upward if not an entity
-            if (p.getAnnotation(jakarta.persistence.Entity.class) == null) {
-                sup = p.getSuperclass();
-                continue;
+            if (p.getAnnotation(jakarta.persistence.Entity.class) != null) {
+                if (directParent == null) {
+                    directParent = p;  // first @Entity ancestor = direct parent
+                }
+                jakarta.persistence.Inheritance inh = p.getAnnotation(jakarta.persistence.Inheritance.class);
+                if (inh != null) {
+                    switch (inh.strategy()) {
+                        case JOINED:
+                            // JOINED root found → hierarchy confirmed, return direct parent
+                            return Optional.of(directParent);
+                        case SINGLE_TABLE:
+                        case TABLE_PER_CLASS:
+                            context.getMessager().printMessage(
+                                    javax.tools.Diagnostic.Kind.ERROR,
+                                    "Found explicit inheritance strategy '" + inh.strategy() +
+                                            "' at '" + qn + "' while searching for a JOINED parent of '" +
+                                            type.getQualifiedName() + "'. Mixed strategies in the same hierarchy are not supported.",
+                                    p
+                            );
+                            return Optional.empty();
+                        default:
+                            break;
+                    }
+                }
+                // @Entity without @Inheritance → intermediate child, keep walking up
             }
 
-            // Check inheritance strategy if it's an entity
-            jakarta.persistence.Inheritance inh = p.getAnnotation(jakarta.persistence.Inheritance.class);
-            if (inh != null) {
-                switch (inh.strategy()) {
-                    case JOINED:
-                        // Return nearest JOINED parent
-                        return Optional.of(p);
-                    case SINGLE_TABLE:
-                    case TABLE_PER_CLASS:
-                        // Conflict with JOINED search → error and terminate
-                        context.getMessager().printMessage(
-                                javax.tools.Diagnostic.Kind.ERROR,
-                                "Found explicit inheritance strategy '" + inh.strategy() +
-                                        "' at '" + qn + "' while searching for a JOINED parent of '" +
-                                        type.getQualifiedName() + "'. Mixed strategies in the same hierarchy are not supported.",
-                                p
-                        );
-                        return Optional.empty();
-                    default:
-                        // For future expansion: just continue
-                        break;
-                }
-            }
-            // Continue upward if no explicit @Inheritance
             sup = p.getSuperclass();
         }
         return Optional.empty();

--- a/jinx-processor/src/main/java/org/jinx/handler/InheritanceHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/InheritanceHandler.java
@@ -198,25 +198,51 @@ public class InheritanceHandler {
                     String fqcn = childEntity.getFqcn();
                     TypeElement childType = (fqcn == null || fqcn.isBlank()) ? null : context.getElementUtils().getTypeElement(fqcn);
                     if (childType == null) {
-                        // Skip if type cannot be resolved (logging the reason is optional).
                         context.getMessager().printMessage(
                                 Diagnostic.Kind.NOTE,
                                 "Skip inheritance child: cannot resolve TypeElement for " + fqcn);
                         return;
                     }
-                    if (context.getTypeUtils().isSubtype(childType.asType(), parentType.asType())) {
-                        try {
-                            processSingleJoinedChild(childEntity, parentEntity, childType);
-                            checkIdentityStrategy(childType, childEntity);
-                        } catch (IllegalStateException ex) {
-                            // If already logged as ERROR/NOTE, swallow here to proceed.
-                            childEntity.setValid(false);
-                        }
+                    // Only process DIRECT children of this root (immediate @Entity parent == parentType).
+                    // Grandchildren and deeper descendants are handled by EntityHandler.processInheritanceJoin(),
+                    // which uses findJoinedDirectParent() to create FK to the correct immediate parent.
+                    // Processing all isSubtype() matches here would cause every descendant to create a FK
+                    // directly to the root, overwriting the correct FK set by EntityHandler (Bug 3).
+                    TypeElement immediateEntityParent = findImmediateEntityParent(childType);
+                    if (immediateEntityParent == null ||
+                            !immediateEntityParent.getQualifiedName().toString()
+                                    .equals(parentType.getQualifiedName().toString())) {
+                        return;
+                    }
+                    try {
+                        processSingleJoinedChild(childEntity, parentEntity, childType);
+                        checkIdentityStrategy(childType, childEntity);
+                    } catch (IllegalStateException ex) {
+                        childEntity.setValid(false);
                     }
                 });
     }
 
     public record JoinPair(ColumnModel parent, String childName) {}
+
+    /**
+     * Walks up the class hierarchy and returns the first {@code @Entity} superclass,
+     * skipping non-JPA intermediate classes (plain Java base classes).
+     * Returns {@code null} if no {@code @Entity} ancestor is found before {@code Object}.
+     *
+     * <p>Used by {@link #findAndProcessJoinedChildren} to restrict processing to direct
+     * children only, preventing grandchildren from being incorrectly linked to the root.
+     */
+    private TypeElement findImmediateEntityParent(TypeElement type) {
+        javax.lang.model.type.TypeMirror sup = type.getSuperclass();
+        while (sup != null && sup.getKind() == javax.lang.model.type.TypeKind.DECLARED) {
+            TypeElement p = (TypeElement) ((javax.lang.model.type.DeclaredType) sup).asElement();
+            if ("java.lang.Object".equals(p.getQualifiedName().toString())) return null;
+            if (p.getAnnotation(jakarta.persistence.Entity.class) != null) return p;
+            sup = p.getSuperclass();
+        }
+        return null;
+    }
     
     /**
      * Normalizes a Java type name for comparison.

--- a/jinx-processor/src/test/java/org/jinx/handler/EntityHandlerInheritanceTest.java
+++ b/jinx-processor/src/test/java/org/jinx/handler/EntityHandlerInheritanceTest.java
@@ -105,35 +105,37 @@ class EntityHandlerInheritanceTest {
     // === 테스트 시나리오 ===
 
     @Test
-    @DisplayName("중간 부모가 @Inheritance 미지정이어도 상위에서 JOINED를 찾아 FK 생성")
-    void joinedParent_found_through_intermediate() {
-        // 체인: Child -> Mid(entity, @Inheritance 없음) -> Root(entity, @Inheritance JOINED) -> (없음)
+    @DisplayName("다단계 JOINED 계층에서 FK는 루트가 아닌 직계 부모를 참조해야 함 (Bug 3)")
+    void joinedChild_referencesDirectParent_notRoot() {
+        // 체인: Child -> Mid(entity, @Inheritance 없음) -> Root(entity, @Inheritance JOINED)
+        // 수정 전: FK → root_tbl (루트)
+        // 수정 후: FK → mid_tbl  (직계 부모)
         TypeElement root = mockTypeElement("com.ex.Root", "Root");
         when(root.getAnnotation(Entity.class)).thenReturn(AnnotationProxies.of(Entity.class, Map.of()));
         Inheritance inhJoined = AnnotationProxies.of(Inheritance.class, Map.of("strategy", InheritanceType.JOINED));
         when(root.getAnnotation(Inheritance.class)).thenReturn(inhJoined);
-        TypeMirror none = noneSuper();
-        when(root.getSuperclass()).thenReturn(none);
+        TypeMirror rootSuper = noneSuper();
+        when(root.getSuperclass()).thenReturn(rootSuper);
 
         TypeElement mid = mockTypeElement("com.ex.Mid", "Mid");
         when(mid.getAnnotation(Entity.class)).thenReturn(AnnotationProxies.of(Entity.class, Map.of()));
-        when(mid.getAnnotation(Inheritance.class)).thenReturn(null); // 명시 X
-        DeclaredType dtMid = declaredOf(root);
-        when(mid.getSuperclass()).thenReturn(dtMid);
+        when(mid.getAnnotation(Inheritance.class)).thenReturn(null);
+        DeclaredType midSuper = declaredOf(root);
+        when(mid.getSuperclass()).thenReturn(midSuper);
 
         TypeElement child = mockTypeElement("com.ex.Child", "child");
-        DeclaredType dtChild = declaredOf(mid);
-        when(child.getSuperclass()).thenReturn(dtChild);
+        DeclaredType childSuper = declaredOf(mid);
+        when(child.getSuperclass()).thenReturn(childSuper);
 
-        // 스키마: Root 엔티티는 이미 존재하며 PK가 준비되어 있어야 함
-        EntityModel rootEntity = EntityModelMother.javaEntityWithPkIdLong("com.ex.Root", "root_tbl");
-        when(entitiesMap.get("com.ex.Root")).thenReturn(rootEntity);
+        // 스키마: 직계 부모인 Mid 엔티티가 PK와 함께 존재해야 함
+        EntityModel midEntity = EntityModelMother.javaEntityWithPkIdLong("com.ex.Mid", "mid_tbl");
+        when(entitiesMap.get("com.ex.Mid")).thenReturn(midEntity);
         when(entitiesMap.containsKey("com.ex.Child")).thenReturn(false);
 
-        // 부모 PK 메타 제공
-        when(context.findAllPrimaryKeyColumns(rootEntity))
+        when(context.findAllPrimaryKeyColumns(midEntity))
                 .thenReturn(List.of(
-                        ColumnModel.builder().columnName("id").tableName("root_tbl").javaType("java.lang.Long").isPrimaryKey(true).build()
+                        ColumnModel.builder().columnName("id").tableName("mid_tbl")
+                                .javaType("java.lang.Long").isPrimaryKey(true).build()
                 ));
 
         // Act
@@ -143,20 +145,20 @@ class EntityHandlerInheritanceTest {
         EntityModel childModel = SchemaCapture.capturePutIfAbsent(entitiesMap, "com.ex.Child");
         assertEquals("child", childModel.getTableName());
 
-        // JOINED 상속 FK가 child 테이블에 생성되어 있어야 함
+        // FK는 루트(root_tbl)가 아닌 직계 부모(mid_tbl)를 참조해야 함
         RelationshipModel rel = childModel.getRelationships().values().stream()
                 .filter(r -> r.getType() == RelationshipType.JOINED_INHERITANCE)
                 .findFirst()
                 .orElseThrow();
 
-        assertEquals("child", rel.getTableName());         // FK가 걸리는 곳 = 자식 테이블
-        assertEquals("root_tbl", rel.getReferencedTable()); // 참조 = 루트(부모) 테이블
-        assertEquals(List.of("id"), rel.getColumns());     // 부모 PK 컬럼과 동일명 매핑
+        assertEquals("child", rel.getTableName());
+        assertEquals("mid_tbl", rel.getReferencedTable()); // Bug 3 수정: 루트 아닌 직계 부모
+        assertEquals(List.of("id"), rel.getColumns());
 
         RelationshipAssertions.assertFkByStructure(
                 childModel,
-                "child",     List.of("id"),
-                "root_tbl",  List.of("id"),
+                "child",    List.of("id"),
+                "mid_tbl",  List.of("id"),
                 RelationshipType.JOINED_INHERITANCE
         );
     }

--- a/jinx-processor/src/test/java/org/jinx/handler/InheritanceHandlerTest.java
+++ b/jinx-processor/src/test/java/org/jinx/handler/InheritanceHandlerTest.java
@@ -15,6 +15,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.annotation.processing.Messager;
 import javax.lang.model.element.*;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
@@ -117,19 +119,21 @@ class InheritanceHandlerTest {
 
         // === TypeElement 및 관련 객체들 명시적 모킹 ===
         TypeElement parentType = mock(TypeElement.class);
-        TypeMirror parentTypeMirror = mock(TypeMirror.class);
         Name parentName = mock(Name.class);
         lenient().when(parentName.toString()).thenReturn("com.example.Parent");
         lenient().when(parentType.getQualifiedName()).thenReturn(parentName);
-        when(parentType.asType()).thenReturn(parentTypeMirror);
         when(parentType.getAnnotation(Inheritance.class))
                 .thenReturn(AnnotationProxies.inheritance(InheritanceType.JOINED));
 
         TypeElement childType = mock(TypeElement.class);
-        TypeMirror childTypeMirror = mock(TypeMirror.class);
-        when(childType.asType()).thenReturn(childTypeMirror);
         when(elements.getTypeElement("com.example.Child")).thenReturn(childType);
-        when(types.isSubtype(childTypeMirror, parentTypeMirror)).thenReturn(true);
+
+        // findImmediateEntityParent(childType) 탐색: childType.superclass → parentType(@Entity)
+        DeclaredType childSuper = mock(DeclaredType.class);
+        when(childSuper.getKind()).thenReturn(TypeKind.DECLARED);
+        when(childSuper.asElement()).thenReturn(parentType);
+        when(childType.getSuperclass()).thenReturn(childSuper);
+        lenient().when(parentType.getAnnotation(Entity.class)).thenReturn(mock(Entity.class));
 
         // PK 조회 모킹
         when(context.findAllPrimaryKeyColumns(parent))
@@ -174,19 +178,21 @@ class InheritanceHandlerTest {
 
         // === TypeElement 명시적 모킹 ===
         TypeElement parentType = mock(TypeElement.class);
-        TypeMirror parentTypeMirror = mock(TypeMirror.class);
         Name parentName = mock(Name.class);
         lenient().when(parentName.toString()).thenReturn("com.example.Parent");
         lenient().when(parentType.getQualifiedName()).thenReturn(parentName);
-        when(parentType.asType()).thenReturn(parentTypeMirror);
         when(parentType.getAnnotation(Inheritance.class))
                 .thenReturn(AnnotationProxies.inheritance(InheritanceType.JOINED));
 
         TypeElement childType = mock(TypeElement.class);
-        TypeMirror childTypeMirror = mock(TypeMirror.class);
-        when(childType.asType()).thenReturn(childTypeMirror);
         when(elements.getTypeElement("com.example.Child")).thenReturn(childType);
-        when(types.isSubtype(childTypeMirror, parentTypeMirror)).thenReturn(true);
+
+        // findImmediateEntityParent(childType) 탐색: childType.superclass → parentType(@Entity)
+        DeclaredType childSuper1 = mock(DeclaredType.class);
+        when(childSuper1.getKind()).thenReturn(TypeKind.DECLARED);
+        when(childSuper1.asElement()).thenReturn(parentType);
+        when(childType.getSuperclass()).thenReturn(childSuper1);
+        lenient().when(parentType.getAnnotation(Entity.class)).thenReturn(mock(Entity.class));
 
         // parent PK 1개 모킹
         when(context.findAllPrimaryKeyColumns(parent))
@@ -222,21 +228,23 @@ class InheritanceHandlerTest {
 
         // === TypeElement 명시적 모킹 ===
         TypeElement parentType = mock(TypeElement.class);
-        TypeMirror parentTypeMirror = mock(TypeMirror.class);
         Name parentName = mock(Name.class);
         lenient().when(parentName.toString()).thenReturn("com.example.Parent");
         lenient().when(parentType.getQualifiedName()).thenReturn(parentName);
-        when(parentType.asType()).thenReturn(parentTypeMirror);
         when(parentType.getAnnotation(Inheritance.class))
                 .thenReturn(AnnotationProxies.inheritance(InheritanceType.JOINED));
 
         TypeElement childType = mock(TypeElement.class);
-        TypeMirror childTypeMirror = mock(TypeMirror.class);
-        when(childType.asType()).thenReturn(childTypeMirror);
         when(elements.getTypeElement("com.example.Child")).thenReturn(childType);
-        when(types.isSubtype(childTypeMirror, parentTypeMirror)).thenReturn(true);
         when(childType.getAnnotation(PrimaryKeyJoinColumn.class)).thenReturn(null);
         when(childType.getAnnotation(PrimaryKeyJoinColumns.class)).thenReturn(null);
+
+        // findImmediateEntityParent(childType) 탐색: childType.superclass → parentType(@Entity)
+        DeclaredType childSuper2 = mock(DeclaredType.class);
+        when(childSuper2.getKind()).thenReturn(TypeKind.DECLARED);
+        when(childSuper2.asElement()).thenReturn(parentType);
+        when(childType.getSuperclass()).thenReturn(childSuper2);
+        lenient().when(parentType.getAnnotation(Entity.class)).thenReturn(mock(Entity.class));
 
         when(context.findAllPrimaryKeyColumns(parent))
                 .thenReturn(List.of(parent.findColumn("parent","id")));

--- a/jinx-processor/src/test/java/org/jinx/processor/JoinedInheritanceDuplicateColumnTest.java
+++ b/jinx-processor/src/test/java/org/jinx/processor/JoinedInheritanceDuplicateColumnTest.java
@@ -157,16 +157,22 @@ class JoinedInheritanceDuplicateColumnTest extends AbstractProcessorTest {
     }
 
     @Test
-    void deepChild_shouldHaveForeignKeyToJoinedRoot() {
-        // jinx의 현재 구현: findNearestJoinedParentEntity()는 @Inheritance(JOINED)가 붙은 가장
-        // 가까운 조상을 탐색한다. Car에는 @Inheritance가 없으므로 SportsCar의 FK는 루트인
-        // vehicles를 직접 가리킨다.
+    void deepChild_shouldHaveForeignKeyToDirectParent() {
+        // Bug 3 수정 후: findJoinedDirectParent()가 직계 @Entity 부모(Car)를 반환하므로
+        // SportsCar의 FK는 루트(vehicles)가 아닌 직계 부모(cars)를 가리켜야 한다.
         EntityModel sportsCar = schema.getEntities().get("entities.joined.SportsCar");
-        boolean hasFkToJoinedRoot = sportsCar.getRelationships().values().stream()
-                .anyMatch(rel -> "vehicles".equals(rel.getReferencedTable()));
-        assertThat(hasFkToJoinedRoot)
-                .as("SportsCar must have a FK relationship pointing to the JOINED root 'vehicles'")
+        boolean hasFkToCars = sportsCar.getRelationships().values().stream()
+                .anyMatch(rel -> "cars".equals(rel.getReferencedTable()));
+        assertThat(hasFkToCars)
+                .as("SportsCar must have a FK pointing to its direct parent 'cars', not to the root 'vehicles' (Bug 3)")
                 .isTrue();
+
+        // 루트(vehicles)를 직접 가리키는 잘못된 FK가 없어야 함
+        boolean hasSpuriousFkToRoot = sportsCar.getRelationships().values().stream()
+                .anyMatch(rel -> "vehicles".equals(rel.getReferencedTable()));
+        assertThat(hasSpuriousFkToRoot)
+                .as("SportsCar must NOT have a spurious FK directly to the root 'vehicles'")
+                .isFalse();
     }
 
     // ══════════════════════════════════════════════════════════


### PR DESCRIPTION
JOINED 상속 전략에서 **부모 `@Entity`의 컬럼이 자식 테이블에도 중복 생성되는 버그**를 수정했습니다.

기존 `collectAttributesFromHierarchy()` 구현은 수퍼클래스 타입과 관계없이 재귀적으로 필드를 수집했기 때문에, 부모 `@Entity`의 필드까지 자식 엔티티의 컬럼으로 포함되었습니다. 이로 인해 JOINED 구조에서 **부모 컬럼이 자식 테이블에도 생성되어 INSERT 시 `NOT NULL` 제약 위반이 발생할 수 있었습니다.**

### Before

```java
collectAttributesFromHierarchy(AccessUtils.getSuperclass(typeElement), candidates);
```

### After

```java
TypeElement superclass = AccessUtils.getSuperclass(typeElement);
if (superclass != null && superclass.getAnnotation(Entity.class) == null) {
    collectAttributesFromHierarchy(superclass, candidates);
}
```

이제 **수퍼클래스가 `@Entity`인 경우 재귀 탐색을 중단**하여:

* 부모 `@Entity`의 컬럼은 부모 테이블에만 생성되고
* 자식 테이블에는 **자식 전용 컬럼 + PK(FK)**만 생성됩니다.

`@MappedSuperclass`, `TABLE_PER_CLASS`, `SINGLE_TABLE` 전략에는 영향을 주지 않습니다.

---

## Tests

다음 회귀 테스트를 추가했습니다.

### `JoinedInheritanceDuplicateColumnTest`

JOINED 상속 구조에서

* 자식 테이블에 **부모 컬럼이 생성되지 않는지**
* 자식 테이블이 **자식 전용 컬럼 + PK(FK)**만 가지는지
* FK가 **JOINED 루트 테이블을 참조하는지**

를 검증합니다.

테스트 대상 구조

```
Vehicle (@Inheritance JOINED)
 ├─ Car
 │   └─ SportsCar
 └─ Truck
```

검증 내용

* `Car` → `id`, `numDoors`
* `Truck` → `id`, `payload`
* `SportsCar` → `id`, `topSpeed`

그리고 다음 컬럼이 존재하면 실패하도록 검증합니다.

* `manufacturer` (Vehicle 컬럼)
* `numDoors` (Car 컬럼, SportsCar에서 금지)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * 다단계 JOINED 상속 계층에서 외래 키가 루트 대신 직접 부모 테이블을 올바르게 참조하도록 수정했습니다. 상속 처리 로직을 개선하여 중간 엔티티가 있는 경우에도 정확한 부모 관계를 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->