### PR TITLE
fix: correct column type mapping for @Convert with @Column(length)

### DIFF
--- a/jinx-core/src/main/java/org/jinx/migration/dialect/mysql/MySqlDialect.java
+++ b/jinx-core/src/main/java/org/jinx/migration/dialect/mysql/MySqlDialect.java
@@ -170,8 +170,13 @@ public class MySqlDialect extends AbstractDialect
 
     @Override
     public String getColumnDefinitionSql(ColumnModel c) {
-        String javaType = c.getConversionClass() != null ? c.getConversionClass() : c.getJavaType();
-        JavaTypeMapper.JavaType javaTypeMapped = javaTypeMapper.map(javaType);
+        // converter 출력 타입(Y)이 있으면 우선 사용하고, 없으면 원본 javaType으로 폴백한다.
+        // conversionClass(컨버터 클래스명)는 MySqlJavaTypeMapper가 인식하지 못해 UNKNOWN_TYPE → TEXT가
+        // 생성되는 버그를 유발하므로 타입 결정에서 제외한다.
+        String typeKey = c.getConverterOutputType() != null
+                ? c.getConverterOutputType()
+                : c.getJavaType();
+        JavaTypeMapper.JavaType javaTypeMapped = javaTypeMapper.map(typeKey);
 
         boolean overrideContainsIdentity = false;
         boolean overrideContainsNotNull = false;
@@ -522,8 +527,12 @@ public class MySqlDialect extends AbstractDialect
         if (column.getSqlTypeOverride() != null && !column.getSqlTypeOverride().trim().isEmpty()) {
             return column.getSqlTypeOverride().trim();
         }
-        
-        String javaType = column.getJavaType();
+
+        // converter 출력 타입(Y)이 있으면 우선 사용하고, 없으면 원본 javaType으로 폴백한다.
+        // 이를 통해 @Convert + @Column(length=N) 조합에서 올바른 타입을 생성한다.
+        String javaType = column.getConverterOutputType() != null
+                ? column.getConverterOutputType()
+                : column.getJavaType();
         int length = column.getLength();
         int precision = column.getPrecision();
         int scale = column.getScale();

--- a/jinx-core/src/main/java/org/jinx/migration/liquibase/LiquibaseVisitor.java
+++ b/jinx-core/src/main/java/org/jinx/migration/liquibase/LiquibaseVisitor.java
@@ -637,8 +637,10 @@ public class LiquibaseVisitor implements TableVisitor, TableContentVisitor, Sequ
                 .map(lb -> lb.getLiquibaseTypeName(c))
                 .orElseGet(() -> {
                     var ddl = dialectBundle.ddl();
+                    // converter 출력 타입(Y)이 있으면 우선 사용하고, 없으면 원본 javaType으로 폴백한다.
+                    // conversionClass(컨버터 클래스명)는 JavaTypeMapper가 인식하지 못하므로 제외한다.
                     var jt = ddl.getJavaTypeMapper().map(
-                            c.getConversionClass() != null ? c.getConversionClass() : c.getJavaType());
+                            c.getConverterOutputType() != null ? c.getConverterOutputType() : c.getJavaType());
                     return jt.getSqlType(c.getLength(), c.getPrecision(), c.getScale());
                 });
     }

--- a/jinx-core/src/main/java/org/jinx/model/ColumnModel.java
+++ b/jinx-core/src/main/java/org/jinx/model/ColumnModel.java
@@ -102,6 +102,19 @@ public class ColumnModel {
     @Builder.Default
     private String conversionClass = null;
 
+    /**
+     * {@code @Convert} 어노테이션이 붙은 필드에서 {@code AttributeConverter<X, Y>}의
+     * Y 타입(실제 DB 저장 타입)의 FQCN을 저장한다.
+     * <p>
+     * 예) {@code MoneyConverter implements AttributeConverter<Money, String>} → {@code "java.lang.String"}
+     * <p>
+     * DDL/Liquibase 타입 결정 시 {@code conversionClass}(컨버터 클래스명) 대신 이 값을 사용함으로써
+     * {@code MySqlJavaTypeMapper}가 컨버터 클래스명을 인식하지 못해 {@code TEXT}가 생성되는 버그를 수정한다.
+     * diff 추적 기준이 아닌 타입 결정용 메타데이터이므로 {@code getAttributeHash()} 에는 포함하지 않는다.
+     */
+    @Builder.Default
+    private String converterOutputType = null;
+
     @Builder.Default
     private TemporalType temporalType = null;
 

--- a/jinx-processor/src/main/java/org/jinx/handler/builtins/AttributeBasedEntityResolver.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/builtins/AttributeBasedEntityResolver.java
@@ -61,9 +61,18 @@ public class AttributeBasedEntityResolver implements AttributeColumnResolver {
             } catch (javax.lang.model.type.MirroredTypeException mte) {
                 TypeMirror typeMirror = mte.getTypeMirror();
                 builder.conversionClass(typeMirror.toString());
+                // AttributeConverter<X, Y>의 Y 타입(DB 저장 타입)을 추출해 저장한다.
+                // DDL/Liquibase 타입 결정 시 컨버터 클래스명 대신 이 값을 사용하여
+                // UNKNOWN_TYPE → TEXT 생성 버그를 수정한다.
+                String outputType = ColumnBuilderFactory.extractConverterOutputType(typeMirror);
+                if (outputType != null) {
+                    builder.converterOutputType(outputType);
+                }
             }
         } else {
             // Check for autoApply converters
+            // 주의: autoApply 경로는 TypeMirror가 없으므로 converterOutputType 추출 불가.
+            // 해당 케이스는 미처리 케이스로 남기며 기존 동작을 유지한다.
             String targetTypeName = actualType.toString();
             String converterClass = context.getAutoApplyConverters().get(targetTypeName);
             if (converterClass != null) {

--- a/jinx-processor/src/main/java/org/jinx/handler/builtins/EntityFieldResolver.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/builtins/EntityFieldResolver.java
@@ -54,8 +54,17 @@ public class EntityFieldResolver extends AbstractColumnResolver {
             } catch (javax.lang.model.type.MirroredTypeException mte) {
                 TypeMirror typeMirror = mte.getTypeMirror();
                 builder.conversionClass(typeMirror.toString());
+                // AttributeConverter<X, Y>의 Y 타입(DB 저장 타입)을 추출해 저장한다.
+                // DDL/Liquibase 타입 결정 시 컨버터 클래스명 대신 이 값을 사용하여
+                // UNKNOWN_TYPE → TEXT 생성 버그를 수정한다.
+                String outputType = ColumnBuilderFactory.extractConverterOutputType(typeMirror);
+                if (outputType != null) {
+                    builder.converterOutputType(outputType);
+                }
             }
         } else {
+            // 주의: autoApply 경로는 TypeMirror가 없으므로 converterOutputType 추출 불가.
+            // 해당 케이스는 미처리 케이스로 남기며 기존 동작을 유지한다.
             String autoApplyConverter = context.getAutoApplyConverters().get(field.asType().toString());
             if (autoApplyConverter != null) {
                 builder.conversionClass(autoApplyConverter);

--- a/jinx-processor/src/main/java/org/jinx/util/ColumnBuilderFactory.java
+++ b/jinx-processor/src/main/java/org/jinx/util/ColumnBuilderFactory.java
@@ -6,8 +6,11 @@ import org.jinx.descriptor.AttributeDescriptor;
 import org.jinx.model.ColumnModel;
 import org.jinx.model.GenerationStrategy;
 
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
+import java.util.List;
 import java.util.Map;
 
 public class ColumnBuilderFactory {
@@ -117,6 +120,34 @@ public class ColumnBuilderFactory {
     
     private static boolean isNotBlank(String s) {
         return s != null && !s.isEmpty();
+    }
+
+    /**
+     * {@code AttributeConverter<X, Y>}의 Y 타입(DB 저장 타입)을 추출한다.
+     * <p>
+     * 어노테이션 프로세서 환경에서 제네릭 인터페이스를 탐색하여 Y 타입의 FQCN을 반환한다.
+     * 추출한 값은 {@link org.jinx.model.ColumnModel#getConverterOutputType()}에 저장되며,
+     * DDL/Liquibase 타입 결정 시 컨버터 클래스명 대신 실제 DB 저장 타입으로 매핑에 사용된다.
+     *
+     * @param converterMirror {@code @Convert(converter=...)}로 지정된 컨버터 클래스의 {@link TypeMirror}
+     * @return Y 타입의 FQCN (예: {@code "java.lang.String"}), 추출 불가 시 {@code null}
+     */
+    public static String extractConverterOutputType(TypeMirror converterMirror) {
+        if (!(converterMirror instanceof DeclaredType converterDeclaredType)) {
+            return null;
+        }
+        TypeElement converterElement = (TypeElement) converterDeclaredType.asElement();
+        for (TypeMirror iface : converterElement.getInterfaces()) {
+            // jakarta.persistence.AttributeConverter<X, Y> 인터페이스를 탐색한다
+            if (iface.toString().startsWith("jakarta.persistence.AttributeConverter")) {
+                List<? extends TypeMirror> typeArgs = ((DeclaredType) iface).getTypeArguments();
+                if (typeArgs.size() == 2) {
+                    // 두 번째 타입 파라미터 Y (DB 저장 타입)를 반환한다
+                    return typeArgs.get(1).toString();
+                }
+            }
+        }
+        return null;
     }
 
 }


### PR DESCRIPTION
fix: `@Convert` + `@Column(length)` 사용 시 TEXT로 생성되는 버그 수정 (Option 4)

## 문제

```java
@Convert(converter = MoneyConverter.class)
@Column(length = 30, nullable = false)
private Money price;
```

→ `price` 컬럼이 `TEXT NOT NULL` 로 생성됨 (length 무시)

## 원인

- `MySqlDialect` 및 Liquibase 타입 결정 시 `conversionClass` (컨버터 클래스명)을 `JavaTypeMapper`에 넘김
- 컨버터 클래스명은 `UNKNOWN_TYPE` → `TEXT` 로 매핑
- `@Column(length=...)` 정보가 완전히 무시됨

## 해결 방식 (Option 4)

- 어노테이션 프로세서 단계에서 `AttributeConverter<X, Y>`의 **Y 타입** (DB 실제 저장 타입)을 추출
- `ColumnModel.converterOutputType` 필드에 저장
- DDL / Liquibase 타입 결정 시 `converterOutputType` → `javaType` 순으로 우선 사용

## 주요 변경 사항

- `ColumnModel`에 `converterOutputType` 필드 추가
- `ColumnBuilderFactory`에 `extractConverterOutputType()` 헬퍼 추가
- `@Convert` 처리 시 Y 타입 추출 및 저장 (`AttributeBasedEntityResolver`, `EntityFieldResolver`)
- `MySqlDialect`, `LiquibaseVisitor` 타입 결정 로직 수정

## 결과

| Converter 예시                        | `@Column` 설정      | 이전     | 이후              |
|---------------------------------------|---------------------|----------|-------------------|
| `MoneyConverter<Money, String>`       | `length=30`         | `TEXT`   | `VARCHAR(30)`     |
| `BoolToIntConverter<Boolean, Integer>`| (기본)              | `TEXT`   | `INT`             |
| `PriceConverter<Price, BigDecimal>`   | `precision=10,scale=2` | `TEXT` | `DECIMAL(10,2)` |
| `@Converter(autoApply=true)`          | —                   | `TEXT`   | `TEXT` (미처리)   |

## 주의사항

- `ColumnModel`에 새 필드 추가 → **baseline JSON 구조 변경**
- `@Convert`가 적용된 엔티티가 있는 프로젝트는 반드시 아래 명령 재실행 필요

```bash
./gradlew jinx:baseline
```

baseline 미갱신 시 schema diff가 잘못 발생할 수 있습니다.

## 남은 이슈

- `@Converter(autoApply = true)` 케이스는 여전히 `TypeMirror`가 없어 미처리
  → 추후 별도 개선 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 사용자 정의 타입 변환기를 사용할 때 데이터베이스 컬럼 타입이 더 정확하게 결정됩니다.
  * 변환기 출력 타입이 이제 올바르게 인식되어, 컬럼 길이 정의와 함께 사용할 때 정확한 타입이 생성됩니다.
  * 데이터베이스 마이그레이션 및 스키마 생성 시 타입 매핑이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->