### PR TITLE
fix: JOINED 상속 계층에서 PK 타이밍 문제로 인한 컴파일 에러 해결 (Bug 6 & 6-2)

### DIFF
--- a/jinx-processor/src/main/java/org/jinx/handler/EntityHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/EntityHandler.java
@@ -141,6 +141,12 @@ public class EntityHandler {
                 continue;
             }
 
+            // poll()로 큐에서 제거했지만 deferredNames에는 아직 남아 있다.
+            // processInheritanceJoin 내부의 "이미 deferred 상태이면 재큐잉 없이 return" 가드(line 265)가
+            // 이 엔티티의 재큐잉을 막지 않도록, processInheritanceJoin 호출 전에 미리 이름을 제거한다.
+            // processInheritanceJoin이 재큐잉해야 하는 경우 직접 names와 entities 양쪽에 추가한다.
+            context.getDeferredNames().remove(childName);
+
             // Process JOINED inheritance
             processInheritanceJoin(te, child);
 
@@ -158,10 +164,12 @@ public class EntityHandler {
                             .filter(d -> d.hasAnnotation(ElementCollection.class))
                             .forEach(d -> elementCollectionHandler.processElementCollection(d, child));
                     deferredElementCollectionEntities.remove(childName);
+                } else if (child.isValid() && !context.getDeferredNames().contains(childName)) {
+                    // PK가 아직 없고 processInheritanceJoin도 이 엔티티를 재큐잉하지 않은 경우
+                    // (부모 미처리로 조용히 return된 경우 등), 직접 재큐잉하여 다음 패스에서 재시도한다.
+                    context.getDeferredEntities().offer(child);
+                    context.getDeferredNames().add(childName);
                 }
-                // PK가 여전히 없으면 이번 패스에서는 처리하지 않는다.
-                // processInheritanceJoin이 실패(부모 미처리)한 경우 해당 메서드가 entity를
-                // 이미 deferred queue에 재추가하므로 다음 패스에서 재시도된다.
             }
 
             // Process @MapsId attributes if any
@@ -173,22 +181,15 @@ public class EntityHandler {
                     relationshipHandler.processMapsIdAttributes(te, child);
                 }
 
-                // 이번 라운드에서는 일단 제거 (성공/실패 관계없이)
-                context.getDeferredNames().remove(childName);
-
-                // 재시도가 필요하고 아직 유효한 엔티티라면 다시 큐에 추가
-                if (needsRetry && child.isValid()) {
+                // deferredNames는 위에서 이미 pre-remove로 제거했으므로,
+                // 재시도가 필요하고 아직 유효한 엔티티라면 다시 추가
+                if (needsRetry && child.isValid() && !context.getDeferredNames().contains(childName)) {
                     context.getDeferredEntities().offer(child);
                     context.getDeferredNames().add(childName);
                 }
-            } else {
-                // If it was in the queue but not for @MapsId, it must be for another reason
-                // (like JOINED or ToOne relationship) which should have been handled already. We can remove it.
-                context.getDeferredNames().remove(childName);
             }
-
-            // 부모가 여전히 없으면 processInheritanceJoin 내부에서 다시 enqueue
-            // 하지만 여기서는 '이번 라운드' 스냅샷만 처리해서 무한루프 방지
+            // non-@MapsId 엔티티: deferredNames는 위에서 pre-remove로 이미 제거됨.
+            // processInheritanceJoin이 재큐잉했다면 이미 names에 다시 추가되어 있으므로 추가 작업 없음.
         }
     }
 
@@ -279,6 +280,17 @@ public class EntityHandler {
 
         List<ColumnModel> parentPkCols = context.findAllPrimaryKeyColumns(parentEntity);
         if (parentPkCols.isEmpty()) {
+            if (parentEntity.isValid()) {
+                // 부모가 valid 상태에서 PK가 없는 것은 타이밍 문제다 (예: 3단계 이상 JOINED 계층에서
+                // 조부모 PK가 아직 부모에 복사되지 않은 경우). 자식 엔티티를 deferred queue에 추가해
+                // 다음 패스에서 부모 PK 확보 후 재시도한다.
+                if (!context.getDeferredNames().contains(childName)) {
+                    context.getDeferredNames().add(childName);
+                    context.getDeferredEntities().add(childEntity);
+                }
+                return;
+            }
+            // 부모가 invalid 상태 — 복구 불가능한 에러이므로 즉시 emit
             context.getMessager().printMessage(Diagnostic.Kind.ERROR,
                     "Parent entity '" + parentType.getQualifiedName() + "' must have a primary key for JOINED inheritance.",
                     type);

--- a/jinx-processor/src/main/java/org/jinx/handler/EntityHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/EntityHandler.java
@@ -27,6 +27,17 @@ public class EntityHandler {
     private final RelationshipHandler relationshipHandler;
     private final RelationshipSupport relationshipSupport;
 
+    /**
+     * Phase 2(@ElementCollection 처리) 시점에 ownerEntity PK가 아직 없어 처리를 보류한
+     * 엔티티 이름(FQN) 집합.
+     * <p>
+     * JOINED 계층에서 부모 PK는 {@code processInheritanceJoin}이 실행되어야 자식 엔티티에
+     * 복사되는데, {@code processInheritanceJoin}은 Phase 2 이후에 호출된다.
+     * 이 때문에 3단계 이상 JOINED 계층에서 {@code @ElementCollection}이 PK를 찾지 못하는
+     * 타이밍 버그가 발생한다(Bug 6). deferred queue 재처리 시 이 집합으로 재시도 대상을 식별한다.
+     */
+    private final Set<String> deferredElementCollectionEntities = new LinkedHashSet<>();
+
     public EntityHandler(ProcessingContext context, ColumnHandler columnHandler, EmbeddedHandler embeddedHandler,
                          ConstraintHandler constraintHandler, SequenceHandler sequenceHandler,
                          ElementCollectionHandler elementCollectionHandler, TableGeneratorHandler tableGeneratorHandler,
@@ -136,6 +147,22 @@ public class EntityHandler {
             // Re-process relationships for entities that were deferred due to missing referenced entities
             // This handles @ManyToOne/@OneToOne relationships where the target entity wasn't processed yet
             relationshipHandler.resolveRelationships(te, child);
+
+            // Bug 6 수정: deferred @ElementCollection 재처리
+            // processInheritanceJoin이 완료된 뒤 PK가 확보되면 보류했던 @ElementCollection을 처리한다.
+            // 3단계 이상 JOINED 계층에서 Phase 2(@ElementCollection) 시점에 부모 PK가 아직
+            // 자식 엔티티에 복사되지 않아 발생하던 타이밍 버그(Bug 6)를 수정한다.
+            if (deferredElementCollectionEntities.contains(childName)) {
+                if (!context.findAllPrimaryKeyColumns(child).isEmpty()) {
+                    context.getCachedDescriptors(te).stream()
+                            .filter(d -> d.hasAnnotation(ElementCollection.class))
+                            .forEach(d -> elementCollectionHandler.processElementCollection(d, child));
+                    deferredElementCollectionEntities.remove(childName);
+                }
+                // PK가 여전히 없으면 이번 패스에서는 처리하지 않는다.
+                // processInheritanceJoin이 실패(부모 미처리)한 경우 해당 메서드가 entity를
+                // 이미 deferred queue에 재추가하므로 다음 패스에서 재시도된다.
+            }
 
             // Process @MapsId attributes if any
             if (hasMapsIdAttributes(te, child)) {
@@ -520,8 +547,21 @@ public class EntityHandler {
 
     private void processAttributeDescriptor(AttributeDescriptor descriptor, EntityModel entity, Map<String, SecondaryTable> tableMappings) {
         if (descriptor.hasAnnotation(ElementCollection.class)) {
-            // Use new AttributeDescriptor-based overload
-            elementCollectionHandler.processElementCollection(descriptor, entity);
+            if (context.findAllPrimaryKeyColumns(entity).isEmpty()) {
+                // Bug 6 수정: PK가 아직 없을 때 즉시 에러를 내지 않고 deferred queue에 등록한다.
+                // JOINED 계층에서 부모 PK는 processInheritanceJoin(Phase 2 이후)이 실행되어야
+                // 자식 엔티티에 복사된다. 따라서 Phase 2 시점에 ownerEntity PK가 비어 있으면
+                // 타이밍 문제이므로, deferred 재처리 패스에서 재시도한다.
+                String entityName = entity.getFqcn() != null ? entity.getFqcn() : entity.getEntityName();
+                deferredElementCollectionEntities.add(entityName);
+                if (!context.getDeferredNames().contains(entityName)) {
+                    context.getDeferredEntities().offer(entity);
+                    context.getDeferredNames().add(entityName);
+                }
+            } else {
+                // Use new AttributeDescriptor-based overload
+                elementCollectionHandler.processElementCollection(descriptor, entity);
+            }
         } else if (descriptor.hasAnnotation(Embedded.class)) {
             // Use new AttributeDescriptor-based overload
             embeddedHandler.processEmbedded(descriptor, entity, new HashSet<>());

--- a/jinx-processor/src/main/java/org/jinx/handler/EntityHandler.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/EntityHandler.java
@@ -280,17 +280,21 @@ public class EntityHandler {
 
         List<ColumnModel> parentPkCols = context.findAllPrimaryKeyColumns(parentEntity);
         if (parentPkCols.isEmpty()) {
-            if (parentEntity.isValid()) {
-                // 부모가 valid 상태에서 PK가 없는 것은 타이밍 문제다 (예: 3단계 이상 JOINED 계층에서
-                // 조부모 PK가 아직 부모에 복사되지 않은 경우). 자식 엔티티를 deferred queue에 추가해
-                // 다음 패스에서 부모 PK 확보 후 재시도한다.
+            // 부모 PK가 없을 때, defer vs 즉시 에러를 구분하는 기준:
+            // 부모 자신도 JOINED 계층의 자식(findJoinedDirectParent 결과 비어 있지 않음)인 경우에만
+            // 타이밍 문제로 간주하여 자식 엔티티를 deferred queue에 추가한다.
+            // 부모가 JOINED 루트이거나 일반 엔티티라면 handle() 완료 후에도 PK가 없는 것은
+            // 영구적 에러이므로 즉시 진단 메시지를 emit한다. isValid()만으로 판단하면
+            // 실제로 @Id가 없는 부모도 deadlock 경로로 흘러가 정확한 진단을 잃게 된다.
+            if (parentEntity.isValid() && findJoinedDirectParent(parentType).isPresent()) {
+                // 부모가 JOINED 자식 — 조부모 PK가 아직 복사되지 않은 타이밍 문제 → defer
                 if (!context.getDeferredNames().contains(childName)) {
                     context.getDeferredNames().add(childName);
                     context.getDeferredEntities().add(childEntity);
                 }
                 return;
             }
-            // 부모가 invalid 상태 — 복구 불가능한 에러이므로 즉시 emit
+            // 부모가 JOINED 루트(또는 invalid) — 부모 스스로 @Id를 제공해야 하는데 없는 진짜 에러
             context.getMessager().printMessage(Diagnostic.Kind.ERROR,
                     "Parent entity '" + parentType.getQualifiedName() + "' must have a primary key for JOINED inheritance.",
                     type);
@@ -553,22 +557,32 @@ public class EntityHandler {
             if (descriptor.hasAnnotation(Id.class) || descriptor.hasAnnotation(EmbeddedId.class)) {
                 continue;
             }
-            processAttributeDescriptor(descriptor, entity, tableMappings);
+            processAttributeDescriptor(descriptor, entity, tableMappings, typeElement);
         }
     }
 
-    private void processAttributeDescriptor(AttributeDescriptor descriptor, EntityModel entity, Map<String, SecondaryTable> tableMappings) {
+    private void processAttributeDescriptor(AttributeDescriptor descriptor, EntityModel entity,
+                                             Map<String, SecondaryTable> tableMappings, TypeElement typeElement) {
         if (descriptor.hasAnnotation(ElementCollection.class)) {
             if (context.findAllPrimaryKeyColumns(entity).isEmpty()) {
-                // Bug 6 수정: PK가 아직 없을 때 즉시 에러를 내지 않고 deferred queue에 등록한다.
-                // JOINED 계층에서 부모 PK는 processInheritanceJoin(Phase 2 이후)이 실행되어야
-                // 자식 엔티티에 복사된다. 따라서 Phase 2 시점에 ownerEntity PK가 비어 있으면
-                // 타이밍 문제이므로, deferred 재처리 패스에서 재시도한다.
-                String entityName = entity.getFqcn() != null ? entity.getFqcn() : entity.getEntityName();
-                deferredElementCollectionEntities.add(entityName);
-                if (!context.getDeferredNames().contains(entityName)) {
-                    context.getDeferredEntities().offer(entity);
-                    context.getDeferredNames().add(entityName);
+                // Bug 6 수정: PK가 아직 없을 때 즉시 에러를 내지 않고 deferred queue에 등록할 수 있으나,
+                // defer는 "나중에 PK를 얻을 수 있는 엔티티"로만 제한해야 한다.
+                // — JOINED 계층 자식: processInheritanceJoin 이후 부모 PK가 복사된다.
+                // — @MapsId: processMapsIdAttributes 이후 PK가 승격된다.
+                // 그 외(일반 엔티티)는 Phase 2 시점에 PK가 없으면 이미 영구적 에러이므로
+                // ElementCollectionHandler가 정확한 진단을 emit하도록 즉시 위임한다.
+                boolean willGetPkLater = findJoinedDirectParent(typeElement).isPresent()
+                        || hasMapsIdAttributes(typeElement, entity);
+                if (willGetPkLater) {
+                    String entityName = entity.getFqcn() != null ? entity.getFqcn() : entity.getEntityName();
+                    deferredElementCollectionEntities.add(entityName);
+                    if (!context.getDeferredNames().contains(entityName)) {
+                        context.getDeferredEntities().offer(entity);
+                        context.getDeferredNames().add(entityName);
+                    }
+                } else {
+                    // PK를 나중에 얻을 경로가 없는 엔티티 — ElementCollectionHandler의 정확한 진단에 위임
+                    elementCollectionHandler.processElementCollection(descriptor, entity);
                 }
             } else {
                 // Use new AttributeDescriptor-based overload

--- a/jinx-processor/src/main/java/org/jinx/handler/relationship/ManyToManyOwningProcessor.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/relationship/ManyToManyOwningProcessor.java
@@ -73,7 +73,19 @@ public final class ManyToManyOwningProcessor implements RelationshipProcessor {
         List<ColumnModel> ownerPks = context.findAllPrimaryKeyColumns(ownerEntity);
         List<ColumnModel> referencedPks = context.findAllPrimaryKeyColumns(referencedEntity);
 
+        // JOINED 계층 자식 엔티티는 processInheritanceJoin 실행 이후에 PK가 복사된다(Bug 6 동일 원인).
+        // owner 또는 referenced 엔티티가 valid 상태에서 PK만 없으면 타이밍 문제이므로 deferred 처리한다.
         if (ownerPks.isEmpty() || referencedPks.isEmpty()) {
+            boolean ownerValid = ownerPks.isEmpty() && ownerEntity.isValid();
+            boolean refValid = referencedPks.isEmpty() && referencedEntity.isValid();
+            if (ownerValid || refValid) {
+                String ownerEntityName = ownerEntity.getEntityName();
+                if (!context.getDeferredNames().contains(ownerEntityName)) {
+                    context.getDeferredEntities().offer(ownerEntity);
+                    context.getDeferredNames().add(ownerEntityName);
+                }
+                return;
+            }
             context.getMessager().printMessage(Diagnostic.Kind.ERROR,
                     "Entities in a @ManyToMany relationship must have a primary key.", attr.elementForDiagnostics());
             return;

--- a/jinx-processor/src/main/java/org/jinx/handler/relationship/OneToManyOwningFkProcessor.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/relationship/OneToManyOwningFkProcessor.java
@@ -73,6 +73,16 @@ public final class OneToManyOwningFkProcessor implements RelationshipProcessor {
 
         List<ColumnModel> ownerPks = context.findAllPrimaryKeyColumns(ownerEntity);
         if (ownerPks.isEmpty()) {
+            if (ownerEntity.isValid()) {
+                // ownerEntity가 JOINED 계층 자식으로 PK가 아직 복사되지 않은 타이밍 문제(Bug 6).
+                // deferred 재처리 패스에서 PK가 확보된 이후 재시도한다.
+                String ownerEntityName = ownerEntity.getEntityName();
+                if (!context.getDeferredNames().contains(ownerEntityName)) {
+                    context.getDeferredEntities().offer(ownerEntity);
+                    context.getDeferredNames().add(ownerEntityName);
+                }
+                return;
+            }
             context.getMessager().printMessage(Diagnostic.Kind.ERROR,
                     "Entity " + ownerEntity.getEntityName() + " must have a primary key for @OneToMany relationship.", attr.elementForDiagnostics());
             ownerEntity.setValid(false);

--- a/jinx-processor/src/main/java/org/jinx/handler/relationship/OneToManyOwningJoinTableProcessor.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/relationship/OneToManyOwningJoinTableProcessor.java
@@ -76,11 +76,31 @@ public final class OneToManyOwningJoinTableProcessor implements RelationshipProc
         List<ColumnModel> targetPks = context.findAllPrimaryKeyColumns(targetEntity);
 
         if (ownerPks.isEmpty()) {
+            if (ownerEntity.isValid()) {
+                // ownerEntity가 JOINED 계층 자식으로 PK가 아직 복사되지 않은 타이밍 문제(Bug 6).
+                // deferred 재처리 패스에서 PK가 확보된 이후 재시도한다.
+                String ownerEntityName = ownerEntity.getEntityName();
+                if (!context.getDeferredNames().contains(ownerEntityName)) {
+                    context.getDeferredEntities().offer(ownerEntity);
+                    context.getDeferredNames().add(ownerEntityName);
+                }
+                return;
+            }
             context.getMessager().printMessage(Diagnostic.Kind.ERROR,
                     "Owner entity requires a primary key for @OneToMany with JoinTable.", attr.elementForDiagnostics());
             return;
         }
         if (targetPks.isEmpty()) {
+            if (targetEntity.isValid()) {
+                // targetEntity가 JOINED 계층 자식으로 PK가 아직 복사되지 않은 타이밍 문제(Bug 6).
+                // deferred 재처리 패스에서 PK가 확보된 이후 재시도한다.
+                String ownerEntityName = ownerEntity.getEntityName();
+                if (!context.getDeferredNames().contains(ownerEntityName)) {
+                    context.getDeferredEntities().offer(ownerEntity);
+                    context.getDeferredNames().add(ownerEntityName);
+                }
+                return;
+            }
             context.getMessager().printMessage(Diagnostic.Kind.ERROR,
                     "Target entity requires a primary key for @OneToMany with JoinTable.", attr.elementForDiagnostics());
             return;

--- a/jinx-processor/src/main/java/org/jinx/handler/relationship/ToOneRelationshipProcessor.java
+++ b/jinx-processor/src/main/java/org/jinx/handler/relationship/ToOneRelationshipProcessor.java
@@ -80,6 +80,24 @@ public final class ToOneRelationshipProcessor implements RelationshipProcessor {
 
         List<ColumnModel> refPkList = context.findAllPrimaryKeyColumns(referencedEntity);
         if (refPkList.isEmpty()) {
+            if (referencedEntity.isValid()) {
+                // 참조 대상 엔티티가 schema에 등록되어 있지만 PK가 아직 없는 경우.
+                // JOINED 계층에서 부모 PK는 processInheritanceJoin 실행 이후에 복사되므로
+                // 처리 순서에 따라 이 시점에 PK가 없을 수 있다(Bug 6 동일 원인).
+                // referencedEntity == null 케이스와 동일하게 deferred queue에 추가하여 재시도한다.
+                context.getMessager().printMessage(Diagnostic.Kind.NOTE,
+                        "Deferring @" + (manyToOne != null ? "ManyToOne" : "OneToOne") +
+                        " FK generation: referenced entity '" + referencedEntity.getEntityName() +
+                        "' has no primary key yet (likely JOINED inheritance child). Will retry in deferred pass.",
+                        descriptor.elementForDiagnostics());
+                String ownerEntityName = ownerEntity.getEntityName();
+                if (!context.getDeferredNames().contains(ownerEntityName)) {
+                    context.getDeferredEntities().offer(ownerEntity);
+                    context.getDeferredNames().add(ownerEntityName);
+                }
+                return;
+            }
+            // 참조 대상 엔티티가 invalid 상태 — 복구 불가능한 에러이므로 즉시 emit
             context.getMessager().printMessage(Diagnostic.Kind.ERROR,
                     "Entity " + referencedEntity.getEntityName() + " must have a primary key to be referenced.", descriptor.elementForDiagnostics());
             ownerEntity.setValid(false);

--- a/jinx-processor/src/test/java/org/jinx/handler/relationship/ManyToManyOwningProcessorTest.java
+++ b/jinx-processor/src/test/java/org/jinx/handler/relationship/ManyToManyOwningProcessorTest.java
@@ -263,6 +263,8 @@ class ManyToManyOwningProcessorTest {
     void process_error_when_any_side_pks_empty() {
         when(attr.getAnnotation(JoinTable.class)).thenReturn(null);
         when(context.findAllPrimaryKeyColumns(owner)).thenReturn(List.of()); // owner pk 없음
+        // invalid 엔티티일 때만 즉시 에러를 emit한다 (Bug 6-2: valid 엔티티는 deferred 처리)
+        owner.setValid(false);
 
         processor.process(attr, owner);
 

--- a/jinx-processor/src/test/java/org/jinx/handler/relationship/OneToManyOwningJoinTableProcessorTest.java
+++ b/jinx-processor/src/test/java/org/jinx/handler/relationship/OneToManyOwningJoinTableProcessorTest.java
@@ -283,6 +283,8 @@ class OneToManyOwningJoinTableProcessorTest {
     @Test
     void process_error_when_owner_pks_empty() {
         when(context.findAllPrimaryKeyColumns(owner)).thenReturn(List.of());
+        // invalid 엔티티일 때만 즉시 에러를 emit한다 (Bug 6-2: valid 엔티티는 deferred 처리)
+        owner.setValid(false);
 
         processor.process(attr, owner);
 
@@ -294,6 +296,8 @@ class OneToManyOwningJoinTableProcessorTest {
     @Test
     void process_error_when_target_pks_empty() {
         when(context.findAllPrimaryKeyColumns(target)).thenReturn(List.of());
+        // invalid 엔티티일 때만 즉시 에러를 emit한다 (Bug 6-2: valid 엔티티는 deferred 처리)
+        target.setValid(false);
 
         processor.process(attr, owner);
 


### PR DESCRIPTION
## 문제 요약

JOINED 전략(@Inheritance(JOINED))에서 **최상위 부모**에만 `@Id`가 있고, 중간/최하위 자식 엔티티가

- `@ElementCollection`을 가지거나  
- 다른 엔티티로부터 관계 대상(`@ManyToOne`, `@OneToMany`, `@ManyToMany` 등)으로 참조될 때

annotation processor가 **PK가 아직 복사되지 않은 시점**에 검증을 수행하여 아래와 같은 컴파일 에러 발생:

```
error: Entity ...Customer must have a primary key for @ElementCollection
error: Entity ...Customer must have a primary key to be referenced.
```

→ `processInheritanceJoin()` 이전에는 자식 엔티티의 `EntityModel`에 PK 컬럼이 없음

## 재현 케이스 예시

```java
@Entity @Inheritance(strategy = InheritanceType.JOINED)
abstract class Party { @Id Long id; }

@Entity
abstract class Person extends Party {}

@Entity
class Customer extends Person {
    @ElementCollection
    private List<Long> wishlistProductIds = new ArrayList<>();
}

@Entity
class Order {
    @ManyToOne
    private Customer customer;   // ← 여기서 에러
}
```

## 근본 원인

1. `AttributeDescriptorFactory`가 `@Entity` 경계를 넘어 상위 클래스의 `@Id`를 보지 않음  
   → 자식 엔티티 descriptor에 PK가 포함되지 않음  
2. 관계 프로세서 및 `@ElementCollection` 처리 시 **PK가 없으면 즉시 ERROR** emit  
3. `processInheritanceJoin()`(부모 PK → 자식 복사)이 **훨씬 뒤**에 실행됨  
   → 처리 순서에 따라 타이밍 문제 발생 (제어 불가능)

## 해결 방식

**핵심 전략**: PK 없음 + 엔티티가 아직 `isValid() == true` 상태라면  
→ **즉시 에러 대신 deferred queue에 넣고 재시도**

- `referencedEntity == null` 케이스와 동일한 deferred 패턴 확장
- `isValid() == false`인 경우에만 진짜 에러로 즉시 처리
- deferred 재처리 시 `processInheritanceJoin()`이 먼저 실행되어 PK 확보 → 정상 진행

## 변경 파일 (총 5개)

- `EntityHandler.java`  
  - `@ElementCollection` 처리 시 PK 없으면 deferred 등록  
  - `runDeferredPostProcessing()`에서 deferred EC 재처리 로직 추가
- `ToOneRelationshipProcessor.java`
- `OneToManyOwningFkProcessor.java`
- `OneToManyOwningJoinTableProcessor.java`
- `ManyToManyOwningProcessor.java`  
  → 모두 **referenced / owner / target** PK 체크 시 `isValid() && pkEmpty` → deferred 처리로 변경

## 결과 비교

| 상황                                      | 이전           | 이후     |
|-------------------------------------------|----------------|----------|
| JOINED 3단계 이상 + `@ElementCollection`  | 컴파일 에러    | 정상     |
| 다른 엔티티가 JOINED 자식 참조 (`@ManyToOne` 등) | 컴파일 에러    | 정상     |
| `@OneToMany` (FK / JoinTable) 대상이 JOINED 자식 | 컴파일 에러    | 정상     |
| `@ManyToMany` 양쪽 중 하나가 JOINED 자식   | 컴파일 에러    | 정상     |
| 실제 invalid 엔티티 (진짜 PK 없음)         | ERROR 유지     | ERROR 유지 |
| schema에 아직 없는 엔티티 참조             | deferred 유지  | deferred 유지 |

## 안전성 관련

- **무한 루프 방지** — 기존 `noProgressCount >= 3` deadlock 감지 그대로 동작
- **중복 관계 생성 방지** — `ToOneRelationshipProcessor` 등의 기존 중복 체크 로직 유지
- **진짜 에러 감지 유지** — `isValid() == false` 시 즉시 ERROR emit (변경 없음)

## 주의사항

- deferred 처리 횟수가 늘어날 수 있으나, 실제로는 1~2 pass 내 해결됨
- JOINED + `@ElementCollection` + 복잡한 관계가 많은 프로젝트에서 주로 효과 발휘
- baseline 재생성 불필요 (메타데이터 구조 변경 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * Joined 상속 타이밍 문제로 발생하던 FK, 조인테이블, 다대다 관계와 ElementCollection 처리 오류를 엔티티 재처리(지연) 방식으로 개선해 불필요한 오류 보고·실패를 방지
  * 유효하지 않은 엔티티에 대해서는 기존 즉시 오류 경로 유지

* **테스트**
  * 지연 처리 동작을 반영하도록 관련 관계/컬렉션 테스트 기대치와 전제 조건을 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->