### PR TITLE
refactor: 옵션 로딩 구조 개선 & jinx.yaml naming.strategy 지원

### DIFF
--- a/jinx-core/src/main/java/org/jinx/config/ConfigurationLoader.java
+++ b/jinx-core/src/main/java/org/jinx/config/ConfigurationLoader.java
@@ -104,9 +104,15 @@ public class ConfigurationLoader {
         var configMap = new HashMap<>(createDefaultConfiguration());
 
         // naming 설정 적용
-        if (profileConfig.getNaming() != null && profileConfig.getNaming().getMaxLength() != null) {
-            configMap.put(JinxOptions.Naming.MAX_LENGTH_KEY,
-                         String.valueOf(profileConfig.getNaming().getMaxLength()));
+        if (profileConfig.getNaming() != null) {
+            if (profileConfig.getNaming().getMaxLength() != null) {
+                configMap.put(JinxOptions.Naming.MAX_LENGTH_KEY,
+                             String.valueOf(profileConfig.getNaming().getMaxLength()));
+            }
+            if (profileConfig.getNaming().getStrategy() != null) {
+                configMap.put(JinxOptions.Naming.STRATEGY_KEY,
+                             profileConfig.getNaming().getStrategy());
+            }
         }
 
         // 향후 database, output 설정들도 여기에 추가

--- a/jinx-core/src/main/java/org/jinx/config/model/JinxConfiguration.java
+++ b/jinx-core/src/main/java/org/jinx/config/model/JinxConfiguration.java
@@ -40,6 +40,9 @@ public class JinxConfiguration {
 
         @JsonProperty("maxLength")
         private Integer maxLength;
+
+        @JsonProperty("strategy")
+        private String strategy;
     }
 
     /**

--- a/jinx-processor/src/main/java/org/jinx/context/ProcessingContext.java
+++ b/jinx-processor/src/main/java/org/jinx/context/ProcessingContext.java
@@ -9,8 +9,6 @@ import org.jinx.model.EntityModel;
 import org.jinx.model.SchemaModel;
 import org.jinx.naming.DefaultNaming;
 import org.jinx.naming.Naming;
-import org.jinx.options.JinxOptions;
-import org.jinx.config.ConfigurationLoader;
 import org.jinx.processor.JpaSqlGeneratorProcessor;
 import org.jinx.spi.naming.JinxNamingStrategy;
 import org.jinx.spi.naming.impl.NoOpNamingStrategy;
@@ -64,72 +62,28 @@ public class ProcessingContext {
     private final Map<String, Map<String, List<String>>> pkAttributeToColumnMap = new HashMap<>();
 
     /**
-     * 기본 생성자 (하위 호환성 유지)
-     * namingStrategy는 NoOpNamingStrategy로 초기화됩니다.
+     * 기본 생성자 (테스트용)
+     * namingStrategy는 NoOpNamingStrategy, maxLength는 기본값(30)으로 초기화됩니다.
      */
     public ProcessingContext(ProcessingEnvironment processingEnv, SchemaModel schemaModel) {
-        this(processingEnv, schemaModel, new NoOpNamingStrategy());
+        this(processingEnv, schemaModel, new NoOpNamingStrategy(), 30);
     }
 
     /**
-     * 네이밍 전략을 지정하는 생성자
+     * 네이밍 전략과 maxLength를 지정하는 생성자.
+     * 옵션 읽기는 {@link org.jinx.processor.JpaSqlGeneratorProcessor}에서 처리 후 전달합니다.
      *
      * @param processingEnv 어노테이션 프로세싱 환경
      * @param schemaModel 스키마 모델
      * @param namingStrategy 네이밍 전략 (null인 경우 NoOpNamingStrategy 사용)
+     * @param maxLength 제약조건/인덱스명 최대 길이
      */
-    public ProcessingContext(ProcessingEnvironment processingEnv, SchemaModel schemaModel, JinxNamingStrategy namingStrategy) {
+    public ProcessingContext(ProcessingEnvironment processingEnv, SchemaModel schemaModel, JinxNamingStrategy namingStrategy, int maxLength) {
         this.processingEnv = processingEnv;
         this.schemaModel = schemaModel;
         this.namingStrategy = namingStrategy != null ? namingStrategy : new NoOpNamingStrategy();
-
-        // Load configuration (with profile support).
-        Map<String, String> config = loadConfiguration(processingEnv);
-        int maxLength = parseMaxLength(config);
-
         this.naming = new DefaultNaming(maxLength);
         this.attributeDescriptorFactory = new AttributeDescriptorFactory(processingEnv.getTypeUtils(), processingEnv.getElementUtils(), this);
-    }
-
-    /**
-     * Loads configuration, considering profiles.
-     * Priority: -A options > configuration file > default values.
-     */
-    private Map<String, String> loadConfiguration(ProcessingEnvironment processingEnv) {
-        // Determine profile: -Ajinx.profile > JINX_PROFILE environment variable > dev.
-        String profile = processingEnv.getOptions().get(JinxOptions.Profile.PROCESSOR_KEY);
-
-        ConfigurationLoader loader = new ConfigurationLoader();
-        Map<String, String> config = loader.loadConfiguration(profile);
-
-        // If values are explicitly specified with -A options, they override the config file.
-        String explicitMaxLength = processingEnv.getOptions().get(JinxOptions.Naming.MAX_LENGTH_KEY);
-        if (explicitMaxLength != null) {
-            Map<String, String> mutableConfig = new HashMap<>(config);
-            mutableConfig.put(JinxOptions.Naming.MAX_LENGTH_KEY, explicitMaxLength);
-            return mutableConfig;
-        }
-
-        return config;
-    }
-
-    /**
-     * Parses the maxLength value from the configuration.
-     */
-    private int parseMaxLength(Map<String, String> config) {
-        String maxLenOpt = config.get(JinxOptions.Naming.MAX_LENGTH_KEY);
-        int maxLength = JinxOptions.Naming.MAX_LENGTH_DEFAULT;
-
-        if (maxLenOpt != null) {
-            try {
-                maxLength = Integer.parseInt(maxLenOpt);
-            } catch (NumberFormatException e) {
-                getMessager().printMessage(Diagnostic.Kind.WARNING,
-                        "Invalid " + JinxOptions.Naming.MAX_LENGTH_KEY + ": " + maxLenOpt + " (use default " + maxLength + ")");
-            }
-        }
-
-        return maxLength;
     }
 
 

--- a/jinx-processor/src/main/java/org/jinx/processor/JpaSqlGeneratorProcessor.java
+++ b/jinx-processor/src/main/java/org/jinx/processor/JpaSqlGeneratorProcessor.java
@@ -57,9 +57,10 @@ public class JpaSqlGeneratorProcessor extends AbstractProcessor {
                 .version(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss")))
                 .build();
 
-        // Create naming strategy based on annotation processor options
+        // Read all options here and pass to ProcessingContext
         JinxNamingStrategy namingStrategy = createNamingStrategy(processingEnv);
-        this.context = new ProcessingContext(processingEnv, schemaModel, namingStrategy);
+        int maxLength = parseMaxLength(processingEnv);
+        this.context = new ProcessingContext(processingEnv, schemaModel, namingStrategy, maxLength);
 
         this.sequenceHandler = new SequenceHandler(context);
         ColumnHandler columnHandler = new ColumnHandler(context, sequenceHandler);
@@ -73,7 +74,29 @@ public class JpaSqlGeneratorProcessor extends AbstractProcessor {
     }
 
     /**
-     * Create naming strategy based on annotation processor options
+     * Parse maxLength from annotation processor options.
+     * Priority: -Ajinx.naming.maxLength > default (30)
+     */
+    private int parseMaxLength(ProcessingEnvironment processingEnv) {
+        String value = processingEnv.getOptions().get(JinxOptions.Naming.MAX_LENGTH_KEY);
+        if (value == null || value.isBlank()) {
+            return JinxOptions.Naming.MAX_LENGTH_DEFAULT;
+        }
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            processingEnv.getMessager().printMessage(
+                    Diagnostic.Kind.WARNING,
+                    "Invalid " + JinxOptions.Naming.MAX_LENGTH_KEY + ": " + value
+                    + ". Using default " + JinxOptions.Naming.MAX_LENGTH_DEFAULT + "."
+            );
+            return JinxOptions.Naming.MAX_LENGTH_DEFAULT;
+        }
+    }
+
+    /**
+     * Create naming strategy based on annotation processor options.
+     * Priority: -Ajinx.naming.strategy > default (NO_OP)
      */
     private JinxNamingStrategy createNamingStrategy(ProcessingEnvironment processingEnv) {
         String strategyOption = processingEnv.getOptions().get(JinxOptions.Naming.STRATEGY_KEY);


### PR DESCRIPTION
## 개요

Annotation Processor 내 옵션 처리 로직이 분산되어 있고, `jinx.yaml`에서 `naming.strategy`가 읽히지 않는 문제를 해결했습니다.  
또한 프로세서 내부에서 불필요하게 `jinx.yaml`을 다시 읽는 이중 로직도 제거했습니다.

## 주요 변경 사항

- **설계 방향 변경**  
  → Annotation Processor는 `-A` 옵션만 신뢰하도록 일원화  
  → `jinx.yaml` 및 Gradle DSL은 모두 `-Akey=value` 형태로 변환되어 전달

- **YAML 지원 확대**  
  `naming.strategy` 필드 추가 및 `ConfigurationLoader`에서 처리하도록 수정  
  → 이제 `jinx.yaml`에서도 strategy 설정 가능

- **코드 정리 & 책임 분리**  
  - `ProcessingContext`에서 `ConfigurationLoader` 호출 및 옵션 파싱 로직 완전 제거  
  - `JpaSqlGeneratorProcessor.init()`에서 모든 `-A` 옵션 파싱 집중  
  - `ProcessingContext` 생성자에 `maxLength`를 명시적 인자로 전달

## 변경 전 → 변경 후 옵션 지원 현황

| 옵션      | YAML 모델 | YAML 읽기 | Gradle DSL | `-A` 옵션 | 비고                     |
|-----------|-----------|-----------|------------|-----------|--------------------------|
| maxLength | ✓         | ✓         | ✓          | ✓         |                          |
| strategy  | ❌ → **✓** | ❌ → **✓** | ✓          | ✓         | 이번에 YAML 지원 추가됨  |
| profile   | ✓         | ✓         | ✓          | ✓         |                          |

## 영향 범위

- Annotation Processor 진입점 (`JpaSqlGeneratorProcessor`)
- `ProcessingContext` 생성 및 초기화 로직
- `JinxConfiguration`, `ConfigurationLoader`
- Gradle 플러그인 및 CLI에서는 **기존 동작 유지** (이미 `-A`로 변환하므로 영향 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 명명 전략 구성 지원 추가

* **개선**
  * 명명 구성 처리 시 안정성 강화
  * 구성 기본값 처리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->