### PR TITLE
FK 의존성 기반 테이블 정렬 도입

### DIFF
--- a/jinx-core/src/main/java/org/jinx/migration/DependencyResolver.java
+++ b/jinx-core/src/main/java/org/jinx/migration/DependencyResolver.java
@@ -1,0 +1,117 @@
+package org.jinx.migration;
+
+import org.jinx.model.EntityModel;
+import org.jinx.model.RelationshipModel;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * FK 의존성 기반 위상정렬 (Kahn's BFS).
+ *
+ * <p>{@link #sortByFkDependency}는 부모 테이블(참조 대상)이 먼저 오는 순서를 반환합니다.
+ * CREATE 순서로 사용하고, DROP 순서는 호출부에서 {@code .reversed()}를 적용합니다.
+ *
+ * <p>입력 집합 내 테이블 간 FK만 고려하며, 사이클 감지 시 경고를 출력하고 원본 순서를 유지합니다.
+ */
+public final class DependencyResolver {
+
+    private DependencyResolver() {}
+
+    /**
+     * FK 의존성 기준으로 테이블 목록을 정렬합니다.
+     *
+     * <ul>
+     *   <li>부모 테이블(referencedTable)이 자식 테이블(FK 보유)보다 앞에 위치합니다.</li>
+     *   <li>{@code noConstraint=true} 관계는 실제 FK가 없으므로 의존성 집계에서 제외됩니다.</li>
+     *   <li>입력 집합 밖 테이블에 대한 참조 및 자기 참조는 무시합니다.</li>
+     *   <li>사이클 감지 시 {@code System.err}에 경고를 출력하고 원본 리스트를 반환합니다.</li>
+     * </ul>
+     *
+     * @param tables 정렬할 테이블 목록
+     * @return FK 의존성 기준으로 정렬된 새 리스트 (원본 불변)
+     */
+    public static List<EntityModel> sortByFkDependency(List<EntityModel> tables) {
+        if (tables == null) {
+            return List.of();
+        }
+        if (tables.size() <= 1) {
+            return tables;
+        }
+
+        // 테이블명(소문자) → EntityModel 맵 (입력 순서 보존)
+        Map<String, EntityModel> byName = new LinkedHashMap<>();
+        for (EntityModel entity : tables) {
+            if (entity.getTableName() != null) {
+                byName.put(entity.getTableName().toLowerCase(), entity);
+            }
+        }
+
+        if (byName.size() <= 1) {
+            return tables;
+        }
+
+        Set<String> scope = byName.keySet();
+
+        // in-degree: 선행 부모 수
+        // successors: parent → 이 parent가 처리된 후 in-degree를 줄일 child 집합
+        // LinkedHashSet으로 중복 엣지(동일 부모를 향한 FK 복수 개)를 방지하고 삽입 순서를 유지
+        Map<String, Integer> inDegree = new HashMap<>();
+        Map<String, Set<String>> successors = new HashMap<>();
+
+        for (String name : scope) {
+            inDegree.put(name, 0);
+            successors.put(name, new LinkedHashSet<>());
+        }
+
+        for (EntityModel entity : tables) {
+            if (entity.getTableName() == null) continue;
+            String child = entity.getTableName().toLowerCase();
+
+            Map<String, RelationshipModel> rels = entity.getRelationships();
+            if (rels == null) continue;
+
+            for (RelationshipModel rel : rels.values()) {
+                if (rel.isNoConstraint() || rel.getReferencedTable() == null) continue;
+                String parent = rel.getReferencedTable().toLowerCase();
+
+                if (!scope.contains(parent) || parent.equals(child)) continue;
+
+                // 동일 parent→child 엣지가 이미 추가되었으면 in-degree를 중복 증가시키지 않음
+                if (successors.get(parent).add(child)) {
+                    inDegree.merge(child, 1, Integer::sum);
+                }
+            }
+        }
+
+        // Kahn's BFS: in-degree 0인 노드(의존성 없는 부모)부터 처리
+        Queue<String> queue = new ArrayDeque<>();
+        inDegree.forEach((name, deg) -> {
+            if (deg == 0) queue.add(name);
+        });
+
+        List<EntityModel> sorted = new ArrayList<>(tables.size());
+        while (!queue.isEmpty()) {
+            String node = queue.poll();
+            sorted.add(byName.get(node));
+            for (String child : successors.get(node)) {
+                if (inDegree.merge(child, -1, Integer::sum) == 0) {
+                    queue.add(child);
+                }
+            }
+        }
+
+        // 처리된 노드 수가 입력보다 적으면 사이클 존재
+        if (sorted.size() != byName.size()) {
+            Set<String> cycleNodes = inDegree.entrySet().stream()
+                    .filter(e -> e.getValue() > 0)
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            System.err.println("[jinx] WARNING: FK dependency cycle detected among tables: "
+                    + cycleNodes + ". Falling back to original order.");
+            return tables;
+        }
+
+        return sorted;
+    }
+}

--- a/jinx-core/src/main/java/org/jinx/migration/DependencyResolver.java
+++ b/jinx-core/src/main/java/org/jinx/migration/DependencyResolver.java
@@ -85,10 +85,11 @@ public final class DependencyResolver {
         }
 
         // Kahn's BFS: in-degree 0인 노드(의존성 없는 부모)부터 처리
+        // byName(LinkedHashMap) 삽입 순서로 초기화해 독립 테이블 간 출력 순서를 결정론적으로 유지
         Queue<String> queue = new ArrayDeque<>();
-        inDegree.forEach((name, deg) -> {
-            if (deg == 0) queue.add(name);
-        });
+        for (String name : byName.keySet()) {
+            if (inDegree.get(name) == 0) queue.add(name);
+        }
 
         List<EntityModel> sorted = new ArrayList<>(tables.size());
         while (!queue.isEmpty()) {

--- a/jinx-core/src/main/java/org/jinx/migration/DependencyResolver.java
+++ b/jinx-core/src/main/java/org/jinx/migration/DependencyResolver.java
@@ -43,7 +43,7 @@ public final class DependencyResolver {
         Map<String, EntityModel> byName = new LinkedHashMap<>();
         for (EntityModel entity : tables) {
             if (entity.getTableName() != null) {
-                byName.put(entity.getTableName().toLowerCase(), entity);
+                byName.put(entity.getTableName().toLowerCase(Locale.ROOT), entity);
             }
         }
 
@@ -66,14 +66,14 @@ public final class DependencyResolver {
 
         for (EntityModel entity : tables) {
             if (entity.getTableName() == null) continue;
-            String child = entity.getTableName().toLowerCase();
+            String child = entity.getTableName().toLowerCase(Locale.ROOT);
 
             Map<String, RelationshipModel> rels = entity.getRelationships();
             if (rels == null) continue;
 
             for (RelationshipModel rel : rels.values()) {
                 if (rel.isNoConstraint() || rel.getReferencedTable() == null) continue;
-                String parent = rel.getReferencedTable().toLowerCase();
+                String parent = rel.getReferencedTable().toLowerCase(Locale.ROOT);
 
                 if (!scope.contains(parent) || parent.equals(child)) continue;
 

--- a/jinx-core/src/main/java/org/jinx/migration/MigrationGenerator.java
+++ b/jinx-core/src/main/java/org/jinx/migration/MigrationGenerator.java
@@ -41,19 +41,31 @@ public class MigrationGenerator {
             out.append(v.getGeneratedSql()).append('\n');
         }
 
-        // 1-2) 테이블 드롭/리네임
+        // 1-2) 테이블 드롭 (renamed old entity 포함 — rename은 DROP+CREATE로 처리)
         {
             var v = providers.tableVisitor().get();
-            diff.tableAccept(v, DiffResult.TablePhase.DROPPED);
-            diff.tableAccept(v, DiffResult.TablePhase.RENAMED);
+            var allToDrop = new java.util.ArrayList<>(diff.getDroppedTables());
+            diff.getRenamedTables().stream()
+                    .map(DiffResult.RenamedTable::getOldEntity)
+                    .forEach(allToDrop::add);
+            // FK 참조 역방향: 자식 테이블(FK 보유)이 부모보다 먼저 DROP되어야 함
+            DependencyResolver.sortByFkDependency(allToDrop)
+                    .reversed()
+                    .forEach(v::visitDroppedTable);
             out.append(((SqlGeneratingVisitor)v).getGeneratedSql()).append('\n');
         }
 
         // 2) 구성적 변경 (ADD/ALTER)
-        // 2-1) 테이블 생성
+        // 2-1) 테이블 생성 (renamed new entity 포함 — rename은 DROP+CREATE로 처리)
         {
             var v = providers.tableVisitor().get();
-            diff.tableAccept(v, DiffResult.TablePhase.ADDED);
+            var allToAdd = new java.util.ArrayList<>(diff.getAddedTables());
+            diff.getRenamedTables().stream()
+                    .map(DiffResult.RenamedTable::getNewEntity)
+                    .forEach(allToAdd::add);
+            // FK 참조 정방향: 부모 테이블이 자식보다 먼저 CREATE되어야 함
+            DependencyResolver.sortByFkDependency(allToAdd)
+                    .forEach(v::visitAddedTable);
             out.append(((SqlGeneratingVisitor)v).getGeneratedSql()).append('\n');
         }
 
@@ -71,11 +83,15 @@ public class MigrationGenerator {
             out.append(v.getGeneratedSql()).append('\n');
         }
 
-        for (var a : diff.getAddedTables()) {
+        // renamed new entity도 새로 생성된 테이블로 취급해 FK 추가
+        java.util.stream.Stream.concat(
+                diff.getAddedTables().stream(),
+                diff.getRenamedTables().stream().map(DiffResult.RenamedTable::getNewEntity)
+        ).forEach(a -> {
             var v = providers.entityTableContentVisitor().apply(a);
             a.getRelationships().values().forEach(v::visitAddedRelationship);
             out.append(v.getGeneratedSql()).append('\n');
-        }
+        });
 
         // 4) Post-Objects: Sequence/TG 드롭
         providers.sequenceVisitor().ifPresent(sup -> diff.sequenceAccept(sup.get(),

--- a/jinx-core/src/test/java/org/jinx/migration/DependencyResolverTest.java
+++ b/jinx-core/src/test/java/org/jinx/migration/DependencyResolverTest.java
@@ -1,0 +1,457 @@
+package org.jinx.migration;
+
+import org.jinx.model.EntityModel;
+import org.jinx.model.RelationshipModel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("DependencyResolver 위상정렬 테스트")
+class DependencyResolverTest {
+
+    // ── 헬퍼 ─────────────────────────────────────────────────────────────────
+
+    /** FK 관계를 가진 EntityModel 생성. referencedTables 순서대로 관계가 등록됩니다. */
+    private static EntityModel table(String tableName, String... referencedTables) {
+        Map<String, RelationshipModel> rels = new LinkedHashMap<>();
+        for (String ref : referencedTables) {
+            String key = "fk_" + tableName.toLowerCase() + "_to_" + ref.toLowerCase();
+            rels.put(key, RelationshipModel.builder()
+                    .constraintName(key)
+                    .referencedTable(ref)
+                    .build());
+        }
+        return EntityModel.builder().tableName(tableName).relationships(rels).build();
+    }
+
+    /** FK 없는 EntityModel 생성. */
+    private static EntityModel table(String tableName) {
+        return EntityModel.builder().tableName(tableName).build();
+    }
+
+    /** noConstraint=true인 FK를 가진 EntityModel 생성. */
+    private static EntityModel tableNoConstraint(String tableName, String referencedTable) {
+        String key = "fk_" + tableName.toLowerCase() + "_to_" + referencedTable.toLowerCase();
+        return EntityModel.builder()
+                .tableName(tableName)
+                .relationships(Map.of(key, RelationshipModel.builder()
+                        .constraintName(key)
+                        .referencedTable(referencedTable)
+                        .noConstraint(true)
+                        .build()))
+                .build();
+    }
+
+    /** 동일 부모에 FK 2개를 가진 EntityModel 생성 (중복 엣지 검증용). */
+    private static EntityModel tableWithDuplicateFk(String tableName, String referencedTable) {
+        return EntityModel.builder()
+                .tableName(tableName)
+                .relationships(Map.of(
+                        "fk_1", RelationshipModel.builder()
+                                .constraintName("fk_1")
+                                .referencedTable(referencedTable)
+                                .build(),
+                        "fk_2", RelationshipModel.builder()
+                                .constraintName("fk_2")
+                                .referencedTable(referencedTable)
+                                .build()
+                ))
+                .build();
+    }
+
+    private static List<String> names(List<EntityModel> entities) {
+        return entities.stream().map(EntityModel::getTableName).collect(Collectors.toList());
+    }
+
+    // ── null / 경계 케이스 ─────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("경계 케이스")
+    class EdgeCases {
+
+        @Test
+        @DisplayName("null 입력 시 빈 리스트 반환")
+        void null_returns_empty() {
+            assertThat(DependencyResolver.sortByFkDependency(null)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("빈 리스트 입력 시 동일 참조 반환")
+        void empty_list_returns_same() {
+            List<EntityModel> empty = List.of();
+            assertThat(DependencyResolver.sortByFkDependency(empty)).isSameAs(empty);
+        }
+
+        @Test
+        @DisplayName("단일 테이블 입력 시 동일 참조 반환")
+        void single_table_returns_same() {
+            List<EntityModel> single = List.of(table("A"));
+            assertThat(DependencyResolver.sortByFkDependency(single)).isSameAs(single);
+        }
+
+        @Test
+        @DisplayName("tableName이 null인 엔티티는 무시되고 나머지를 반환")
+        void null_tableName_is_skipped() {
+            EntityModel noName = EntityModel.builder().build(); // tableName = null
+            EntityModel a = table("A");
+            List<EntityModel> result = DependencyResolver.sortByFkDependency(List.of(noName, a));
+            // null-name 엔티티 1개만 scope에서 제외 → size <= 1 → 원본 반환
+            assertThat(result).containsExactly(noName, a);
+        }
+    }
+
+    // ── FK 없는 경우 ──────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("FK 의존성 없음")
+    class NoFkDependency {
+
+        @Test
+        @DisplayName("FK 없는 두 테이블은 입력 순서 유지")
+        void no_fk_preserves_order() {
+            List<EntityModel> tables = List.of(table("A"), table("B"));
+            assertThat(names(DependencyResolver.sortByFkDependency(tables)))
+                    .containsExactly("A", "B");
+        }
+
+        @Test
+        @DisplayName("FK 없는 세 테이블은 입력 순서 유지")
+        void no_fk_three_tables_preserves_order() {
+            List<EntityModel> tables = List.of(table("A"), table("B"), table("C"));
+            assertThat(names(DependencyResolver.sortByFkDependency(tables)))
+                    .containsExactly("A", "B", "C");
+        }
+    }
+
+    // ── 단순 의존 관계 ────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("단순 FK 의존 정렬")
+    class SimpleFkOrdering {
+
+        @Test
+        @DisplayName("A→B: 부모 B가 자식 A보다 먼저 나온다")
+        void parent_before_child() {
+            // A has FK to B (A depends on B, B is parent)
+            List<EntityModel> tables = List.of(table("A", "B"), table("B"));
+            assertThat(names(DependencyResolver.sortByFkDependency(tables)))
+                    .containsExactly("B", "A");
+        }
+
+        @Test
+        @DisplayName("역순 입력 [B, A] A→B: 정렬 후에도 B가 앞에 나온다")
+        void parent_before_child_reversed_input() {
+            List<EntityModel> tables = List.of(table("B"), table("A", "B"));
+            assertThat(names(DependencyResolver.sortByFkDependency(tables)))
+                    .containsExactly("B", "A");
+        }
+
+        @Test
+        @DisplayName("선형 체인 A→B→C: 정렬 결과는 [C, B, A]")
+        void linear_chain() {
+            // C ← B ← A
+            List<EntityModel> tables = List.of(
+                    table("A", "B"),
+                    table("B", "C"),
+                    table("C")
+            );
+            assertThat(names(DependencyResolver.sortByFkDependency(tables)))
+                    .containsExactly("C", "B", "A");
+        }
+
+        @Test
+        @DisplayName("선형 체인 역순 입력 [C, B, A]: 정렬 결과는 [C, B, A]")
+        void linear_chain_reversed_input() {
+            List<EntityModel> tables = List.of(
+                    table("C"),
+                    table("B", "C"),
+                    table("A", "B")
+            );
+            assertThat(names(DependencyResolver.sortByFkDependency(tables)))
+                    .containsExactly("C", "B", "A");
+        }
+    }
+
+    // ── 복잡한 위상 구조 ──────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("복잡한 위상 구조")
+    class ComplexTopology {
+
+        @Test
+        @DisplayName("다이아몬드 A→C, B→C: C가 A, B보다 먼저 나온다")
+        void diamond_shape() {
+            List<EntityModel> tables = List.of(
+                    table("A", "C"),
+                    table("B", "C"),
+                    table("C")
+            );
+            List<String> result = names(DependencyResolver.sortByFkDependency(tables));
+            assertThat(result.indexOf("C")).isLessThan(result.indexOf("A"));
+            assertThat(result.indexOf("C")).isLessThan(result.indexOf("B"));
+            assertThat(result).hasSize(3);
+        }
+
+        @Test
+        @DisplayName("두 독립 체인 {A→B}, {C→D}: 각 체인 내 부모가 자식보다 먼저 나온다")
+        void two_independent_chains() {
+            List<EntityModel> tables = List.of(
+                    table("A", "B"),
+                    table("B"),
+                    table("C", "D"),
+                    table("D")
+            );
+            List<String> result = names(DependencyResolver.sortByFkDependency(tables));
+            assertThat(result.indexOf("B")).isLessThan(result.indexOf("A"));
+            assertThat(result.indexOf("D")).isLessThan(result.indexOf("C"));
+            assertThat(result).hasSize(4);
+        }
+
+        @Test
+        @DisplayName("join table: A→C, B→C, AB(A,B 동시 참조): C가 가장 먼저, A와 B는 AB보다 앞")
+        void join_table_ordering() {
+            // AB는 A와 B를 동시에 참조하는 조인 테이블
+            List<EntityModel> tables = List.of(
+                    table("AB", "A", "B"),
+                    table("A", "C"),
+                    table("B", "C"),
+                    table("C")
+            );
+            List<String> result = names(DependencyResolver.sortByFkDependency(tables));
+            assertThat(result.indexOf("C")).isLessThan(result.indexOf("A"));
+            assertThat(result.indexOf("C")).isLessThan(result.indexOf("B"));
+            assertThat(result.indexOf("A")).isLessThan(result.indexOf("AB"));
+            assertThat(result.indexOf("B")).isLessThan(result.indexOf("AB"));
+            assertThat(result).hasSize(4);
+        }
+    }
+
+    // ── DROP 순서 (.reversed()) ───────────────────────────────────────────
+
+    @Nested
+    @DisplayName("DROP 순서: .reversed() 적용")
+    class DropOrdering {
+
+        @Test
+        @DisplayName("A→B 체인 reversed: 자식 A가 부모 B보다 먼저 드롭")
+        void drop_order_simple() {
+            List<EntityModel> tables = List.of(table("A", "B"), table("B"));
+            List<String> dropOrder = names(
+                    DependencyResolver.sortByFkDependency(tables).reversed()
+            );
+            assertThat(dropOrder).containsExactly("A", "B");
+        }
+
+        @Test
+        @DisplayName("선형 체인 A→B→C reversed: 드롭 순서는 [A, B, C]")
+        void drop_order_chain() {
+            List<EntityModel> tables = List.of(
+                    table("A", "B"),
+                    table("B", "C"),
+                    table("C")
+            );
+            List<String> dropOrder = names(
+                    DependencyResolver.sortByFkDependency(tables).reversed()
+            );
+            assertThat(dropOrder).containsExactly("A", "B", "C");
+        }
+    }
+
+    // ── FK 무시 케이스 ────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("FK 무시 케이스")
+    class FkIgnored {
+
+        @Test
+        @DisplayName("noConstraint=true인 관계는 의존성에서 제외 → 순서 영향 없음")
+        void no_constraint_fk_ignored() {
+            // A가 B를 noConstraint FK로 참조: 의존성 없음
+            List<EntityModel> tables = List.of(
+                    tableNoConstraint("A", "B"),
+                    table("B")
+            );
+            // B → A 순서 강제가 없으므로 입력 순서 [A, B] 유지
+            assertThat(names(DependencyResolver.sortByFkDependency(tables)))
+                    .containsExactly("A", "B");
+        }
+
+        @Test
+        @DisplayName("자기 참조(A→A)는 무시하고 다른 의존성은 정상 처리")
+        void self_reference_ignored() {
+            EntityModel selfRef = EntityModel.builder()
+                    .tableName("A")
+                    .relationships(Map.of(
+                            "fk_self", RelationshipModel.builder()
+                                    .constraintName("fk_self")
+                                    .referencedTable("A")  // 자기 참조
+                                    .build()
+                    ))
+                    .build();
+            EntityModel b = table("B");
+            List<EntityModel> tables = List.of(selfRef, b);
+            // 자기 참조는 무시 → A와 B는 독립 → 입력 순서 유지
+            assertThat(names(DependencyResolver.sortByFkDependency(tables)))
+                    .containsExactly("A", "B");
+        }
+
+        @Test
+        @DisplayName("입력 집합 밖 테이블 참조는 무시 → 나머지 순서 영향 없음")
+        void reference_outside_scope_ignored() {
+            // A가 EXTERNAL을 참조하지만 EXTERNAL은 입력 목록에 없음
+            List<EntityModel> tables = List.of(
+                    table("A", "EXTERNAL"),
+                    table("B")
+            );
+            // 범위 외 참조 무시 → A, B는 독립 → 입력 순서 유지
+            assertThat(names(DependencyResolver.sortByFkDependency(tables)))
+                    .containsExactly("A", "B");
+        }
+
+        @Test
+        @DisplayName("referencedTable이 null인 관계는 무시")
+        void null_referenced_table_ignored() {
+            EntityModel a = EntityModel.builder()
+                    .tableName("A")
+                    .relationships(Map.of(
+                            "fk_null_ref", RelationshipModel.builder()
+                                    .constraintName("fk_null_ref")
+                                    .referencedTable(null)
+                                    .build()
+                    ))
+                    .build();
+            List<EntityModel> tables = List.of(a, table("B"));
+            assertThat(names(DependencyResolver.sortByFkDependency(tables)))
+                    .containsExactly("A", "B");
+        }
+    }
+
+    // ── 중복 엣지 ─────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("중복 FK 엣지 처리")
+    class DuplicateFkEdge {
+
+        @Test
+        @DisplayName("A가 B에 대한 FK 2개 보유: in-degree가 중복 카운트되지 않아 정상 정렬")
+        void duplicate_fk_to_same_parent_sorts_correctly() {
+            // A has 2 FKs both pointing to B → should still sort as [B, A]
+            List<EntityModel> tables = List.of(tableWithDuplicateFk("A", "B"), table("B"));
+            assertThat(names(DependencyResolver.sortByFkDependency(tables)))
+                    .containsExactly("B", "A");
+        }
+
+        @Test
+        @DisplayName("중복 FK reversed: DROP 순서도 올바름")
+        void duplicate_fk_drop_order() {
+            List<EntityModel> tables = List.of(tableWithDuplicateFk("A", "B"), table("B"));
+            List<String> dropOrder = names(
+                    DependencyResolver.sortByFkDependency(tables).reversed()
+            );
+            assertThat(dropOrder).containsExactly("A", "B");
+        }
+    }
+
+    // ── 사이클 감지 ───────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("사이클 감지 및 fallback")
+    class CycleDetection {
+
+        @Test
+        @DisplayName("사이클 A⇄B: 원본 리스트를 그대로 반환")
+        void cycle_returns_original_list() {
+            List<EntityModel> tables = List.of(
+                    table("A", "B"),
+                    table("B", "A")
+            );
+            List<EntityModel> result = DependencyResolver.sortByFkDependency(tables);
+            // 사이클 → fallback: 원본 참조 반환
+            assertThat(result).isSameAs(tables);
+        }
+
+        @Test
+        @DisplayName("사이클 A→B→C→A: 원본 리스트를 그대로 반환")
+        void three_way_cycle_returns_original_list() {
+            List<EntityModel> tables = List.of(
+                    table("A", "B"),
+                    table("B", "C"),
+                    table("C", "A")
+            );
+            assertThat(DependencyResolver.sortByFkDependency(tables)).isSameAs(tables);
+        }
+
+        @Test
+        @DisplayName("사이클 감지 시 System.err에 경고 메시지가 출력된다")
+        void cycle_logs_warning_to_stderr() {
+            PrintStream originalErr = System.err;
+            ByteArrayOutputStream captured = new ByteArrayOutputStream();
+            System.setErr(new PrintStream(captured));
+            try {
+                List<EntityModel> tables = List.of(
+                        table("A", "B"),
+                        table("B", "A")
+                );
+                DependencyResolver.sortByFkDependency(tables);
+            } finally {
+                System.setErr(originalErr);
+            }
+            assertThat(captured.toString())
+                    .contains("[jinx] WARNING")
+                    .contains("cycle");
+        }
+
+        @Test
+        @DisplayName("사이클이 없는 부분은 정렬, 사이클이 있는 부분은 fallback (전체 원본 반환)")
+        void partial_cycle_still_returns_original() {
+            // D는 독립, A⇄B⇄C는 사이클 → 전체 fallback
+            List<EntityModel> tables = List.of(
+                    table("A", "B"),
+                    table("B", "C"),
+                    table("C", "A"),
+                    table("D")
+            );
+            assertThat(DependencyResolver.sortByFkDependency(tables)).isSameAs(tables);
+        }
+    }
+
+    // ── 대소문자 정규화 ───────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("테이블명 대소문자 정규화")
+    class CaseNormalization {
+
+        @Test
+        @DisplayName("FK referencedTable이 대문자여도 tableName 소문자와 동일하게 매칭")
+        void case_insensitive_matching() {
+            // tableName "orders" (소문자), referencedTable "CUSTOMERS" (대문자)
+            List<EntityModel> tables = List.of(
+                    table("orders", "CUSTOMERS"),
+                    table("customers")
+            );
+            List<String> result = names(DependencyResolver.sortByFkDependency(tables));
+            assertThat(result.indexOf("customers")).isLessThan(result.indexOf("orders"));
+        }
+
+        @Test
+        @DisplayName("혼합 케이스 테이블명: 동일 테이블로 인식")
+        void mixed_case_tables() {
+            List<EntityModel> tables = List.of(
+                    table("Order", "Customer"),
+                    table("CUSTOMER")
+            );
+            List<String> result = names(DependencyResolver.sortByFkDependency(tables));
+            // CUSTOMER (소문자: "customer")가 Order (소문자: "order") 앞에 나와야 함
+            assertThat(result.indexOf("CUSTOMER")).isLessThan(result.indexOf("Order"));
+        }
+    }
+}

--- a/jinx-core/src/test/java/org/jinx/migration/MigrationGeneratorTest.java
+++ b/jinx-core/src/test/java/org/jinx/migration/MigrationGeneratorTest.java
@@ -10,14 +10,18 @@ import org.jinx.testing.visitor.RecordingEntityTableContentVisitor;
 import org.jinx.testing.visitor.RecordingTableContentVisitor;
 import org.jinx.testing.visitor.RecordingTableVisitor;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -25,7 +29,7 @@ import static org.mockito.Mockito.*;
 class MigrationGeneratorTest {
 
     @Test
-    @DisplayName("reverse + warnings + (DROP/RENAME) + (ADDED) + (ALTER) + (FK_ADD) 순서대로 SQL이 조립된다")
+    @DisplayName("reverse + warnings + DROP + ADD(rename→drop+create 포함) + ALTER + FK_ADD 순서대로 SQL이 조립된다")
     void generateSql_full_flow() {
         // --- given: 번들/다이얼렉트 ---
         DdlDialect ddl = mock(DdlDialect.class);
@@ -40,7 +44,18 @@ class MigrationGeneratorTest {
         when(newEntity.getTableName()).thenReturn("t_new");
         when(me.getNewEntity()).thenReturn(newEntity);
         when(diff.getModifiedTables()).thenReturn(List.of(me));
-        when(diff.getAddedTables()).thenReturn(List.of());
+
+        // DROPPED: MigrationGenerator가 getDroppedTables()를 직접 호출하여 DependencyResolver에 전달
+        EntityModel droppedTable = mock(EntityModel.class);
+        when(droppedTable.getTableName()).thenReturn("old_table");
+        when(droppedTable.getRelationships()).thenReturn(Map.of());
+        when(diff.getDroppedTables()).thenReturn(List.of(droppedTable));
+
+        // ADDED: MigrationGenerator가 getAddedTables()를 직접 호출하여 DependencyResolver에 전달
+        EntityModel addedTable = mock(EntityModel.class);
+        when(addedTable.getTableName()).thenReturn("new_table");
+        when(addedTable.getRelationships()).thenReturn(Map.of());
+        when(diff.getAddedTables()).thenReturn(List.of(addedTable));
 
         // ModifiedEntity.accept: Phase 별로 녹화형 비지터에 visit* 호출 → SQL 축적
         doAnswer(inv -> {
@@ -81,31 +96,17 @@ class MigrationGeneratorTest {
             return null;
         }).when(me).accept(any(), eq(DiffResult.TableContentPhase.FK_ADD));
 
-        // tableAccept: DROPPED/RENAMED/ADDED 각각 호출 시 녹화형 비지터에 visit* 호출
-        doAnswer(inv -> {
-            TableVisitor v = inv.getArgument(0);
-            DiffResult.TablePhase phase = inv.getArgument(1);
-            if (phase == DiffResult.TablePhase.DROPPED) {
-                var t = mock(EntityModel.class);
-                when(t.getTableName()).thenReturn("old_table");
-                v.visitDroppedTable(t);
-            } else if (phase == DiffResult.TablePhase.RENAMED) {
-                var r = mock(DiffResult.RenamedTable.class);
-                EntityModel oldE = mock(EntityModel.class);
-                when(oldE.getTableName()).thenReturn("old_name");
-                when(r.getOldEntity()).thenReturn(oldE);
-
-                EntityModel newE = mock(EntityModel.class);
-                when(newE.getTableName()).thenReturn("new_name");
-                when(r.getNewEntity()).thenReturn(newE);
-                v.visitRenamedTable(r);
-            } else if (phase == DiffResult.TablePhase.ADDED) {
-                var t = mock(EntityModel.class);
-                when(t.getTableName()).thenReturn("new_table");
-                v.visitAddedTable(t);
-            }
-            return null;
-        }).when(diff).tableAccept(any(), any());
+        // RENAMED → DROP old + CREATE new 로 처리: getRenamedTables()를 직접 호출
+        EntityModel oldNameEntity = mock(EntityModel.class);
+        when(oldNameEntity.getTableName()).thenReturn("old_name");
+        when(oldNameEntity.getRelationships()).thenReturn(Map.of());
+        EntityModel newNameEntity = mock(EntityModel.class);
+        when(newNameEntity.getTableName()).thenReturn("new_name");
+        when(newNameEntity.getRelationships()).thenReturn(Map.of());
+        DiffResult.RenamedTable renamedTable = mock(DiffResult.RenamedTable.class);
+        when(renamedTable.getOldEntity()).thenReturn(oldNameEntity);
+        when(renamedTable.getNewEntity()).thenReturn(newNameEntity);
+        when(diff.getRenamedTables()).thenReturn(List.of(renamedTable));
 
         // sequence/tableGenerator accept는 호출만 검증(출력 영향 없음)
         doNothing().when(diff).sequenceAccept(any(), any(), any());
@@ -172,6 +173,10 @@ class MigrationGeneratorTest {
             String sql = gen.generateSql(diff);
 
             // --- then: 순서대로 기대 문자열 조립 ---
+            // 1-2 DROP: [droppedTables + renamed.oldEntity] → sortByFkDependency → reversed
+            //   입력 순서: [old_table, old_name], FK 없음 → sorted 동일, reversed → [old_name, old_table]
+            // 2-1 ADD: [addedTables + renamed.newEntity] → sortByFkDependency
+            //   입력 순서: [new_table, new_name], FK 없음 → [new_table, new_name]
             String expected = String.join("\n",
                     "-- WARNING: this is rollback SQL for a migration",
                     "-- WARNING: W1",
@@ -179,11 +184,12 @@ class MigrationGeneratorTest {
                     // 1-1 DROP (modified)
                     "ALTER TABLE DROP COLUMN \"age\"",
                     "ALTER TABLE DROP PRIMARY KEY",
-                    // 1-2 DROPPED/RENAMED (tables)
+                    // 1-2 DROPPED (droppedTables + renamed old entity, reversed)
+                    "DROP TABLE \"old_name\"",
                     "DROP TABLE \"old_table\"",
-                    "RENAME TABLE \"old_name\" TO \"new_name\"",
-                    // 2-1 ADDED (tables)
+                    // 2-1 ADDED (addedTables + renamed new entity)
                     "CREATE TABLE \"new_table\" ()",
+                    "CREATE TABLE \"new_name\" ()",
                     // 2-2 ALTER (modified)
                     "ALTER TABLE ADD COLUMN \"name\"",
                     "ALTER TABLE MODIFY COLUMN \"name\" /* from \"name_old\" */",
@@ -200,6 +206,161 @@ class MigrationGeneratorTest {
         }
     }
 
+    @Nested
+    @DisplayName("DependencyResolver 적용: FK 의존성 기반 테이블 순서")
+    class FkDependencyOrdering {
+
+        private VisitorProviders minimalProviders() {
+            return new VisitorProviders(
+                    RecordingTableVisitor::new,
+                    me -> new RecordingTableContentVisitor(),
+                    me -> new RecordingEntityTableContentVisitor(),
+                    Optional.empty(),
+                    Optional.empty()
+            );
+        }
+
+        @Test
+        @DisplayName("addedTables: 자식(A)이 먼저 입력되어도 부모(B)가 먼저 CREATE된다")
+        void create_order_parent_before_child() {
+            EntityModel tableB = EntityModel.builder().tableName("table_b").build();
+            EntityModel tableA = EntityModel.builder()
+                    .tableName("table_a")
+                    .relationships(Map.of("fk_a_b", RelationshipModel.builder()
+                            .constraintName("fk_a_b").referencedTable("table_b").build()))
+                    .build();
+
+            // 의도적으로 자식(A) 먼저 입력 — DependencyResolver가 B, A 순으로 정렬해야 함
+            DiffResult diff = DiffResult.builder()
+                    .addedTables(new ArrayList<>(List.of(tableA, tableB)))
+                    .droppedTables(new ArrayList<>())
+                    .build();
+
+            DdlDialect ddl = mock(DdlDialect.class);
+            DialectBundle bundle = DialectBundle.builder(ddl, DatabaseType.MYSQL).build();
+
+            try (MockedStatic<VisitorFactory> vf = mockStatic(VisitorFactory.class)) {
+                vf.when(() -> VisitorFactory.forBundle(bundle)).thenReturn(minimalProviders());
+
+                String sql = new MigrationGenerator(bundle, SchemaModel.builder().build(), false)
+                        .generateSql(diff);
+
+                int posB = sql.indexOf("CREATE TABLE \"table_b\"");
+                int posA = sql.indexOf("CREATE TABLE \"table_a\"");
+                assertThat(posB).isGreaterThanOrEqualTo(0);
+                assertThat(posB).isLessThan(posA);
+            }
+        }
+
+        @Test
+        @DisplayName("droppedTables: 부모(B)가 먼저 입력되어도 자식(A)이 먼저 DROP된다")
+        void drop_order_child_before_parent() {
+            EntityModel tableB = EntityModel.builder().tableName("table_b").build();
+            EntityModel tableA = EntityModel.builder()
+                    .tableName("table_a")
+                    .relationships(Map.of("fk_a_b", RelationshipModel.builder()
+                            .constraintName("fk_a_b").referencedTable("table_b").build()))
+                    .build();
+
+            // 의도적으로 부모(B) 먼저 입력 — DependencyResolver.reversed()가 A, B 순으로 정렬해야 함
+            DiffResult diff = DiffResult.builder()
+                    .addedTables(new ArrayList<>())
+                    .droppedTables(new ArrayList<>(List.of(tableB, tableA)))
+                    .build();
+
+            DdlDialect ddl = mock(DdlDialect.class);
+            DialectBundle bundle = DialectBundle.builder(ddl, DatabaseType.MYSQL).build();
+
+            try (MockedStatic<VisitorFactory> vf = mockStatic(VisitorFactory.class)) {
+                vf.when(() -> VisitorFactory.forBundle(bundle)).thenReturn(minimalProviders());
+
+                String sql = new MigrationGenerator(bundle, SchemaModel.builder().build(), false)
+                        .generateSql(diff);
+
+                int posA = sql.indexOf("DROP TABLE \"table_a\"");
+                int posB = sql.indexOf("DROP TABLE \"table_b\"");
+                assertThat(posA).isGreaterThanOrEqualTo(0);
+                assertThat(posA).isLessThan(posB);
+            }
+        }
+
+        @Test
+        @DisplayName("선형 체인 A→B→C: CREATE 순서는 C, B, A")
+        void create_order_linear_chain() {
+            EntityModel tableC = EntityModel.builder().tableName("table_c").build();
+            EntityModel tableB = EntityModel.builder()
+                    .tableName("table_b")
+                    .relationships(Map.of("fk_b_c", RelationshipModel.builder()
+                            .constraintName("fk_b_c").referencedTable("table_c").build()))
+                    .build();
+            EntityModel tableA = EntityModel.builder()
+                    .tableName("table_a")
+                    .relationships(Map.of("fk_a_b", RelationshipModel.builder()
+                            .constraintName("fk_a_b").referencedTable("table_b").build()))
+                    .build();
+
+            // 의도적으로 자식 우선 입력 [A, B, C] — 정렬 후 [C, B, A] 이어야 함
+            DiffResult diff = DiffResult.builder()
+                    .addedTables(new ArrayList<>(List.of(tableA, tableB, tableC)))
+                    .droppedTables(new ArrayList<>())
+                    .build();
+
+            DdlDialect ddl = mock(DdlDialect.class);
+            DialectBundle bundle = DialectBundle.builder(ddl, DatabaseType.MYSQL).build();
+
+            try (MockedStatic<VisitorFactory> vf = mockStatic(VisitorFactory.class)) {
+                vf.when(() -> VisitorFactory.forBundle(bundle)).thenReturn(minimalProviders());
+
+                String sql = new MigrationGenerator(bundle, SchemaModel.builder().build(), false)
+                        .generateSql(diff);
+
+                int posC = sql.indexOf("CREATE TABLE \"table_c\"");
+                int posB = sql.indexOf("CREATE TABLE \"table_b\"");
+                int posA = sql.indexOf("CREATE TABLE \"table_a\"");
+                assertThat(posC).isLessThan(posB);
+                assertThat(posB).isLessThan(posA);
+            }
+        }
+
+        @Test
+        @DisplayName("선형 체인 DROP: C→B→A 역순 입력이어도 DROP 순서는 A, B, C")
+        void drop_order_linear_chain() {
+            EntityModel tableC = EntityModel.builder().tableName("table_c").build();
+            EntityModel tableB = EntityModel.builder()
+                    .tableName("table_b")
+                    .relationships(Map.of("fk_b_c", RelationshipModel.builder()
+                            .constraintName("fk_b_c").referencedTable("table_c").build()))
+                    .build();
+            EntityModel tableA = EntityModel.builder()
+                    .tableName("table_a")
+                    .relationships(Map.of("fk_a_b", RelationshipModel.builder()
+                            .constraintName("fk_a_b").referencedTable("table_b").build()))
+                    .build();
+
+            // 의도적으로 부모 우선 입력 [C, B, A] — reversed() 후 [A, B, C] 이어야 함
+            DiffResult diff = DiffResult.builder()
+                    .addedTables(new ArrayList<>())
+                    .droppedTables(new ArrayList<>(List.of(tableC, tableB, tableA)))
+                    .build();
+
+            DdlDialect ddl = mock(DdlDialect.class);
+            DialectBundle bundle = DialectBundle.builder(ddl, DatabaseType.MYSQL).build();
+
+            try (MockedStatic<VisitorFactory> vf = mockStatic(VisitorFactory.class)) {
+                vf.when(() -> VisitorFactory.forBundle(bundle)).thenReturn(minimalProviders());
+
+                String sql = new MigrationGenerator(bundle, SchemaModel.builder().build(), false)
+                        .generateSql(diff);
+
+                int posA = sql.indexOf("DROP TABLE \"table_a\"");
+                int posB = sql.indexOf("DROP TABLE \"table_b\"");
+                int posC = sql.indexOf("DROP TABLE \"table_c\"");
+                assertThat(posA).isLessThan(posB);
+                assertThat(posB).isLessThan(posC);
+            }
+        }
+    }
+
     @Test
     @DisplayName("변경 없음 + reverse=false → 경고 없으면 빈 문자열")
     void generateSql_no_changes_no_warnings() {
@@ -210,7 +371,8 @@ class MigrationGeneratorTest {
         when(diff.getWarnings()).thenReturn(List.of());
         when(diff.getModifiedTables()).thenReturn(List.of());
         when(diff.getAddedTables()).thenReturn(List.of());
-        doNothing().when(diff).tableAccept(any(), any());
+        when(diff.getDroppedTables()).thenReturn(List.of());
+        when(diff.getRenamedTables()).thenReturn(List.of());
         doNothing().when(diff).sequenceAccept(any(), any(), any());
         doNothing().when(diff).tableGeneratorAccept(any(), any(), any());
 


### PR DESCRIPTION
# FK 의존성 기반 위상정렬 도입 (DependencyResolver)

관련 이슈: [#123](https://github.com/yyubin/jinx/issues/123)

---

## 배경

`MigrationGenerator`는 테이블 생성(CREATE) 및 삭제(DROP) 순서를 `DiffResult`가 반환하는 리스트 순서 그대로 사용했다.
`SchemaDiffer` 파이프라인이 삽입하는 순서에는 FK 의존성이 고려되지 않았기 때문에, 다음 두 가지 케이스에서 런타임 오류가 발생할 수 있었다.

| 케이스 | 문제 |
|--------|------|
| 신규 테이블 일괄 추가 (A→B→C 체인) | 자식 테이블이 부모보다 먼저 CREATE → FK 참조 실패 |
| 기존 테이블 일괄 삭제 (A→B→C 체인) | 부모 테이블이 자식보다 먼저 DROP → FK 제약 위반 |

기존 `AlterTableBuilder.priority()` 정수 정렬은 **테이블 내부** 컬럼·제약 순서를 담당하고, **테이블 간** 순서는 완전히 미처리 상태였다.

추가로, `MigrationGenerator`에 남아 있던 `RENAME TABLE` 경로는 실제 프로덕션에서 의미 없는 코드였다. 리네임 탐지로 인해 `renamedTables`에 들어온 항목을 DROP+CREATE로 처리하는 것이 원래 의도였으나, RENAMED 분기가 사실상 살아있는 데드 코드로 유지되어 있었다.

---

## 변경 개요

| 파일 | 유형 | 내용 |
|------|------|------|
| `migration/DependencyResolver.java` | **신규** | FK 의존성 기반 위상정렬 (Kahn's BFS) |
| `migration/MigrationGenerator.java` | **수정** | DependencyResolver 적용 + RENAMED → DROP+CREATE |
| `test/.../DependencyResolverTest.java` | **신규** | 위상정렬 27개 단위 테스트 |
| `test/.../MigrationGeneratorTest.java` | **수정** | 스텁 정리 + FK 순서 검증 테스트 4개 추가 |

---

## 세부 변경 내용

### 1. `DependencyResolver` — Kahn's BFS 위상정렬

**위치**: `jinx-core/src/main/java/org/jinx/migration/DependencyResolver.java`

**핵심 API**

```java
public static List<EntityModel> sortByFkDependency(List<EntityModel> tables)
```

반환값: 부모 테이블(참조 대상)이 먼저 오는 새 리스트.
- CREATE 순서 → 반환값 그대로 사용
- DROP 순서  → `.reversed()` 적용

**그래프 구성 규칙**

| 조건 | 처리 |
|------|------|
| `noConstraint = true` | 엣지 생성 안 함 (실제 FK 없음) |
| `referencedTable = null` | 건너뜀 |
| 자기 참조 (`A → A`) | 건너뜀 |
| 입력 집합 외부 참조 | 건너뜀 |
| 동일 부모를 향한 FK 복수 개 | `LinkedHashSet`으로 중복 엣지 방지 (in-degree 초과 카운트 차단) |

**사이클 처리**

```
sorted.size() != byName.size()
  → System.err 경고 출력 (사이클 참여 테이블명 표시)
  → 원본 리스트 참조 반환 (안전한 fallback)
```

**BFS 초기화 순서**

`inDegree`는 `HashMap`이라 `forEach` 반복 순서가 비결정론적이다. 독립 테이블 간 출력 순서를 결정론적으로 유지하기 위해 `byName`(`LinkedHashMap`)의 `keySet()` 삽입 순서로 초기화한다.

```java
// HashMap.forEach() — 비결정론적 (수정 전)
inDegree.forEach((name, deg) -> { if (deg == 0) queue.add(name); });

// byName.keySet() — 삽입 순서 보존 (수정 후)
for (String name : byName.keySet()) {
    if (inDegree.get(name) == 0) queue.add(name);
}
```

---

### 2. `MigrationGenerator` — DependencyResolver 적용 + RENAMED 제거

#### 2-1. 섹션 1-2: DROP 순서 보장

```java
// 수정 전
diff.tableAccept(v, DiffResult.TablePhase.DROPPED);
diff.tableAccept(v, DiffResult.TablePhase.RENAMED);   // ← RENAME TABLE SQL 생성

// 수정 후
var allToDrop = new ArrayList<>(diff.getDroppedTables());
diff.getRenamedTables().stream()
        .map(DiffResult.RenamedTable::getOldEntity)
        .forEach(allToDrop::add);
DependencyResolver.sortByFkDependency(allToDrop)
        .reversed()
        .forEach(v::visitDroppedTable);
// tableAccept(RENAMED) 호출 없음
```

- `droppedTables`와 `renamedTables`의 old entity를 합산해 FK 역방향 정렬
- FK 참조 관계: 자식(FK 보유) → 부모 순서로 DROP

#### 2-2. 섹션 2-1: CREATE 순서 보장

```java
// 수정 전
diff.tableAccept(v, DiffResult.TablePhase.ADDED);

// 수정 후
var allToAdd = new ArrayList<>(diff.getAddedTables());
diff.getRenamedTables().stream()
        .map(DiffResult.RenamedTable::getNewEntity)
        .forEach(allToAdd::add);
DependencyResolver.sortByFkDependency(allToAdd)
        .forEach(v::visitAddedTable);
```

- `addedTables`와 `renamedTables`의 new entity를 합산해 FK 정방향 정렬
- FK 참조 관계: 부모 → 자식(FK 보유) 순서로 CREATE

#### 2-3. 섹션 3: FK ADD 범위 확장

```java
// 수정 전 — addedTables만 대상
for (var a : diff.getAddedTables()) { ... }

// 수정 후 — renamedTables.newEntity 포함
Stream.concat(
        diff.getAddedTables().stream(),
        diff.getRenamedTables().stream().map(DiffResult.RenamedTable::getNewEntity)
).forEach(a -> {
    var v = providers.entityTableContentVisitor().apply(a);
    a.getRelationships().values().forEach(v::visitAddedRelationship);
    out.append(v.getGeneratedSql()).append('\n');
});
```

리네임 처리된 new entity의 FK 제약도 모든 테이블 생성 이후에 추가된다.

---

### 3. 테스트 변경

#### `DependencyResolverTest` (신규, 27개)

| `@Nested` 그룹 | 검증 내용 |
|----------------|-----------|
| 경계 케이스 | null, 빈 리스트, 단일 테이블, null tableName |
| FK 없음 | 입력 순서 그대로 유지 |
| 단순 FK 정렬 | A→B, 역순 입력, 선형 체인 |
| 복잡한 위상 | 다이아몬드, 독립 체인 2개, join table |
| DROP 순서 | `.reversed()` 적용 검증 |
| FK 무시 케이스 | noConstraint, 자기 참조, 범위 외, null ref |
| 중복 FK 엣지 | in-degree 중복 카운트 방지 |
| 사이클 감지 | A⇄B, 3-way 사이클, stderr 경고, partial cycle |
| 대소문자 정규화 | 혼합 케이스 테이블명 매칭 |

#### `MigrationGeneratorTest` (수정 + 4개 추가)

기존 `full_flow` 테스트:
- `tableAccept(RENAMED)` doAnswer mock 제거
- `diff.getRenamedTables()` 스텁 추가
- expected SQL: `RENAME TABLE "old_name" TO "new_name"` → `DROP TABLE "old_name"` + `CREATE TABLE "new_name" ()`

신규 `FkDependencyOrdering` 그룹:
- `create_order_parent_before_child` — 잘못된 입력 순서에서도 부모가 먼저 CREATE됨
- `drop_order_child_before_parent` — 잘못된 입력 순서에서도 자식이 먼저 DROP됨
- `create_order_linear_chain` — A→B→C 체인 CREATE 순서: C, B, A
- `drop_order_linear_chain` — A→B→C 체인 DROP 순서: A, B, C

---

## 효과

### 1. FK 체인 안전성 보장

이전에는 `SchemaDiffer`의 리스트 삽입 순서에 따라 CREATE/DROP 순서가 결정되었다. 이제는 FK 의존성 그래프를 기반으로 정렬하므로, 상속 계층, join table, 복잡한 참조 체인 등 어떤 구조도 별도 수동 조정 없이 올바른 순서가 보장된다.

```
Before: A, B, C 순서 입력 → A 먼저 CREATE → FK 참조 실패 가능
After:  A→B→C 체인 → C, B, A 순서로 CREATE 보장
```

### 2. 사이클 자동 감지

이전에는 순환 FK 구조가 있어도 조용히 잘못된 SQL이 생성됐다. 이제 Kahn's BFS에서 사이클을 감지해 `System.err`에 경고를 출력하고, 원본 순서로 안전하게 fallback한다.

### 3. 기술 부채 해소

이전에는 새로운 FK 케이스가 발생할 때마다 다음 레이어를 모두 함께 수정해야 했다.

```
contributor priority → visitor → dialect
```

이제는 `DependencyResolver` 알고리즘이 자동으로 처리하므로 해당 레이어들을 건드릴 필요가 없다.

### 4. RENAMED 데드 코드 제거

`MigrationGenerator`에서 `RENAME TABLE` SQL이 생성되는 경로가 완전히 제거됐다. 리네임 탐지로 인해 `renamedTables`에 들어온 항목은 이제 DROP+CREATE로 일관되게 처리된다.

### 5. 결정론적 출력 순서

`HashMap.forEach()`의 비결정론적 반복 순서 버그를 수정해, FK 의존성이 없는 독립 테이블 간에도 입력 순서 기반의 결정론적 정렬 결과가 보장된다. 테스트 flakiness 가능성을 차단했다.

---

## 리스크

### 리스크 1: SQL 경로와 Liquibase 경로 간 RENAME 처리 불일치 ⚠️

`MigrationGenerator`(SQL 경로)는 이번 변경으로 RENAMED를 DROP+CREATE로 처리하지만,
`LiquibaseYamlGenerator`는 여전히 `tableAccept(visitor, TablePhase.RENAMED)`를 호출해 `renameTable` 체인지셋을 생성한다.

```java
// LiquibaseYamlGenerator.java:42 — 미수정
diff.tableAccept(visitor, TablePhase.RENAMED);
```

같은 `DiffResult`를 두 생성기에 각각 통과시킬 경우 SQL 출력과 Liquibase 출력의 의미가 달라진다. Liquibase 경로도 동일하게 처리할지 별도로 결정이 필요하다.

**완화**: 현재 두 경로는 독립적으로 사용하는 엔트리포인트가 분리되어 있으므로, 단기 운영상 직접 충돌은 없다. 그러나 장기적으로 동작 정의를 통일해야 한다.

### 리스크 2: 리네임 처리 의미론 변경으로 인한 데이터 유실

RENAMED → DROP+CREATE 처리는 기존 테이블의 데이터를 보존하지 않는다. 만약 누군가 `renamedTables`를 "실제 RENAME TABLE을 실행해야 하는 시그널"로 기대하는 컨슈머가 있다면 데이터 유실 위험이 있다.

**완화**: 이슈 #123 논의에서 "프로덕션에서 리네임 탐지는 의미 없고 DROP+CREATE가 원래 의도"라고 명시됐다. 그러나 외부 플러그인이나 사용자 코드가 `renamedTables`에 의존할 경우 예상치 못한 데이터 손실로 이어질 수 있으므로, 릴리스 노트에 명시적으로 기재해야 한다.

### 리스크 3: `TableVisitor.visitRenamedTable()` 인터페이스 데드 코드

`TableVisitor` 인터페이스와 `MySqlMigrationVisitor`, `PostgreSqlMigrationVisitor`의 `visitRenamedTable()` 구현은 SQL 경로에서 더 이상 호출되지 않는다. 코드는 남아 있어 혼란을 줄 수 있다.

```java
// TableVisitor.java — 더 이상 MigrationGenerator에서 호출 안 됨
void visitRenamedTable(DiffResult.RenamedTable renamed);
```

**완화**: 단기적으로는 LiquibaseYamlGenerator가 여전히 사용하므로 즉시 제거할 수 없다. Liquibase 경로 결정(리스크 1)과 함께 처리할 것.

### 리스크 4: 사이클 fallback의 한계

사이클 감지 시 원본 리스트 순서로 fallback한다. 이는 순환 FK 구조를 가진 DB(MySQL의 DEFERRABLE 미지원 환경에서도 이미 존재하는 경우)에서 원래 잘못된 순서로 SQL이 생성될 수 있음을 의미한다.

```
사이클: A⇄B → fallback → 원본 순서 → CREATE TABLE A (FK to B), CREATE TABLE B → 여전히 실패 가능
```

**완화**: 이는 `DependencyResolver` 이전에도 동일하게 잘못된 순서가 나오던 상황이며, 추가적인 위험이 아니다. 경고 메시지를 통해 사용자가 수동으로 처리하도록 안내한다. 순환 FK는 DB 설계 수준에서 해결해야 하는 문제다.

### 리스크 5: 배치 외 테이블 참조 무시 범위

`DependencyResolver`는 입력 리스트에 포함된 테이블 간 의존성만 고려한다. 이미 DB에 존재하는 테이블(수정/유지 대상)을 참조하는 FK는 정렬 알고리즘에 반영되지 않는다.

```
예: 기존 테이블 users가 존재하고, orders(신규)가 users를 FK 참조하는 경우
    → orders는 sortByFkDependency 입력에만 있고 users는 없음
    → "범위 외 참조"로 무시 → orders의 in-degree = 0 → 정상 처리됨
```

이 경우는 실제로 문제가 없다(참조 대상이 이미 DB에 존재). 그러나 동일 배치 내 두 테이블 간 의존성이 `relationships` 맵에 등록되지 않은 경우(잘못된 모델링)에는 여전히 순서 보장이 안 된다.

**완화**: `relationships` 맵이 정확히 채워지는 것은 `jinx-processor` 모듈의 책임이며, 이 범위 밖이다.

---

## 미결 사항

- [ ] `LiquibaseYamlGenerator`의 RENAMED 처리를 SQL 경로와 동일하게 통일할지 결정 (리스크 1)
- [ ] `TableVisitor.visitRenamedTable()`, `DiffResult.TablePhase.RENAMED` 정리 시점 결정 (리스크 3)
- [ ] 사이클 감지 경고를 `System.err` 대신 jinx 공통 로거로 교체 (로깅 프레임워크 도입 시점에 함께)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 외래키 의존성을 기반으로 한 데이터베이스 테이블 마이그레이션 순서 최적화
  * 테이블 이름 변경 시 의존성을 고려한 정확한 처리 추가

* **버그 수정**
  * 순환 참조 감지 및 경고 메시지 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->